### PR TITLE
style: reformat for prettier 3.9

### DIFF
--- a/packages/backend/src/routes/registry.ts
+++ b/packages/backend/src/routes/registry.ts
@@ -25,12 +25,7 @@ import shaclRoutes from './shacl.routes';
 /** Logical grouping for the root page. New categories can be added; see
  *  CATEGORY_ORDER in utils/rootView.ts for render order. */
 export type RouteCategory =
-  | 'Health & monitoring'
-  | 'Discovery'
-  | 'Validation'
-  | 'Execution'
-  | 'Assets'
-  | 'Integrations';
+  'Health & monitoring' | 'Discovery' | 'Validation' | 'Execution' | 'Assets' | 'Integrations';
 
 export interface RouteDefinition {
   /** Mount path under which the router is attached. Drives both registration

--- a/packages/backend/src/services/sparql.service.ts
+++ b/packages/backend/src/services/sparql.service.ts
@@ -288,10 +288,7 @@ ORDER BY ?identifier
 
           // NEW: Validation metadata from RONL Ontology v1.0
           validationStatus: binding.validationStatus?.value as
-            | 'validated'
-            | 'in-review'
-            | 'not-validated'
-            | undefined,
+            'validated' | 'in-review' | 'not-validated' | undefined,
           validatedBy: binding.validatedBy?.value,
           validatedByName: binding.validatedByName?.value, // Already fetched by SPARQL query
           validatedAt: binding.validatedAt?.value,

--- a/packages/frontend/src/components/ChainBuilder/ChainConfig.tsx
+++ b/packages/frontend/src/components/ChainBuilder/ChainConfig.tsx
@@ -171,9 +171,7 @@ const ChainConfig: React.FC<ChainConfigProps> = ({
         defaultInputs: inputs,
         tags: [`${chain.length}-dmn`, templateType],
         complexity: (chain.length === 1 ? 'simple' : chain.length <= 3 ? 'medium' : 'complex') as
-          | 'simple'
-          | 'medium'
-          | 'complex',
+          'simple' | 'medium' | 'complex',
         estimatedTime: validation?.estimatedTime || chain.length * 150 + 50,
         isPublic: false,
         endpoint,

--- a/packages/frontend/src/components/DocumentComposer/DocumentList.tsx
+++ b/packages/frontend/src/components/DocumentComposer/DocumentList.tsx
@@ -107,8 +107,7 @@ const DocumentList: React.FC<DocumentListProps> = ({
           const baseName = file.name.replace(/\.document$/i, '');
           const langMatch = baseName.match(/\.(en|nl|de)$/i);
           const inferredLanguage = langMatch?.[1].toLowerCase() as
-            | DocumentTemplate['language']
-            | undefined;
+            DocumentTemplate['language'] | undefined;
 
           // e2e-fixtures .document files declare status: "e2e" directly (see
           // manifest.json) — trust only that exact sentinel; any other

--- a/packages/frontend/src/types/ropa.types.ts
+++ b/packages/frontend/src/types/ropa.types.ts
@@ -1,13 +1,7 @@
 export type ProcessLevel = 'shell' | 'subprocess';
 export type RopaStatus = 'draft' | 'active' | 'archived';
 export type DataCategory =
-  | 'identity'
-  | 'financial'
-  | 'residence'
-  | 'health'
-  | 'civil status'
-  | 'criminal'
-  | 'other';
+  'identity' | 'financial' | 'residence' | 'health' | 'civil status' | 'criminal' | 'other';
 
 export interface RopaPersonalDataField {
   id: string;


### PR DESCRIPTION
Follow-up to #38.

That PR raised **prettier `3.7.4` → `3.9.6`** as one of twenty-three backend
dependency updates. 3.9 formats short union types on a single line rather than
the leading-pipe multiline style 3.7 produced, so five existing files began
failing `prettier --check` the moment #38 landed:

```
packages/backend/src/routes/registry.ts
packages/backend/src/services/sparql.service.ts
packages/frontend/src/components/ChainBuilder/ChainConfig.tsx
packages/frontend/src/components/DocumentComposer/DocumentList.tsx
packages/frontend/src/types/ropa.types.ts
```

## Why CI didn't catch it

**No workflow runs `check-format`.** The deploy workflows run `npm run lint` and
`npm test`; the audit gate runs zizmor and the Renovate config validator. The
check that catches this is the **pre-push hook** — so the symptom would have
been the next person's `git push` failing on files they never touched.

Worth noting as a gap in its own right: `check-format` is enforced locally but
not in CI, which is the wrong way round for a rule meant to hold on the shared
branch.

## This change

Purely cosmetic — 5 files, **+5/−22**, produced by `npm run format` and reviewed
as a diff rather than taken on trust.

| | |
| --- | --- |
| `npm run check-format` | exit 0 |
| `npm run lint` | pass |
| backend (Jest) | 1130/1130 |
| frontend (Vitest) | 573/573 |
| `npm run build` | pass (verified on #38's branch) |

Kept as its own commit rather than folded into the v2026.08.4 release that
follows, so the reformat stays attributable to the upgrade that caused it
instead of being buried among twenty-five unrelated commits.