### PR TITLE
fix: use description fields for renovate config comments

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -53,3 +53,24 @@ jobs:
           # even with online-audits: false:
           #   error: invalid value '' for '--gh-token <GH_TOKEN>'
           # Learned the hard way in ttl-editor; do not retry it.
+
+      - name: Validate renovate.json
+        # Runs even when zizmor fails, so a single run reports on both halves
+        # of the policy rather than the first failure hiding the second.
+        if: always()
+        # Pinned like everything else here. A supply-chain check that fetched a
+        # floating version of its own tool would be self-defeating. Renovate's
+        # npm manager will NOT maintain this for us -- it is an inline npx
+        # argument, not a manifest entry -- so it is bumped by hand, alongside
+        # the zizmor version above.
+        #
+        # --strict also fails on configuration Renovate would silently
+        # auto-migrate. That is deliberate: it is how `baseBranches`, renamed
+        # upstream to `baseBranchPatterns`, was caught in linked-data-explorer
+        # rather than living on as a deprecated key that still "worked".
+        #
+        # No filename argument. Passing one switches the validator into global
+        # config mode, which applies different rules than the repository config
+        # this file actually is -- it will happily validate and tell you
+        # nothing useful.
+        run: npx --yes --package renovate@44.50.3 renovate-config-validator --strict

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -32,6 +32,20 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
+      - name: Set up Node 24 for the config validator
+        # renovate@44.50.3 declares engines.node ^24.11.0; the runner's
+        # default is Node 22. npm accepts that with an EBADENGINE warning
+        # rather than refusing, so the validator ran unsupported and green
+        # -- the kind of mismatch that keeps working until it abruptly
+        # does not. Reuses the setup-node pin this repository already
+        # carries, so Renovate maintains one digest rather than two.
+        #
+        # Placed BEFORE the zizmor step deliberately: a step after a
+        # failing one is skipped, and the validator's `if: always()`
+        # would then run on whatever Node the runner defaulted to.
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '24'
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
         with:

--- a/renovate.json
+++ b/renovate.json
@@ -1,38 +1,64 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": [
+    "Supply-chain policy for linked-data-explorer. Companion to .github/zizmor.yml",
+    "and the Supply-chain audit workflow: zizmor enforces that every action",
+    "reference is a commit hash, Renovate keeps those hashes current. Pinning",
+    "without automated updates decays into an unpatched tree, which is worse",
+    "than floating. See SECURITY-PIPELINE.md.",
+    "baseBranches targets acc, this repository's integration and default",
+    "branch. main is promoted from acc and must never receive dependency",
+    "pull requests directly."
+  ],
   "extends": [
     "config:recommended",
     ":dependencyDashboard",
     "helpers:pinGitHubActionDigests"
   ],
-
-  "//": "IOU supply-chain policy. Nothing a pipeline downloads or executes may float: actions are pinned to a commit hash, and Renovate is the mechanism that keeps those hashes current without anyone hand-resolving a digest again.",
-
   "minimumReleaseAge": "14 days",
   "internalChecksFilter": "strict",
-
-  "//minimumReleaseAge": "A cooldown, not a security control. A compromised release is usually yanked within days; waiting two weeks means this repository never installs it. 'strict' makes Renovate actually hold the pull request back rather than raise it and annotate it as pending.",
-
   "vulnerabilityAlerts": {
+    "description": [
+      "Security advisories bypass the cooldown. Without this override the",
+      "14-day wait would delay exactly the updates that must not wait, which",
+      "is why such policies get disabled mid-incident. Requires GitHub",
+      "Dependabot ALERTS to be enabled on the repository; Dependabot security",
+      "UPDATES must stay off, or it opens competing PRs that ignore the cooldown."
+    ],
     "minimumReleaseAge": null,
     "labels": ["security"]
   },
-
-  "//vulnerabilityAlerts": "The fast lane. A fix for a known advisory is the one update that must not wait out the cooldown, so the delay is explicitly cleared here.",
-
   "packageRules": [
     {
+      "description": [
+        "Actions land across all seven workflows at once, so they are grouped",
+        "separately from the workspace dependencies below."
+      ],
       "matchManagers": ["github-actions"],
       "groupName": "github actions",
       "matchUpdateTypes": ["minor", "patch", "digest"]
     },
     {
+      "description": [
+        "Azure/static-web-apps-deploy publishes v1 as BOTH a 2021 tag and a",
+        "2024 branch head (4d27395796ac319302594769cfe812bd207490b1). The four",
+        "Static Web Apps workflows pin the branch head; Renovate's github-tags",
+        "datasource resolves the tag, so it would open a routine-looking digest",
+        "update that reverts those deploy steps to 3.5-year-old code.",
+        "minimumReleaseAge gives no protection here - the target commit is",
+        "years old already. Re-resolve by hand if this action ever needs to",
+        "move. See SECURITY-PIPELINE.md."
+      ],
       "matchManagers": ["github-actions"],
       "matchDepNames": ["Azure/static-web-apps-deploy"],
-      "enabled": false,
-      "description": "Pinned to 4d27395 — the newest commit on the v1 branch, not the v1 tag, which has not moved since 2021. Renovate resolves @v1 to the tag, so leaving this enabled would raise a pull request 'updating' the pin backwards by four years. Re-resolve by hand if this action ever needs to move."
+      "enabled": false
     },
     {
+      "description": [
+        "Three deployables, three groups. An update that breaks one workspace",
+        "should not be entangled with the other two in a single pull request -",
+        "each has its own deploy workflow and its own acceptance site."
+      ],
       "matchFileNames": ["packages/backend/**"],
       "groupName": "backend dependencies"
     },
@@ -45,15 +71,9 @@
       "groupName": "ropa-site dependencies"
     }
   ],
-
-  "//packageRules": "Three workspaces, three groups: an update that breaks one deployable should not be entangled with the other two in a single pull request. Actions are grouped separately again because they land across all six workflows at once.",
-
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2,
   "baseBranches": ["acc"],
-
-  "//baseBranches": "acc is the integration branch. main is promoted from acc and must never receive dependency pull requests directly.",
-
   "labels": ["dependencies"],
   "rangeStrategy": "bump",
   "postUpdateOptions": ["npmDedupe"],

--- a/renovate.json
+++ b/renovate.json
@@ -6,9 +6,9 @@
     "reference is a commit hash, Renovate keeps those hashes current. Pinning",
     "without automated updates decays into an unpatched tree, which is worse",
     "than floating. See SECURITY-PIPELINE.md.",
-    "baseBranches targets acc, this repository's integration and default",
-    "branch. main is promoted from acc and must never receive dependency",
-    "pull requests directly."
+    "baseBranchPatterns targets acc, this repository's integration and",
+    "default branch. main is promoted from acc and must never receive",
+    "dependency pull requests directly."
   ],
   "extends": [
     "config:recommended",
@@ -73,7 +73,7 @@
   ],
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2,
-  "baseBranches": ["acc"],
+  "baseBranchPatterns": ["acc"],
   "labels": ["dependencies"],
   "rangeStrategy": "bump",
   "postUpdateOptions": ["npmDedupe"],


### PR DESCRIPTION
Closes #31.

Renovate validates its configuration strictly and rejects unknown options, so
the `"//"`-prefixed keys I used as comments in `renovate.json` were read as five
invalid settings rather than ignored:

```
Invalid configuration option: //, //baseBranches, //minimumReleaseAge,
//packageRules, //vulnerabilityAlerts
```

Renovate stopped opening pull requests as a precaution. That is the correct
behaviour from it — a dependency bot proceeding on a configuration it cannot
parse would be worse — but it meant the half of the supply-chain policy that
keeps pins current was inert from the moment it landed in #30.

## The fix

The `//` convention is borrowed from tools that ignore unknown keys. Renovate
supplies its own: a `description` field, valid at the top level and inside any
nested object, which `ronl-business-api` already uses. Every comment moves
there, and the note about `baseBranches` moves up to the top-level
`description` rather than sitting inside `lockFileMaintenance`, where it had
nothing to do with its surroundings.

**No policy changes.** The 14-day cooldown, `internalChecksFilter: strict`, the
`vulnerabilityAlerts` fast-lane, the three workspace groups and the
`Azure/static-web-apps-deploy` exclusion are byte-for-byte identical in effect;
only the annotation style differs.

## Verification

```
$ npx --package renovate renovate-config-validator renovate.json
 INFO: Config validated successfully against 1 file(s)
```

Run against the version merged in #30 it exits 1 on `Invalid configuration
option: //` — so this was preventable by a check that was never run. Adding
`renovate-config-validator` to the audit workflow follows in its own pull
request, across all three repositories.

`ttl-editor` and `ronl-business-api` were both checked for the same mistake and
have none, so it did not propagate.

## Note

First change through the `acc supply-chain gate` ruleset added today, so this
also exercises the gate.