### PR TITLE
ci: enforce supply-chain pinning on the acceptance pipeline

### DIFF
--- a/.github/workflows/azure-backend-acc.yml
+++ b/.github/workflows/azure-backend-acc.yml
@@ -9,8 +9,23 @@ on:
       - '.github/workflows/azure-backend-acc.yml'
   workflow_dispatch:
 
+# Serialise deployments to one environment. Keyed on the pull-request
+# NUMBER rather than the ref: keyed on github.ref alone, the
+# pull_request(closed) teardown and the push deploy that a merge fires
+# simultaneously land in one group and cancel each other at random.
+# Learned in ronl-business-api on 2026-08-29.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+# Default to read-only; jobs opt into more only where required.
+permissions:
+  contents: read
+
 jobs:
   deploy:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     environment:
       name: acceptance
@@ -18,10 +33,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
 
@@ -82,7 +99,7 @@ jobs:
           echo "SCM_DO_BUILD_DURING_DEPLOYMENT = false" >> .deployment
 
       - name: Deploy to Azure Web App
-        uses: azure/webapps-deploy@v3
+        uses: azure/webapps-deploy@02a81bead70021f5284939794bcec79c271ab383 # v3.0.8
         with:
           app-name: 'ronl-linkeddata-backend-acc'
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_ACC }}

--- a/.github/workflows/azure-backend-production.yml
+++ b/.github/workflows/azure-backend-production.yml
@@ -9,8 +9,21 @@ on:
       - '.github/workflows/azure-backend-production.yml'
   workflow_dispatch:
 
+# Same serialisation as the acc workflow, but production runs QUEUE
+# rather than cancel: interrupting a live production deployment to
+# start another is worse than waiting for it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
+# Default to read-only; jobs opt into more only where required.
+permissions:
+  contents: read
+
 jobs:
   deploy:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     environment:
       name: production
@@ -18,10 +31,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
 
@@ -75,7 +90,7 @@ jobs:
           echo "SCM_DO_BUILD_DURING_DEPLOYMENT = false" >> .deployment
 
       - name: Deploy to Azure Web App
-        uses: azure/webapps-deploy@v3
+        uses: azure/webapps-deploy@02a81bead70021f5284939794bcec79c271ab383 # v3.0.8
         with:
           app-name: 'ronl-linkeddata-backend-prod'
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_PROD }}

--- a/.github/workflows/azure-frontend-acc.yml
+++ b/.github/workflows/azure-frontend-acc.yml
@@ -6,25 +6,44 @@ on:
       - acc
     paths:
       - 'packages/frontend/**'
+      - '.github/workflows/azure-frontend-acc.yml'
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
       - acc
     paths:
       - 'packages/frontend/**'
+      - '.github/workflows/azure-frontend-acc.yml'
+
+# Serialise deployments to one environment. Keyed on the pull-request
+# NUMBER rather than the ref: keyed on github.ref alone, the
+# pull_request(closed) teardown and the push deploy that a merge fires
+# simultaneously land in one group and cancel each other at random.
+# Learned in ronl-business-api on 2026-08-29.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+# Default to read-only; jobs opt into more only where required.
+permissions:
+  contents: read
 
 jobs:
   build_and_deploy_job:
+    permissions:
+      contents: read
+      pull-requests: write
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           submodules: true
+          persist-credentials: false
           lfs: false
       - name: Setup Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
           cache: "npm"
@@ -39,7 +58,7 @@ jobs:
         run: npm test --workspace=packages/frontend
       - name: Build And Deploy
         id: builddeploy
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_BRAVE_BAY_04F351E03 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
@@ -53,13 +72,14 @@ jobs:
       ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:
+    permissions: {}
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: Close Pull Request Job
     steps:
       - name: Close Pull Request
         id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_BRAVE_BAY_04F351E03 }}
           action: "close"

--- a/.github/workflows/azure-frontend-production.yml
+++ b/.github/workflows/azure-frontend-production.yml
@@ -6,25 +6,42 @@ on:
       - main
     paths:
       - 'packages/frontend/**'
+      - '.github/workflows/azure-frontend-production.yml'
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
       - main
     paths:
       - 'packages/frontend/**'
+      - '.github/workflows/azure-frontend-production.yml'
+
+# Same serialisation as the acc workflow, but production runs QUEUE
+# rather than cancel: interrupting a live production deployment to
+# start another is worse than waiting for it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
+# Default to read-only; jobs opt into more only where required.
+permissions:
+  contents: read
 
 jobs:
   build_and_deploy_job:
+    permissions:
+      contents: read
+      pull-requests: write
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           submodules: true
+          persist-credentials: false
           lfs: false
       - name: Setup Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
           cache: "npm"
@@ -39,7 +56,7 @@ jobs:
         run: npm test --workspace=packages/frontend
       - name: Build And Deploy
         id: builddeploy
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_WITTY_BEACH_0A7CFA203 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
@@ -53,13 +70,14 @@ jobs:
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:
+    permissions: {}
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: Close Pull Request Job
     steps:
       - name: Close Pull Request
         id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_WITTY_BEACH_0A7CFA203 }}
           action: "close"

--- a/.github/workflows/azure-ropa-site-acc.yml
+++ b/.github/workflows/azure-ropa-site-acc.yml
@@ -6,26 +6,45 @@ on:
       - acc
     paths:
       - 'packages/ropa-site/**'
+      - '.github/workflows/azure-ropa-site-acc.yml'
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
       - acc
     paths:
       - 'packages/ropa-site/**'
+      - '.github/workflows/azure-ropa-site-acc.yml'
+
+# Serialise deployments to one environment. Keyed on the pull-request
+# NUMBER rather than the ref: keyed on github.ref alone, the
+# pull_request(closed) teardown and the push deploy that a merge fires
+# simultaneously land in one group and cancel each other at random.
+# Learned in ronl-business-api on 2026-08-29.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+# Default to read-only; jobs opt into more only where required.
+permissions:
+  contents: read
 
 jobs:
   build_and_deploy_job:
+    permissions:
+      contents: read
+      pull-requests: write
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           submodules: true
+          persist-credentials: false
           lfs: false
       - name: Build And Deploy
         id: builddeploy
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_DELIGHTFUL_CLIFF_04B2D4E03 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
@@ -35,13 +54,14 @@ jobs:
           output_location: "packages/ropa-site" # Built app content directory - optional
 
   close_pull_request_job:
+    permissions: {}
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: Close Pull Request Job
     steps:
       - name: Close Pull Request
         id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_DELIGHTFUL_CLIFF_04B2D4E03 }}
           action: "close"

--- a/.github/workflows/azure-ropa-site-prod.yml
+++ b/.github/workflows/azure-ropa-site-prod.yml
@@ -6,26 +6,43 @@ on:
       - main
     paths:
       - 'packages/ropa-site/**'
+      - '.github/workflows/azure-ropa-site-prod.yml'
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
       - main
     paths:
       - 'packages/ropa-site/**'
+      - '.github/workflows/azure-ropa-site-prod.yml'
+
+# Same serialisation as the acc workflow, but production runs QUEUE
+# rather than cancel: interrupting a live production deployment to
+# start another is worse than waiting for it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
+# Default to read-only; jobs opt into more only where required.
+permissions:
+  contents: read
 
 jobs:
   build_and_deploy_job:
+    permissions:
+      contents: read
+      pull-requests: write
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           submodules: true
+          persist-credentials: false
           lfs: false
       - name: Build And Deploy
         id: builddeploy
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_ROPA_PROD }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -35,13 +52,14 @@ jobs:
           output_location: "packages/ropa-site"
 
   close_pull_request_job:
+    permissions: {}
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: Close Pull Request Job
     steps:
       - name: Close Pull Request
         id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_ROPA_PROD }}
           action: "close"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,55 @@
+name: Supply-chain audit
+
+on:
+  pull_request:
+    branches:
+      - acc
+      - main
+  push:
+    branches:
+      - acc
+      - main
+
+# Deliberately NO paths filter. The audit must run on every pull request
+# regardless of what changed — filtering it would let a pull request skip the
+# gate by touching nothing the filter watches.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+# Read-only: the audit inspects the tree and needs nothing else.
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          # The action's `version` input defaults to "latest". Pinning it is
+          # the whole point of this exercise — and it keeps CI's findings
+          # identical to the local baseline this work was measured against.
+          # Not Renovate-maintained: the github-actions manager does not
+          # parse action inputs, so this must be bumped by hand.
+          version: '1.29.0'
+          # advanced-security uploads SARIF, which needs security-events:
+          # write. This job is contents: read only, so it must be false.
+          # It also means fork PRs work, having no upload step to fail.
+          advanced-security: false
+          annotations: true
+          online-audits: false
+          # Leave `token` at its default. Setting it to '' looks like sound
+          # least-privilege hardening, but zizmor's --gh-token is env-backed
+          # and clap rejects a set-but-empty value before any audit runs,
+          # even with online-audits: false:
+          #   error: invalid value '' for '--gh-token <GH_TOKEN>'
+          # Learned the hard way in ttl-editor; do not retry it.

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,11 @@
+# IOU supply-chain policy: every action reference must be a commit hash,
+# with no exemption for first-party actions/*.
+#
+# zizmor 1.29.0 enforces this by default, so this file changes no findings
+# today. It is committed deliberately: the policy belongs in the repository
+# rather than in a tool default that a future release could relax.
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        '*': hash-pin

--- a/SECURITY-PIPELINE.md
+++ b/SECURITY-PIPELINE.md
@@ -1,0 +1,149 @@
+# Supply-chain posture of this pipeline
+
+What CI downloads and executes, how each of those things is pinned, and — the
+part that matters — what is **not** pinned and why.
+
+This is a state document. It describes the pipeline as it stands, not the work
+that produced it; the reasoning behind the gate lives in
+[`docs/the-gate-has-teeth.md`](docs/the-gate-has-teeth.md).
+
+Applies to the `acc` branch. `main` is promoted from `acc` and inherits this
+once promoted; until then production workflows on `main` still resolve floating
+tags.
+
+## The rule
+
+> Nothing downloaded or executed by a pipeline may float.
+
+No `latest`, no empty version, no mutable tag. Every reference resolves to a
+specific immutable object — a commit hash, a digest, a checksum — so that what
+ran yesterday is byte-identical to what runs today, and a compromised upstream
+release cannot reach this repository merely by being published.
+
+## What is pinned
+
+Every action reference in all seven workflows is a 40-character commit hash with
+its human-readable version in a trailing comment. The comment is not decoration:
+a digest nobody can read is a pin nobody will maintain, and Renovate moves the
+two together.
+
+| Action                         | Pinned at                                  | Version          |
+| ------------------------------ | ------------------------------------------ | ---------------- |
+| `actions/checkout`             | `11d5960a326750d5838078e36cf38b85af677262` | v4.4.0           |
+| `actions/checkout`             | `a37ce9120846195fa4ece8f58b268e6043cb2f26` | v3.7.0           |
+| `actions/setup-node`           | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4.4.0           |
+| `Azure/static-web-apps-deploy` | `4d27395796ac319302594769cfe812bd207490b1` | v1 (branch head) |
+| `azure/webapps-deploy`         | `02a81bead70021f5284939794bcec79c271ab383` | v3.0.8           |
+| `zizmorcore/zizmor-action`     | `3dc1ecc9bcb9e94e9b2c709687979e1298497054` | v0.6.2           |
+
+`zizmor 1.29.0` reports **0 findings** across all seven workflows.
+
+Node dependencies install through `npm ci` in the frontend and backend build
+jobs, which installs the lockfile exactly and fails rather than resolving
+anything fresh. One deploy step is an exception — see below.
+
+## What is not pinned
+
+Recording these honestly is the point. An exception you have written down is a
+known risk; an exception you have not is a false sense of coverage.
+
+### 1. `mcr.microsoft.com/appsvc/staticappsclient:stable`
+
+`Azure/static-web-apps-deploy` is a Docker action, and at the exact commit we
+pin it to, its `Dockerfile` reads:
+
+```
+FROM mcr.microsoft.com/appsvc/staticappsclient:stable
+```
+
+So pinning the action pins the _wrapper_, not the image that actually runs. The
+`stable` tag is mutable and Microsoft-controlled; every deployment pulls whatever
+it points at that day. There is no input to override it, and forking the action
+to pin the digest would mean owning Microsoft's deployment client — a larger and
+worse-understood risk than the one it removes.
+
+**Four of the six deployment workflows sit behind this.** It is the single
+largest unpinned surface in the repository and it is not closeable from here.
+
+### 2. `npm install --production --omit=dev` in the backend deploy step
+
+Both backend workflows build with `npm ci`, then assemble a `deploy/` folder and
+run a **second, lockfile-less install** inside it:
+
+- `azure-backend-acc.yml:95`
+- `azure-backend-production.yml:86`
+
+`npm ci` requires a lockfile and installs it exactly. `npm install` in a folder
+without one resolves ranges fresh at deploy time — so the code shipped to Azure
+can contain dependency versions that no build step ever saw and no lockfile
+records. This is a real gap, inside the deploy path, and it is fixable: copying
+the workspace lockfile into `deploy/` and using `npm ci --omit=dev` would close
+it. Left alone deliberately, because the pinning work was scoped to be
+behaviour-preserving.
+
+### 3. `node-version` floats within a major
+
+`'22'` in the backend workflows, `'20'` in the frontend. `setup-node` resolves
+these to whatever patch the runner has cached. Pinning to an exact patch would
+trade a small supply-chain surface for routine breakage as runners roll forward,
+and the Node distribution is not the threat model this policy was written for.
+
+### 4. `zizmor-action`'s `version: '1.29.0'` input
+
+The action itself is hash-pinned, and this input pins the zizmor binary it
+fetches — so nothing floats. But Renovate's `github-actions` manager does not
+parse action _inputs_, only `uses:` lines, so this one number is maintained by
+hand. If the audit ever needs a newer zizmor, someone must edit it.
+
+### 5. `ropa-site` builds inside Azure
+
+`packages/ropa-site` has no `package.json` — it is `index.html` and a
+`staticwebapp.config.json`. The workflows set no `skip_app_build`, so Azure's
+Oryx builder inspects it, finds nothing to build, and uploads it as-is. The
+build environment is Microsoft's and unpinnable, but with no dependency manifest
+there is nothing for it to resolve. Worth stating precisely, because
+"unpinned build environment" and "unpinned dependencies" are not the same claim.
+
+## Version currency
+
+The four `ropa-site` action references pin `actions/checkout` at **v3.7.0**,
+four majors behind. Pinned is not the same as current: a hash freezes a version
+in place, including an old one. Renovate now raises these as upgrades under the
+14-day cooldown, which is the intended way for them to move — deliberately, in a
+reviewable pull request, rather than silently on the next run.
+
+## How the pins stay current
+
+Pinning without automated updates decays into an unpatched tree, which is worse
+than floating. `renovate.json` supplies the other half:
+
+- **`helpers:pinGitHubActionDigests`** — anything reintroduced as a tag gets
+  pinned back to a hash.
+- **`minimumReleaseAge: "14 days"` with `internalChecksFilter: "strict"`** — a
+  cooldown, not a security control. A compromised release is usually yanked
+  within days; waiting two weeks means this repository never installs it.
+  `strict` makes Renovate hold the pull request back rather than raise it and
+  annotate it as pending.
+- **`vulnerabilityAlerts` with `minimumReleaseAge: null`** — the fast lane. A
+  fix for a known advisory must not wait out the cooldown.
+- **Three workspace groups** — `backend`, `frontend`, `ropa-site`. An update
+  that breaks one deployable should not be entangled with the other two.
+- **`Azure/static-web-apps-deploy` disabled.** It is pinned to the newest commit
+  on the `v1` _branch_; the `v1` _tag_ has not moved since 2021. Renovate
+  resolves `@v1` to the tag, so leaving it enabled would raise a pull request
+  "updating" the pin backwards by four years.
+
+## How the rule is enforced
+
+`.github/workflows/zizmor.yml` runs `zizmor` on every pull request and push to
+`acc` and `main`, under `.github/zizmor.yml`, which sets `unpinned-uses` to
+`hash-pin` for **`'*'`** — no exemption for first-party `actions/*`.
+
+The audit workflow deliberately has **no `paths:` filter**. Every other workflow
+here is path-filtered; filtering this one would let a pull request skip the gate
+by touching nothing the filter watches.
+
+The `acc` ruleset requires a pull request and a passing `audit` check, so the
+gate is not advisory — a branch that reintroduces a floating tag cannot merge.
+That includes releases: `/bump-release` was rewritten to land through a pull
+request for exactly this reason.

--- a/docs/the-gate-has-teeth.md
+++ b/docs/the-gate-has-teeth.md
@@ -1,0 +1,164 @@
+# The gate has teeth
+
+How the IOU supply-chain pinning policy was applied to the Linked Data Explorer,
+and — more usefully — what was different here from the two repositories that went
+first.
+
+`ttl-editor` and `ronl-business-api` each carry a document with this name. This
+one deliberately does not restate what they say. The policy, the rationale for
+hash-pinning, the cooldown, and the ruleset mechanics are settled and identical;
+read `ttl-editor`'s copy for those. What follows is what this repository taught
+us, and what a fourth repository should expect to differ again.
+
+The resulting state — every pin, and every honest exception — is
+[`SECURITY-PIPELINE.md`](../SECURITY-PIPELINE.md).
+
+## The shape of this repository
+
+Three deployables, not one:
+
+| Workspace            | acc                       | production                      | Deployed by     |
+| -------------------- | ------------------------- | ------------------------------- | --------------- |
+| `packages/backend`   | `azure-backend-acc.yml`   | `azure-backend-production.yml`  | App Service     |
+| `packages/frontend`  | `azure-frontend-acc.yml`  | `azure-frontend-production.yml` | Static Web Apps |
+| `packages/ropa-site` | `azure-ropa-site-acc.yml` | `azure-ropa-site-prod.yml`      | Static Web Apps |
+
+Six deployment workflows plus the audit. `ttl-editor` had two. That difference is
+not just arithmetic: it is the reason `renovate.json` groups dependencies per
+workspace, so a breaking update to one deployable is not entangled with the other
+two in a single pull request.
+
+Result: **40 zizmor findings to 0**, twenty action references pinned.
+
+## What was already right here
+
+Two things this repository had that the others did not, both of which meant less
+work rather than more.
+
+**`pull_request` was already path-filtered.** In `ronl-business-api`, every pull
+request to `acc` deployed all three sites, each holding a Static Web Apps staging
+environment against a per-app ceiling of three — five open pull requests
+exhausted it on 2026-08-28, and fixing that became follow-up item 5. Here, all
+four Static Web Apps workflows already filtered `pull_request` on the same paths
+as `push`. The problem never existed.
+
+It is worth saying plainly that I reported the opposite at first. My survey
+grepped the trigger blocks with `head -8`, which truncated inside
+`pull_request:` and showed only its `branches:`. The filter was there the whole
+time; the tool cut it off. A survey that truncates is not a survey, and a finding
+derived from one is not a finding.
+
+**The backend deploys with `azure/webapps-deploy@v3` and a publish profile, and
+it works.** This matters outside this repository. `ronl-business-api`'s follow-up
+item 2 records a _hypothesis_ that its backend cannot deploy from CI because
+App Service disables SCM basic authentication by default. This repository does
+exactly that, successfully, against the same subscription — so the hypothesis is
+wrong as stated. Whatever blocks `ronl-business-api` is per-App-Service
+configuration, not a platform default. That item needs correcting there.
+
+## What was different, and cost something
+
+### The self-reference asymmetry
+
+Every workflow now lists its own file in its `paths:`, matching the convention
+the backend workflows already followed:
+
+```yaml
+paths:
+  - "packages/frontend/**"
+  - ".github/workflows/azure-frontend-acc.yml"
+```
+
+Without it, a pull request that changes only a workflow does not run that
+workflow — so the pinning pull request itself would have modified six deploy
+pipelines and exercised none of them.
+
+The script that applied this added the self-reference to `push` only. Because
+`pull_request` already had its own `paths:` block, the mirroring branch that
+would have handled it was correctly skipped — and the asymmetry that left behind
+was worse than either state alone: `push` would deploy on merge, `pull_request`
+would not deploy on the pull request. The change would have gone in untested and
+landed straight on `acc`.
+
+The lesson is narrow and worth keeping: **a filter is two lists, and a change to
+one of them is not a change.** Both halves now carry the self-reference.
+
+### Concurrency, applied before it broke anything
+
+All six deployment workflows gained:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true # false on the two production workflows
+```
+
+This is the _corrected_ key from `ronl-business-api`, adopted here without the
+intervening incident. Keyed on `github.ref` alone, the `pull_request(closed)`
+teardown and the `push` deploy that a merge fires simultaneously land in the same
+group and cancel each other at random — which there skipped two acceptance
+deploys and stranded a preview environment before anyone noticed.
+
+Production queues rather than cancels: interrupting a live production deployment
+to start another is worse than waiting for it.
+
+Note that this is the _GitHub_ concurrency layer. Azure cancels overlapping
+deployments to a single Static Web Apps environment on its own, and reports
+`Deployment Canceled` on a job that did nothing wrong. Both layers exist; a green
+`concurrency:` block is not evidence that Azure is not also cancelling something.
+
+### `staticappsclient:stable` is the real ceiling here
+
+Four of six deployment workflows go through `Azure/static-web-apps-deploy`, a
+Docker action whose image is `mcr.microsoft.com/appsvc/staticappsclient:stable` —
+a mutable tag, pulled fresh on every deployment, with no input to override it.
+
+Pinning the action pins the wrapper, not what runs. With four workflows behind
+it, this is the largest unpinned surface in the repository, and it is larger here
+than in `ttl-editor` simply because there is more of it. It is not closeable from
+this side, so it is recorded rather than solved.
+
+Verified against the Dockerfile at the exact commit we pin, not carried over from
+the earlier repository — the same action can change its base image between
+commits, and an exception inherited without checking is an assumption.
+
+## Sequence
+
+The order below is not incidental. Pinning without Renovate decays into an
+unpatched tree; a ruleset before a green audit blocks every pull request
+including the one that fixes it.
+
+1. Pin all twenty action references; add `persist-credentials: false`,
+   workflow- and job-level `permissions:`, `concurrency:`, and the `paths:`
+   self-references. Verify locally: `uvx zizmor@1.29.0 .github/workflows/`.
+2. Add `.github/zizmor.yml` (policy) and `.github/workflows/zizmor.yml` (gate).
+3. Add `renovate.json`.
+4. Merge to `acc`. Only now enable the Renovate App — it reads `renovate.json`
+   from the default branch, so enabling it earlier onboards with defaults.
+5. Enable Dependabot alerts.
+6. Add the `acc` ruleset requiring a pull request and a passing `audit` check.
+   Last, once `audit` has actually reported green at least once.
+7. Repository settings: merge commits only, `delete_branch_on_merge`.
+
+## Two things not to repeat
+
+**Do not set `token: ''` on the zizmor action.** It reads as sound
+least-privilege hardening and it is not; `--gh-token` is env-backed and clap
+rejects a set-but-empty value before any audit runs, even with
+`online-audits: false`:
+
+```
+error: invalid value '' for '--gh-token <GH_TOKEN>': GitHub token cannot be empty
+```
+
+That broke the gate on its first run in `ttl-editor`. The default is correct.
+
+**Do not measure the baseline with a different zizmor than the gate runs.**
+zizmor 1.29.0 no longer exempts `actions/*` from `unpinned-uses`; an older local
+binary reports a much smaller number and makes the work look finished.
+
+## Still open
+
+`main` is untouched. Production workflows on `main` still resolve floating tags
+until `acc` is promoted — the pins described here protect acceptance, not yet
+production. The same is true of `ttl-editor` and `ronl-business-api`.

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    "helpers:pinGitHubActionDigests"
+  ],
+
+  "//": "IOU supply-chain policy. Nothing a pipeline downloads or executes may float: actions are pinned to a commit hash, and Renovate is the mechanism that keeps those hashes current without anyone hand-resolving a digest again.",
+
+  "minimumReleaseAge": "14 days",
+  "internalChecksFilter": "strict",
+
+  "//minimumReleaseAge": "A cooldown, not a security control. A compromised release is usually yanked within days; waiting two weeks means this repository never installs it. 'strict' makes Renovate actually hold the pull request back rather than raise it and annotate it as pending.",
+
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": null,
+    "labels": ["security"]
+  },
+
+  "//vulnerabilityAlerts": "The fast lane. A fix for a known advisory is the one update that must not wait out the cooldown, so the delay is explicitly cleared here.",
+
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions",
+      "matchUpdateTypes": ["minor", "patch", "digest"]
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["Azure/static-web-apps-deploy"],
+      "enabled": false,
+      "description": "Pinned to 4d27395 — the newest commit on the v1 branch, not the v1 tag, which has not moved since 2021. Renovate resolves @v1 to the tag, so leaving this enabled would raise a pull request 'updating' the pin backwards by four years. Re-resolve by hand if this action ever needs to move."
+    },
+    {
+      "matchFileNames": ["packages/backend/**"],
+      "groupName": "backend dependencies"
+    },
+    {
+      "matchFileNames": ["packages/frontend/**"],
+      "groupName": "frontend dependencies"
+    },
+    {
+      "matchFileNames": ["packages/ropa-site/**"],
+      "groupName": "ropa-site dependencies"
+    }
+  ],
+
+  "//packageRules": "Three workspaces, three groups: an update that breaks one deployable should not be entangled with the other two in a single pull request. Actions are grouped separately again because they land across all six workflows at once.",
+
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "baseBranches": ["acc"],
+
+  "//baseBranches": "acc is the integration branch. main is promoted from acc and must never receive dependency pull requests directly.",
+
+  "labels": ["dependencies"],
+  "rangeStrategy": "bump",
+  "postUpdateOptions": ["npmDedupe"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 5am on monday"]
+  }
+}


### PR DESCRIPTION
Applies the IOU supply-chain pinning policy to this repository, following
`ttl-editor` and `ronl-business-api`.

**Nothing downloaded or executed by this pipeline may float.** All twenty action
references across the six deployment workflows are now commit hashes with their
version in a trailing comment. A zizmor gate refuses any pull request that
reintroduces a floating tag.

zizmor findings: **40 → 0**.

## What is in here

| | |
| --- | --- |
| 6 deploy workflows | hash pins, `persist-credentials: false`, workflow + job `permissions:`, `concurrency:`, `paths:` self-references |
| `.github/workflows/zizmor.yml` | the gate — job `audit`, zizmor `1.29.0`, deliberately no `paths:` filter |
| `.github/zizmor.yml` | `unpinned-uses: hash-pin` for `'*'`, no exemption for `actions/*` |
| `renovate.json` | 14-day cooldown + `internalChecksFilter: strict`, security fast-lane, three workspace groups |
| `SECURITY-PIPELINE.md` | what is pinned, and honestly what is not |
| `docs/the-gate-has-teeth.md` | what differed here from the first two repositories |

## Verification

- `uvx zizmor@1.29.0 .github/workflows/` — 0 findings across all seven workflows
- backend (Jest) 1130/1130, frontend (Vitest) 573/573
- `npm run lint` clean, `npm run check-format` clean

Every workflow now lists its own file in its `paths:` on **both** the `push` and
the `pull_request` half, so this pull request actually exercises the six
pipelines it changes rather than modifying them untested.

## Two exceptions worth reading

1. **`mcr.microsoft.com/appsvc/staticappsclient:stable`** — `Azure/static-web-apps-deploy`
   is a Docker action, and its `Dockerfile` at the exact commit we pin uses that
   mutable tag. Pinning the action pins the wrapper, not what runs. Four of six
   deployment workflows sit behind it and it is not closeable from our side.
2. **`npm install --production --omit=dev`** in both backend deploy steps —
   a second, lockfile-less install after the `npm ci` build. Real gap in the
   deploy path, fixable separately; left alone here to keep this change
   behaviour-preserving.

Both are recorded in `SECURITY-PIPELINE.md` rather than quietly omitted.

## Note for `ronl-business-api`

That repository's open follow-up item 2 assumes App Service disables SCM basic
authentication by default, blocking backend deploys from CI. This repository
deploys its backend with `azure/webapps-deploy` and a publish profile against
the same subscription, successfully — so that assumption is wrong, and the
blocker there is per-App-Service configuration. Item 2 needs correcting.

## Not in scope

`main` is untouched. Production workflows still resolve floating tags until
`acc` is promoted.