### PR TITLE
fix(bpmn): bind forms to their own deployment instead of the latest version

### DIFF
--- a/e2e-fixtures/flevoland/AwbShellProcess.bpmn
+++ b/e2e-fixtures/flevoland/AwbShellProcess.bpmn
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:ronl="http://ronl.nl/schema/1.0" id="Definitions_AWB" targetNamespace="http://example.com/awb" exporter="Camunda Modeler" exporterVersion="5.43.1">
   <bpmn:process id="AwbShellProcess" name="AWB General Administrative Law Act - Generic Process" isExecutable="true" camunda:historyTimeToLive="365">
-    <bpmn:startEvent id="StartEvent_AWB" name="Application submitted" camunda:formRef="kapvergunning-start" camunda:formRefBinding="latest">
+    <bpmn:startEvent id="StartEvent_AWB" name="Application submitted" camunda:formRef="kapvergunning-start" camunda:formRefBinding="deployment">
       <bpmn:outgoing>Flow_Start_Phase1</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:scriptTask id="Task_Phase1_Identity" name="Phase 1: Determine legal relationship (identification)" scriptFormat="javascript">
@@ -83,7 +83,7 @@
       <bpmn:incoming>Flow_Recheck_Process</bpmn:incoming>
       <bpmn:outgoing>Flow_Phase45_Phase6</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:userTask id="Task_Phase6_Notify" name="Phase 6: Notify applicant of decision (Awb 3:6)" camunda:formRef="awb-notify-applicant" camunda:formRefBinding="latest" camunda:candidateGroups="caseworker" ronl:documentRef="example_treefelling_beschikking">
+    <bpmn:userTask id="Task_Phase6_Notify" name="Phase 6: Notify applicant of decision (Awb 3:6)" camunda:formRef="awb-notify-applicant" camunda:formRefBinding="deployment" camunda:candidateGroups="caseworker" ronl:documentRef="example_treefelling_beschikking">
       <bpmn:incoming>Flow_Phase45_Phase6</bpmn:incoming>
       <bpmn:incoming>Flow_Refuse_Notify</bpmn:incoming>
       <bpmn:outgoing>Flow_Phase6_PaymentGateway</bpmn:outgoing>

--- a/e2e-fixtures/flevoland/RipR21Process.bpmn
+++ b/e2e-fixtures/flevoland/RipR21Process.bpmn
@@ -46,36 +46,36 @@
     <bpmn:startEvent id="StartEvent_RipPhase1" name="Start RIP fase 1">
       <bpmn:outgoing>Flow_Start_Aanlevren</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:userTask id="Task_AanlevrenProjectplan" name="Aanleveren Projectplan&#10;1. Intake-formulier" camunda:formRef="rip-intake" camunda:formRefBinding="latest" camunda:candidateGroups="rip-aandrager">
+    <bpmn:userTask id="Task_AanlevrenProjectplan" name="Aanleveren Projectplan&#10;1. Intake-formulier" camunda:formRef="rip-intake" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-aandrager">
       <bpmn:incoming>Flow_Start_Aanlevren</bpmn:incoming>
       <bpmn:outgoing>Flow_Aanlevren_Organiseren</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_VerberenKwaliteit" name="Verbeteren kwaliteit&#10;1. Intake-formulier" camunda:formRef="rip-kwaliteit-verbetering" camunda:formRefBinding="latest" camunda:candidateGroups="rip-aandrager">
+    <bpmn:userTask id="Task_VerberenKwaliteit" name="Verbeteren kwaliteit&#10;1. Intake-formulier" camunda:formRef="rip-kwaliteit-verbetering" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-aandrager">
       <bpmn:incoming>Flow_IntakeNee_Verbeteren</bpmn:incoming>
       <bpmn:outgoing>Flow_Verbeteren_Accorderen2</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_OrganiserenIntakeoverleg" name="Organiseren intake-overleg" camunda:formRef="rip-intake-meeting" camunda:formRefBinding="latest" camunda:candidateGroups="rip-manager-pb">
+    <bpmn:userTask id="Task_OrganiserenIntakeoverleg" name="Organiseren intake-overleg" camunda:formRef="rip-intake-meeting" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-manager-pb">
       <bpmn:incoming>Flow_Aanlevren_Organiseren</bpmn:incoming>
       <bpmn:outgoing>Flow_Organiseren_Uitvoeren</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_OpstellenRisicodossier" name="Opstellen risicossier&#10;en versturen aan PL" camunda:formRef="rip-risk-file" camunda:formRefBinding="latest" camunda:candidateGroups="rip-manager-pb">
+    <bpmn:userTask id="Task_OpstellenRisicodossier" name="Opstellen risicossier&#10;en versturen aan PL" camunda:formRef="rip-risk-file" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-manager-pb">
       <bpmn:incoming>Flow_Relatics_Risicodossier</bpmn:incoming>
       <bpmn:outgoing>Flow_Risicodossier_UitvoerenPSU</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_OpstellenPlanning" name="Opstellen planning en&#10;informeren PL en ondersteuner" camunda:formRef="rip-planning" camunda:formRefBinding="latest" camunda:candidateGroups="rip-manager-pb">
+    <bpmn:userTask id="Task_OpstellenPlanning" name="Opstellen planning en&#10;informeren PL en ondersteuner" camunda:formRef="rip-planning" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-manager-pb">
       <bpmn:incoming>Flow_UitvoerenPSU_Planning</bpmn:incoming>
       <bpmn:outgoing>Flow_Planning_Aanvullen4</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_AanvullenProjectplan2" name="Aanvullen Projectplan&#10;2. Intake-verslag" camunda:formRef="rip-intake-report" camunda:formRefBinding="latest" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-intake-report">
+    <bpmn:userTask id="Task_AanvullenProjectplan2" name="Aanvullen Projectplan&#10;2. Intake-verslag" camunda:formRef="rip-intake-report" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-intake-report">
       <bpmn:incoming>Flow_IntakeJa_Aanvullen2</bpmn:incoming>
       <bpmn:incoming>Flow_Akkoord2Rejected_Aanvullen2</bpmn:incoming>
       <bpmn:outgoing>Flow_Aanvullen2_Accorderen2</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_InitierenPSU" name="Initieren / organiseren PSU" camunda:formRef="rip-psu-organize" camunda:formRefBinding="latest" camunda:candidateGroups="rip-projectleider">
+    <bpmn:userTask id="Task_InitierenPSU" name="Initieren / organiseren PSU" camunda:formRef="rip-psu-organize" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
       <bpmn:incoming>Flow_Akkoord2Approved_InitierenPSU</bpmn:incoming>
       <bpmn:outgoing>Flow_InitierenPSU_Relatics</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_AanvullenProjectplan4" name="Aanvullen Projectplan&#10;4. Uitgangspunten VO-fase" camunda:formRef="rip-pdp-aanvullen" camunda:formRefBinding="latest" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-pdp">
+    <bpmn:userTask id="Task_AanvullenProjectplan4" name="Aanvullen Projectplan&#10;4. Uitgangspunten VO-fase" camunda:formRef="rip-pdp-aanvullen" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-pdp">
       <bpmn:incoming>Flow_Planning_Aanvullen4</bpmn:incoming>
       <bpmn:incoming>Flow_Akkoord4Rejected_Aanvullen4</bpmn:incoming>
       <bpmn:outgoing>Flow_Aanvullen4_OverlegVO</bpmn:outgoing>
@@ -84,7 +84,7 @@
       <bpmn:incoming>Flow_InitierenPSU_Relatics</bpmn:incoming>
       <bpmn:outgoing>Flow_Relatics_Risicodossier</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:userTask id="Task_UitvoerenIntakeoverleg" name="Uitvoeren intake-overleg" camunda:formRef="rip-uitvoer-intake" camunda:formRefBinding="latest" camunda:candidateGroups="rip-ao,rip-aandrager,rip-projectleider">
+    <bpmn:userTask id="Task_UitvoerenIntakeoverleg" name="Uitvoeren intake-overleg" camunda:formRef="rip-uitvoer-intake" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-ao,rip-aandrager,rip-projectleider">
       <bpmn:incoming>Flow_Organiseren_Uitvoeren</bpmn:incoming>
       <bpmn:outgoing>Flow_Uitvoeren_Gateway</bpmn:outgoing>
     </bpmn:userTask>
@@ -93,7 +93,7 @@
       <bpmn:outgoing>Flow_IntakeJa_Aanvullen2</bpmn:outgoing>
       <bpmn:outgoing>Flow_IntakeNee_Verbeteren</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:userTask id="Task_AccorderenProjectplan2" name="Accorderen Projectplan&#10;2. Intake-verslag" camunda:formRef="rip-approval" camunda:formRefBinding="latest" camunda:candidateGroups="rip-aandrager,rip-projectleider">
+    <bpmn:userTask id="Task_AccorderenProjectplan2" name="Accorderen Projectplan&#10;2. Intake-verslag" camunda:formRef="rip-approval" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-aandrager,rip-projectleider">
       <bpmn:incoming>Flow_Aanvullen2_Accorderen2</bpmn:incoming>
       <bpmn:incoming>Flow_Verbeteren_Accorderen2</bpmn:incoming>
       <bpmn:outgoing>Flow_Accorderen2_Gateway</bpmn:outgoing>
@@ -103,15 +103,15 @@
       <bpmn:outgoing>Flow_Akkoord2Approved_InitierenPSU</bpmn:outgoing>
       <bpmn:outgoing>Flow_Akkoord2Rejected_Aanvullen2</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:userTask id="Task_UitvoerenPSU" name="Uitvoeren PSU en aanvullen&#10;Projectplan 3. PSU-verslag" camunda:formRef="rip-psu-execution" camunda:formRefBinding="latest" camunda:candidateGroups="rip-deelnemers-psu" ronl:documentRef="rip-psu-report">
+    <bpmn:userTask id="Task_UitvoerenPSU" name="Uitvoeren PSU en aanvullen&#10;Projectplan 3. PSU-verslag" camunda:formRef="rip-psu-execution" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-deelnemers-psu" ronl:documentRef="rip-psu-report">
       <bpmn:incoming>Flow_Risicodossier_UitvoerenPSU</bpmn:incoming>
       <bpmn:outgoing>Flow_UitvoerenPSU_Planning</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_HoudenOverlegVO" name="Houden overleg&#10;uitgangspunten VO-fase" camunda:formRef="rip-overleg-vo" camunda:formRefBinding="latest" camunda:candidateGroups="rip-team">
+    <bpmn:userTask id="Task_HoudenOverlegVO" name="Houden overleg&#10;uitgangspunten VO-fase" camunda:formRef="rip-overleg-vo" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-team">
       <bpmn:incoming>Flow_Aanvullen4_OverlegVO</bpmn:incoming>
       <bpmn:outgoing>Flow_OverlegVO_Accorderen4</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_AccorderenProjectplan4" name="Accorderen Projectplan&#10;4. Uitgangspunten VO-fase" camunda:formRef="rip-approval" camunda:formRefBinding="latest" camunda:candidateGroups="rip-projectleider,rip-aandrager,rip-ao" ronl:signatureRef="rip-pdp">
+    <bpmn:userTask id="Task_AccorderenProjectplan4" name="Accorderen Projectplan&#10;4. Uitgangspunten VO-fase" camunda:formRef="rip-approval" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider,rip-aandrager,rip-ao" ronl:signatureRef="rip-pdp">
       <bpmn:incoming>Flow_OverlegVO_Accorderen4</bpmn:incoming>
       <bpmn:outgoing>Flow_Accorderen4_Gateway</bpmn:outgoing>
     </bpmn:userTask>

--- a/e2e-fixtures/flevoland/RipR22Process.bpmn
+++ b/e2e-fixtures/flevoland/RipR22Process.bpmn
@@ -42,23 +42,23 @@
       <bpmn:outgoing>Flow_Gateway_UitgangspuntenSplit_Task_InventariserenKabelsLeidingen</bpmn:outgoing>
       <bpmn:outgoing>Flow_Gateway_UitgangspuntenSplit_Task_AanvragenRaamvergunning</bpmn:outgoing>
     </bpmn:parallelGateway>
-    <bpmn:userTask id="Task_UitvoerenConditionerendeOnderzoeken" name="Uitvoeren conditionerende onderzoeken" camunda:formRef="rip-conditionerende-onderzoeken" camunda:formRefBinding="latest" camunda:candidateGroups="rip-projectleider">
+    <bpmn:userTask id="Task_UitvoerenConditionerendeOnderzoeken" name="Uitvoeren conditionerende onderzoeken" camunda:formRef="rip-conditionerende-onderzoeken" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
       <bpmn:incoming>Flow_Gateway_UitgangspuntenSplit_Task_UitvoerenConditionerendeOnderzoeken</bpmn:incoming>
       <bpmn:outgoing>Flow_Task_UitvoerenConditionerendeOnderzoeken_Gateway_UitgangspuntenJoin</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_OpstellenConceptVO" name="Opstellen concept VO" camunda:formRef="rip-concept-vo" camunda:formRefBinding="latest" camunda:candidateGroups="rip-ontwerper" ronl:documentRef="rip-ontwerptoelichting">
+    <bpmn:userTask id="Task_OpstellenConceptVO" name="Opstellen concept VO" camunda:formRef="rip-concept-vo" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-ontwerper" ronl:documentRef="rip-ontwerptoelichting">
       <bpmn:incoming>Flow_Gateway_UitgangspuntenSplit_Task_OpstellenConceptVO</bpmn:incoming>
       <bpmn:outgoing>Flow_Task_OpstellenConceptVO_Gateway_UitgangspuntenJoin</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_VerzamelenKlanteisen" name="Verzamelen klanteisen" camunda:formRef="rip-verzamelen-klanteisen" camunda:formRefBinding="latest" camunda:candidateGroups="rip-omgevingsmanager" ronl:documentRef="rip-kes">
+    <bpmn:userTask id="Task_VerzamelenKlanteisen" name="Verzamelen klanteisen" camunda:formRef="rip-verzamelen-klanteisen" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-omgevingsmanager" ronl:documentRef="rip-kes">
       <bpmn:incoming>Flow_Gateway_UitgangspuntenSplit_Task_VerzamelenKlanteisen</bpmn:incoming>
       <bpmn:outgoing>Flow_Task_VerzamelenKlanteisen_Gateway_UitgangspuntenJoin</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_InventariserenKabelsLeidingen" name="Inventariseren&#10;kabels en leidingen" camunda:formRef="rip-inventariseren-kabels-leidingen" camunda:formRefBinding="latest" camunda:candidateGroups="rip-omgevingsmanager">
+    <bpmn:userTask id="Task_InventariserenKabelsLeidingen" name="Inventariseren&#10;kabels en leidingen" camunda:formRef="rip-inventariseren-kabels-leidingen" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-omgevingsmanager">
       <bpmn:incoming>Flow_Gateway_UitgangspuntenSplit_Task_InventariserenKabelsLeidingen</bpmn:incoming>
       <bpmn:outgoing>Flow_Task_InventariserenKabelsLeidingen_Gateway_UitgangspuntenJoin</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_AanvragenRaamvergunning" name="Aanvragen raamvergunning" camunda:formRef="rip-aanvragen-raamvergunning" camunda:formRefBinding="latest" camunda:candidateGroups="rip-omgevingsmanager">
+    <bpmn:userTask id="Task_AanvragenRaamvergunning" name="Aanvragen raamvergunning" camunda:formRef="rip-aanvragen-raamvergunning" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-omgevingsmanager">
       <bpmn:incoming>Flow_Gateway_UitgangspuntenSplit_Task_AanvragenRaamvergunning</bpmn:incoming>
       <bpmn:outgoing>Flow_Task_AanvragenRaamvergunning_Gateway_UitgangspuntenJoin</bpmn:outgoing>
     </bpmn:userTask>
@@ -75,11 +75,11 @@
       <bpmn:outgoing>Flow_Gateway_BesprekenSplit_Task_BesprekenConceptVO</bpmn:outgoing>
       <bpmn:outgoing>Flow_Gateway_BesprekenSplit_Task_BesprekenKlanteisenKL</bpmn:outgoing>
     </bpmn:parallelGateway>
-    <bpmn:userTask id="Task_BesprekenConceptVO" name="Bespreken concept VO" camunda:formRef="rip-bespreken-concept-vo" camunda:formRefBinding="latest" camunda:candidateGroups="rip-team,rip-aandrager,rip-adviseur" ronl:documentRef="rip-bevindingenformulier">
+    <bpmn:userTask id="Task_BesprekenConceptVO" name="Bespreken concept VO" camunda:formRef="rip-bespreken-concept-vo" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-team,rip-aandrager,rip-adviseur" ronl:documentRef="rip-bevindingenformulier">
       <bpmn:incoming>Flow_Gateway_BesprekenSplit_Task_BesprekenConceptVO</bpmn:incoming>
       <bpmn:outgoing>Flow_Task_BesprekenConceptVO_Gateway_BesprekenJoin</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_BesprekenKlanteisenKL" name="Bespreken klanteisen en&#10;kabels en leidingen" camunda:formRef="rip-bespreken-klanteisen-kl" camunda:formRefBinding="latest" camunda:candidateGroups="rip-team,rip-aandrager,rip-adviseur">
+    <bpmn:userTask id="Task_BesprekenKlanteisenKL" name="Bespreken klanteisen en&#10;kabels en leidingen" camunda:formRef="rip-bespreken-klanteisen-kl" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-team,rip-aandrager,rip-adviseur">
       <bpmn:incoming>Flow_Gateway_BesprekenSplit_Task_BesprekenKlanteisenKL</bpmn:incoming>
       <bpmn:outgoing>Flow_Task_BesprekenKlanteisenKL_Gateway_BesprekenJoin</bpmn:outgoing>
     </bpmn:userTask>
@@ -93,11 +93,11 @@
       <bpmn:outgoing>Flow_Gateway_AfrondingSplit_Task_TerugkoppelenKlanteisen</bpmn:outgoing>
       <bpmn:outgoing>Flow_Gateway_AfrondingSplit_Task_OpstellenDefinitiefVO</bpmn:outgoing>
     </bpmn:parallelGateway>
-    <bpmn:userTask id="Task_TerugkoppelenKlanteisen" name="Terugkoppelen klanteisen" camunda:formRef="rip-terugkoppelen-klanteisen" camunda:formRefBinding="latest" camunda:candidateGroups="rip-omgevingsmanager">
+    <bpmn:userTask id="Task_TerugkoppelenKlanteisen" name="Terugkoppelen klanteisen" camunda:formRef="rip-terugkoppelen-klanteisen" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-omgevingsmanager">
       <bpmn:incoming>Flow_Gateway_AfrondingSplit_Task_TerugkoppelenKlanteisen</bpmn:incoming>
       <bpmn:outgoing>Flow_Task_TerugkoppelenKlanteisen_EndEvent_KlanteisenTeruggekoppeld</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_OpstellenDefinitiefVO" name="Opstellen definitief VO" camunda:formRef="rip-definitief-vo" camunda:formRefBinding="latest" camunda:candidateGroups="rip-ontwerper" ronl:documentRef="rip-hoeveelheidsbepaling">
+    <bpmn:userTask id="Task_OpstellenDefinitiefVO" name="Opstellen definitief VO" camunda:formRef="rip-definitief-vo" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-ontwerper" ronl:documentRef="rip-hoeveelheidsbepaling">
       <bpmn:incoming>Flow_Gateway_AfrondingSplit_Task_OpstellenDefinitiefVO</bpmn:incoming>
       <bpmn:outgoing>Flow_Task_OpstellenDefinitiefVO_EndEvent_VOGereed</bpmn:outgoing>
     </bpmn:userTask>

--- a/e2e-fixtures/flevoland/TreeFellingPermitSubProcessE2E.bpmn
+++ b/e2e-fixtures/flevoland/TreeFellingPermitSubProcessE2E.bpmn
@@ -68,7 +68,7 @@
       Caseworker must claim via POST /v1/task/:id/claim before completing.
       candidateGroups routes this task to the caseworker group in Operaton.
     -->
-      <bpmn:userTask id="Sub_CaseReview" name="Case review: tree felling permit decision" camunda:formRef="tree-felling-review" camunda:formRefBinding="latest" camunda:candidateGroups="caseworker">      <bpmn:incoming>Flow_Sub_Replacement_Review</bpmn:incoming>
+      <bpmn:userTask id="Sub_CaseReview" name="Case review: tree felling permit decision" camunda:formRef="tree-felling-review" camunda:formRefBinding="deployment" camunda:candidateGroups="caseworker">      <bpmn:incoming>Flow_Sub_Replacement_Review</bpmn:incoming>
       <bpmn:outgoing>Flow_Sub_Review_Resolve</bpmn:outgoing>
     </bpmn:userTask>
 

--- a/e2e-fixtures/toeslagen/AwbZorgtoeslagProcess.bpmn
+++ b/e2e-fixtures/toeslagen/AwbZorgtoeslagProcess.bpmn
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:ronl="http://ronl.nl/schema/1.0" id="Definitions_AWB_Zorgtoeslag" targetNamespace="http://example.com/zorgtoeslag/awb" exporter="Camunda Modeler" exporterVersion="5.43.1">
   <bpmn:process id="AwbZorgtoeslagProcess" name="AWB Zorgtoeslag — Provisional Entitlement Process" isExecutable="true" camunda:historyTimeToLive="365">
-    <bpmn:startEvent id="StartEvent_AWB" name="Application submitted" camunda:formRef="zorgtoeslag-provisional-start" camunda:formRefBinding="latest">
+    <bpmn:startEvent id="StartEvent_AWB" name="Application submitted" camunda:formRef="zorgtoeslag-provisional-start" camunda:formRefBinding="deployment">
       <bpmn:outgoing>Flow_Start_Phase1</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:scriptTask id="Task_Phase1_Identity" name="Phase 1: Determine legal relationship (identification)" scriptFormat="javascript">
@@ -82,7 +82,7 @@
       <bpmn:incoming>Flow_Recheck_Process</bpmn:incoming>
       <bpmn:outgoing>Flow_Phase45_Phase6</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:userTask id="Task_Phase6_Notify" name="Phase 6: Notify applicant of decision (Awb 3:6)" camunda:formRef="zorgtoeslag-notify-applicant" camunda:formRefBinding="latest" camunda:candidateGroups="caseworker" ronl:documentRef="example_zorgtoeslag_provisional_beschikking">
+    <bpmn:userTask id="Task_Phase6_Notify" name="Phase 6: Notify applicant of decision (Awb 3:6)" camunda:formRef="zorgtoeslag-notify-applicant" camunda:formRefBinding="deployment" camunda:candidateGroups="caseworker" ronl:documentRef="example_zorgtoeslag_provisional_beschikking">
       <bpmn:incoming>Flow_Phase45_Phase6</bpmn:incoming>
       <bpmn:incoming>Flow_Refuse_Notify</bpmn:incoming>
       <bpmn:outgoing>Flow_Phase6_PaymentGateway</bpmn:outgoing>

--- a/e2e-fixtures/toeslagen/ZorgtoeslagProvisionalSubProcessE2E.bpmn
+++ b/e2e-fixtures/toeslagen/ZorgtoeslagProvisionalSubProcessE2E.bpmn
@@ -53,7 +53,7 @@
         execution.setVariable("amountYear", amountYear != null ? Number(amountYear) : 0);
       </bpmn:script>
     </bpmn:scriptTask>
-    <bpmn:userTask id="Sub_CaseReview" name="Case review: provisional entitlement decision" camunda:formRef="zorgtoeslag-provisional-review" camunda:formRefBinding="latest" camunda:candidateGroups="caseworker">
+    <bpmn:userTask id="Sub_CaseReview" name="Case review: provisional entitlement decision" camunda:formRef="zorgtoeslag-provisional-review" camunda:formRefBinding="deployment" camunda:candidateGroups="caseworker">
       <bpmn:incoming>Flow_Sub_Extract_Review</bpmn:incoming>
       <bpmn:outgoing>Flow_Sub_Review_Resolve</bpmn:outgoing>
     </bpmn:userTask>

--- a/examples/organizations/flevoland/HR-capacity/en/ManagementCapacityClaimProcess.bpmn
+++ b/examples/organizations/flevoland/HR-capacity/en/ManagementCapacityClaimProcess.bpmn
@@ -4,7 +4,7 @@
     <bpmn:startEvent id="StartEvent_CapacityClaim" name="Start capacity claim">
       <bpmn:outgoing>Flow_Start_Intake</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:userTask id="Task_ConsultAndClassify" name="Consult and classify" camunda:formRef="capacity-claim-intake" camunda:formRefBinding="latest" camunda:candidateGroups="manager">
+    <bpmn:userTask id="Task_ConsultAndClassify" name="Consult and classify" camunda:formRef="capacity-claim-intake" camunda:formRefBinding="deployment" camunda:candidateGroups="manager">
       <bpmn:incoming>Flow_Start_Intake</bpmn:incoming>
       <bpmn:outgoing>Flow_Intake_RequestTypeGateway</bpmn:outgoing>
     </bpmn:userTask>
@@ -14,11 +14,11 @@
       <bpmn:outgoing>Flow_Gateway_Staffing</bpmn:outgoing>
       <bpmn:outgoing>Flow_Gateway_Hiring</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:userTask id="Task_PrepareStaffingClaim" name="Prepare staffing claim" camunda:formRef="capacity-claim-staffing" camunda:formRefBinding="latest" camunda:candidateGroups="manager">
+    <bpmn:userTask id="Task_PrepareStaffingClaim" name="Prepare staffing claim" camunda:formRef="capacity-claim-staffing" camunda:formRefBinding="deployment" camunda:candidateGroups="manager">
       <bpmn:incoming>Flow_Gateway_Staffing</bpmn:incoming>
       <bpmn:outgoing>Flow_Staffing_MergePrepare</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_PrepareHiringClaim" name="Prepare hiring claim" camunda:formRef="capacity-claim-hiring" camunda:formRefBinding="latest" camunda:candidateGroups="manager">
+    <bpmn:userTask id="Task_PrepareHiringClaim" name="Prepare hiring claim" camunda:formRef="capacity-claim-hiring" camunda:formRefBinding="deployment" camunda:candidateGroups="manager">
       <bpmn:incoming>Flow_Gateway_Hiring</bpmn:incoming>
       <bpmn:outgoing>Flow_Hiring_MergePrepare</bpmn:outgoing>
     </bpmn:userTask>
@@ -40,11 +40,11 @@
         execution.setVariable("advisoryGroup",   routingResult.get("advisoryGroup"));
       </bpmn:script>
     </bpmn:scriptTask>
-    <bpmn:userTask id="Task_SubmitToBoardAgenda" name="Submit to Board agenda" camunda:formRef="capacity-claim-submit" camunda:formRefBinding="latest" camunda:candidateGroups="board-secretary">
+    <bpmn:userTask id="Task_SubmitToBoardAgenda" name="Submit to Board agenda" camunda:formRef="capacity-claim-submit" camunda:formRefBinding="deployment" camunda:candidateGroups="board-secretary">
       <bpmn:incoming>Flow_MapOutputs_Submit</bpmn:incoming>
       <bpmn:outgoing>Flow_Submit_BoardDecision</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_BoardDecision" name="Board decision" camunda:formRef="capacity-claim-board-decision" camunda:formRefBinding="latest" camunda:candidateGroups="board-director" ronl:documentRef="board-decision-notification">
+    <bpmn:userTask id="Task_BoardDecision" name="Board decision" camunda:formRef="capacity-claim-board-decision" camunda:formRefBinding="deployment" camunda:candidateGroups="board-director" ronl:documentRef="board-decision-notification">
       <bpmn:incoming>Flow_Submit_BoardDecision</bpmn:incoming>
       <bpmn:outgoing>Flow_BoardDecision_Gateway</bpmn:outgoing>
     </bpmn:userTask>
@@ -53,7 +53,7 @@
       <bpmn:outgoing>Flow_Gateway_Approved</bpmn:outgoing>
       <bpmn:outgoing>Flow_Gateway_Rejected</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:userTask id="Task_ReconsiderationMeeting" name="Reconsideration meeting" camunda:formRef="capacity-claim-reconsideration" camunda:formRefBinding="latest" camunda:candidateGroups="manager,hr-business-partner,personnel-controller">
+    <bpmn:userTask id="Task_ReconsiderationMeeting" name="Reconsideration meeting" camunda:formRef="capacity-claim-reconsideration" camunda:formRefBinding="deployment" camunda:candidateGroups="manager,hr-business-partner,personnel-controller">
       <bpmn:incoming>Flow_Gateway_Rejected</bpmn:incoming>
       <bpmn:outgoing>Flow_Reconsider_OutcomeGateway</bpmn:outgoing>
     </bpmn:userTask>
@@ -70,11 +70,11 @@
       <bpmn:outgoing>Flow_Route_Recruitment</bpmn:outgoing>
       <bpmn:outgoing>Flow_Route_Procurement</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:userTask id="Task_HandoverToRecruitment" name="Handover to Recruitment (HRM)" camunda:formRef="capacity-claim-handover" camunda:formRefBinding="latest" camunda:candidateGroups="hrm-unit" ronl:documentRef="capacity-claim-handover">
+    <bpmn:userTask id="Task_HandoverToRecruitment" name="Handover to Recruitment (HRM)" camunda:formRef="capacity-claim-handover" camunda:formRefBinding="deployment" camunda:candidateGroups="hrm-unit" ronl:documentRef="capacity-claim-handover">
       <bpmn:incoming>Flow_Route_Recruitment</bpmn:incoming>
       <bpmn:outgoing>Flow_Recruitment_MergeHandover</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_HandoverToProcurement" name="Handover to Procurement" camunda:formRef="capacity-claim-handover" camunda:formRefBinding="latest" camunda:candidateGroups="procurement-unit,planning-control-officer" ronl:documentRef="capacity-claim-handover">
+    <bpmn:userTask id="Task_HandoverToProcurement" name="Handover to Procurement" camunda:formRef="capacity-claim-handover" camunda:formRefBinding="deployment" camunda:candidateGroups="procurement-unit,planning-control-officer" ronl:documentRef="capacity-claim-handover">
       <bpmn:incoming>Flow_Route_Procurement</bpmn:incoming>
       <bpmn:outgoing>Flow_Procurement_MergeHandover</bpmn:outgoing>
     </bpmn:userTask>
@@ -83,7 +83,7 @@
       <bpmn:incoming>Flow_Procurement_MergeHandover</bpmn:incoming>
       <bpmn:outgoing>Flow_MergeHandover_Reservation</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:userTask id="Task_RegisterReservation" name="Register financial reservation" camunda:formRef="capacity-claim-register-reservation" camunda:formRefBinding="latest" camunda:candidateGroups="financial-controller">
+    <bpmn:userTask id="Task_RegisterReservation" name="Register financial reservation" camunda:formRef="capacity-claim-register-reservation" camunda:formRefBinding="deployment" camunda:candidateGroups="financial-controller">
       <bpmn:incoming>Flow_MergeHandover_Reservation</bpmn:incoming>
       <bpmn:outgoing>Flow_Reservation_End</bpmn:outgoing>
     </bpmn:userTask>

--- a/examples/organizations/flevoland/HR-capacity/nl/ManagementCapacityClaimProcess.nl.bpmn
+++ b/examples/organizations/flevoland/HR-capacity/nl/ManagementCapacityClaimProcess.nl.bpmn
@@ -4,7 +4,7 @@
     <bpmn:startEvent id="StartEvent_CapacityClaim" name="Start capaciteitsclaim">
       <bpmn:outgoing>Flow_Start_Intake</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:userTask id="Task_ConsultAndClassify" name="Overleggen en classificeren" camunda:formRef="capacity-claim-intake-nl" camunda:formRefBinding="latest" camunda:candidateGroups="manager">
+    <bpmn:userTask id="Task_ConsultAndClassify" name="Overleggen en classificeren" camunda:formRef="capacity-claim-intake-nl" camunda:formRefBinding="deployment" camunda:candidateGroups="manager">
       <bpmn:incoming>Flow_Start_Intake</bpmn:incoming>
       <bpmn:outgoing>Flow_Intake_RequestTypeGateway</bpmn:outgoing>
     </bpmn:userTask>
@@ -14,11 +14,11 @@
       <bpmn:outgoing>Flow_Gateway_Staffing</bpmn:outgoing>
       <bpmn:outgoing>Flow_Gateway_Hiring</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:userTask id="Task_PrepareStaffingClaim" name="Formatieclaim opstellen" camunda:formRef="capacity-claim-staffing-nl" camunda:formRefBinding="latest" camunda:candidateGroups="manager">
+    <bpmn:userTask id="Task_PrepareStaffingClaim" name="Formatieclaim opstellen" camunda:formRef="capacity-claim-staffing-nl" camunda:formRefBinding="deployment" camunda:candidateGroups="manager">
       <bpmn:incoming>Flow_Gateway_Staffing</bpmn:incoming>
       <bpmn:outgoing>Flow_Staffing_MergePrepare</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_PrepareHiringClaim" name="Inhuurclaim opstellen" camunda:formRef="capacity-claim-hiring-nl" camunda:formRefBinding="latest" camunda:candidateGroups="manager">
+    <bpmn:userTask id="Task_PrepareHiringClaim" name="Inhuurclaim opstellen" camunda:formRef="capacity-claim-hiring-nl" camunda:formRefBinding="deployment" camunda:candidateGroups="manager">
       <bpmn:incoming>Flow_Gateway_Hiring</bpmn:incoming>
       <bpmn:outgoing>Flow_Hiring_MergePrepare</bpmn:outgoing>
     </bpmn:userTask>
@@ -40,11 +40,11 @@
         execution.setVariable("advisoryGroup",   routingResult.get("advisoryGroup"));
       </bpmn:script>
     </bpmn:scriptTask>
-    <bpmn:userTask id="Task_SubmitToBoardAgenda" name="Agenderen Directievergadering" camunda:formRef="capacity-claim-submit-nl" camunda:formRefBinding="latest" camunda:candidateGroups="board-secretary">
+    <bpmn:userTask id="Task_SubmitToBoardAgenda" name="Agenderen Directievergadering" camunda:formRef="capacity-claim-submit-nl" camunda:formRefBinding="deployment" camunda:candidateGroups="board-secretary">
       <bpmn:incoming>Flow_MapOutputs_Submit</bpmn:incoming>
       <bpmn:outgoing>Flow_Submit_BoardDecision</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_BoardDecision" name="Directiebesluit" camunda:formRef="capacity-claim-board-decision-nl" camunda:formRefBinding="latest" camunda:candidateGroups="board-director" ronl:documentRef="board-decision-notification-nl">
+    <bpmn:userTask id="Task_BoardDecision" name="Directiebesluit" camunda:formRef="capacity-claim-board-decision-nl" camunda:formRefBinding="deployment" camunda:candidateGroups="board-director" ronl:documentRef="board-decision-notification-nl">
       <bpmn:incoming>Flow_Submit_BoardDecision</bpmn:incoming>
       <bpmn:outgoing>Flow_BoardDecision_Gateway</bpmn:outgoing>
     </bpmn:userTask>
@@ -53,7 +53,7 @@
       <bpmn:outgoing>Flow_Gateway_Approved</bpmn:outgoing>
       <bpmn:outgoing>Flow_Gateway_Rejected</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:userTask id="Task_ReconsiderationMeeting" name="Heroverwegingsoverleg" camunda:formRef="capacity-claim-reconsideration-nl" camunda:formRefBinding="latest" camunda:candidateGroups="manager,hr-business-partner,personnel-controller">
+    <bpmn:userTask id="Task_ReconsiderationMeeting" name="Heroverwegingsoverleg" camunda:formRef="capacity-claim-reconsideration-nl" camunda:formRefBinding="deployment" camunda:candidateGroups="manager,hr-business-partner,personnel-controller">
       <bpmn:incoming>Flow_Gateway_Rejected</bpmn:incoming>
       <bpmn:outgoing>Flow_Reconsider_OutcomeGateway</bpmn:outgoing>
     </bpmn:userTask>
@@ -70,11 +70,11 @@
       <bpmn:outgoing>Flow_Route_Recruitment</bpmn:outgoing>
       <bpmn:outgoing>Flow_Route_Procurement</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:userTask id="Task_HandoverToRecruitment" name="Overdracht naar werving &amp; selectie" camunda:formRef="capacity-claim-handover-nl" camunda:formRefBinding="latest" camunda:candidateGroups="hrm-unit" ronl:documentRef="capacity-claim-handover-nl">
+    <bpmn:userTask id="Task_HandoverToRecruitment" name="Overdracht naar werving &amp; selectie" camunda:formRef="capacity-claim-handover-nl" camunda:formRefBinding="deployment" camunda:candidateGroups="hrm-unit" ronl:documentRef="capacity-claim-handover-nl">
       <bpmn:incoming>Flow_Route_Recruitment</bpmn:incoming>
       <bpmn:outgoing>Flow_Recruitment_MergeHandover</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_HandoverToProcurement" name="Overdracht naar inkoop" camunda:formRef="capacity-claim-handover-nl" camunda:formRefBinding="latest" camunda:candidateGroups="procurement-unit,planning-control-officer" ronl:documentRef="capacity-claim-handover-nl">
+    <bpmn:userTask id="Task_HandoverToProcurement" name="Overdracht naar inkoop" camunda:formRef="capacity-claim-handover-nl" camunda:formRefBinding="deployment" camunda:candidateGroups="procurement-unit,planning-control-officer" ronl:documentRef="capacity-claim-handover-nl">
       <bpmn:incoming>Flow_Route_Procurement</bpmn:incoming>
       <bpmn:outgoing>Flow_Procurement_MergeHandover</bpmn:outgoing>
     </bpmn:userTask>
@@ -83,7 +83,7 @@
       <bpmn:incoming>Flow_Procurement_MergeHandover</bpmn:incoming>
       <bpmn:outgoing>Flow_MergeHandover_Reservation</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:userTask id="Task_RegisterReservation" name="Financiële reservering registreren" camunda:formRef="capacity-claim-register-reservation-nl" camunda:formRefBinding="latest" camunda:candidateGroups="financial-controller">
+    <bpmn:userTask id="Task_RegisterReservation" name="Financiële reservering registreren" camunda:formRef="capacity-claim-register-reservation-nl" camunda:formRefBinding="deployment" camunda:candidateGroups="financial-controller">
       <bpmn:incoming>Flow_MergeHandover_Reservation</bpmn:incoming>
       <bpmn:outgoing>Flow_Reservation_End</bpmn:outgoing>
     </bpmn:userTask>

--- a/examples/organizations/flevoland/HrOnboardingProcess.bpmn
+++ b/examples/organizations/flevoland/HrOnboardingProcess.bpmn
@@ -4,7 +4,7 @@
     <bpmn:startEvent id="StartEvent_Onboarding" name="Start onboarding">
       <bpmn:outgoing>Flow_Start_CollectData</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:userTask id="Task_CollectEmployeeData" name="Collect employee data" camunda:formRef="hr-onboarding-start" camunda:formRefBinding="latest" camunda:candidateGroups="hr-medewerker">
+    <bpmn:userTask id="Task_CollectEmployeeData" name="Collect employee data" camunda:formRef="hr-onboarding-start" camunda:formRefBinding="deployment" camunda:candidateGroups="hr-medewerker">
       <bpmn:incoming>Flow_Start_CollectData</bpmn:incoming>
       <bpmn:incoming>Flow_Revision_BackToCollect</bpmn:incoming>
       <bpmn:outgoing>Flow_CollectData_DetermineRoles</bpmn:outgoing>
@@ -22,7 +22,7 @@
         execution.setVariable("accessLevel",     roleResult.get("accessLevel"));
       </bpmn:script>
     </bpmn:scriptTask>
-    <bpmn:userTask id="Task_ReviewRoleAssignment" name="Review role assignment" camunda:formRef="hr-role-review" camunda:formRefBinding="latest" camunda:candidateGroups="hr-medewerker">
+    <bpmn:userTask id="Task_ReviewRoleAssignment" name="Review role assignment" camunda:formRef="hr-role-review" camunda:formRefBinding="deployment" camunda:candidateGroups="hr-medewerker">
       <bpmn:incoming>Flow_MapOutputs_ReviewRoles</bpmn:incoming>
       <bpmn:outgoing>Flow_Review_Gateway</bpmn:outgoing>
     </bpmn:userTask>
@@ -31,7 +31,7 @@
       <bpmn:outgoing>Flow_Gateway_Notify</bpmn:outgoing>
       <bpmn:outgoing>Flow_Gateway_Revision</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:userTask id="Task_NotifyEmployee" name="Notify employee" camunda:formRef="hr-notify-employee" camunda:formRefBinding="latest" camunda:candidateGroups="hr-medewerker">
+    <bpmn:userTask id="Task_NotifyEmployee" name="Notify employee" camunda:formRef="hr-notify-employee" camunda:formRefBinding="deployment" camunda:candidateGroups="hr-medewerker">
       <bpmn:incoming>Flow_Gateway_Notify</bpmn:incoming>
       <bpmn:outgoing>Flow_Notify_End</bpmn:outgoing>
     </bpmn:userTask>

--- a/examples/organizations/flevoland/TreeFellingPermitSubProcess.bpmn
+++ b/examples/organizations/flevoland/TreeFellingPermitSubProcess.bpmn
@@ -67,7 +67,7 @@
       Caseworker must claim via POST /v1/task/:id/claim before completing.
       candidateGroups routes this task to the caseworker group in Operaton.
     -->
-      <bpmn:userTask id="Sub_CaseReview" name="Case review: tree felling permit decision" camunda:formRef="tree-felling-review" camunda:formRefBinding="latest" camunda:candidateGroups="caseworker">      <bpmn:incoming>Flow_Sub_Replacement_Review</bpmn:incoming>
+      <bpmn:userTask id="Sub_CaseReview" name="Case review: tree felling permit decision" camunda:formRef="tree-felling-review" camunda:formRefBinding="deployment" camunda:candidateGroups="caseworker">      <bpmn:incoming>Flow_Sub_Replacement_Review</bpmn:incoming>
       <bpmn:outgoing>Flow_Sub_Review_Resolve</bpmn:outgoing>
     </bpmn:userTask>
 

--- a/examples/organizations/flevoland/rip-phase-21/RipR21Process.bpmn
+++ b/examples/organizations/flevoland/rip-phase-21/RipR21Process.bpmn
@@ -46,36 +46,36 @@
     <bpmn:startEvent id="StartEvent_RipPhase1" name="Start RIP fase 1">
       <bpmn:outgoing>Flow_Start_Aanlevren</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:userTask id="Task_AanlevrenProjectplan" name="Aanleveren Projectplan&#10;1. Intake-formulier" camunda:formRef="rip-intake" camunda:formRefBinding="latest" camunda:candidateGroups="rip-aandrager">
+    <bpmn:userTask id="Task_AanlevrenProjectplan" name="Aanleveren Projectplan&#10;1. Intake-formulier" camunda:formRef="rip-intake" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-aandrager">
       <bpmn:incoming>Flow_Start_Aanlevren</bpmn:incoming>
       <bpmn:outgoing>Flow_Aanlevren_Organiseren</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_VerberenKwaliteit" name="Verbeteren kwaliteit&#10;1. Intake-formulier" camunda:formRef="rip-kwaliteit-verbetering" camunda:formRefBinding="latest" camunda:candidateGroups="rip-aandrager">
+    <bpmn:userTask id="Task_VerberenKwaliteit" name="Verbeteren kwaliteit&#10;1. Intake-formulier" camunda:formRef="rip-kwaliteit-verbetering" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-aandrager">
       <bpmn:incoming>Flow_IntakeNee_Verbeteren</bpmn:incoming>
       <bpmn:outgoing>Flow_Verbeteren_Accorderen2</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_OrganiserenIntakeoverleg" name="Organiseren intake-overleg" camunda:formRef="rip-intake-meeting" camunda:formRefBinding="latest" camunda:candidateGroups="rip-manager-pb">
+    <bpmn:userTask id="Task_OrganiserenIntakeoverleg" name="Organiseren intake-overleg" camunda:formRef="rip-intake-meeting" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-manager-pb">
       <bpmn:incoming>Flow_Aanlevren_Organiseren</bpmn:incoming>
       <bpmn:outgoing>Flow_Organiseren_Uitvoeren</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_OpstellenRisicodossier" name="Opstellen risicossier&#10;en versturen aan PL" camunda:formRef="rip-risk-file" camunda:formRefBinding="latest" camunda:candidateGroups="rip-manager-pb">
+    <bpmn:userTask id="Task_OpstellenRisicodossier" name="Opstellen risicossier&#10;en versturen aan PL" camunda:formRef="rip-risk-file" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-manager-pb">
       <bpmn:incoming>Flow_Relatics_Risicodossier</bpmn:incoming>
       <bpmn:outgoing>Flow_Risicodossier_UitvoerenPSU</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_OpstellenPlanning" name="Opstellen planning en&#10;informeren PL en ondersteuner" camunda:formRef="rip-planning" camunda:formRefBinding="latest" camunda:candidateGroups="rip-manager-pb">
+    <bpmn:userTask id="Task_OpstellenPlanning" name="Opstellen planning en&#10;informeren PL en ondersteuner" camunda:formRef="rip-planning" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-manager-pb">
       <bpmn:incoming>Flow_UitvoerenPSU_Planning</bpmn:incoming>
       <bpmn:outgoing>Flow_Planning_Aanvullen4</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_AanvullenProjectplan2" name="Aanvullen Projectplan&#10;2. Intake-verslag" camunda:formRef="rip-intake-report" camunda:formRefBinding="latest" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-intake-report">
+    <bpmn:userTask id="Task_AanvullenProjectplan2" name="Aanvullen Projectplan&#10;2. Intake-verslag" camunda:formRef="rip-intake-report" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-intake-report">
       <bpmn:incoming>Flow_IntakeJa_Aanvullen2</bpmn:incoming>
       <bpmn:incoming>Flow_Akkoord2Rejected_Aanvullen2</bpmn:incoming>
       <bpmn:outgoing>Flow_Aanvullen2_Accorderen2</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_InitierenPSU" name="Initieren / organiseren PSU" camunda:formRef="rip-psu-organize" camunda:formRefBinding="latest" camunda:candidateGroups="rip-projectleider">
+    <bpmn:userTask id="Task_InitierenPSU" name="Initieren / organiseren PSU" camunda:formRef="rip-psu-organize" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
       <bpmn:incoming>Flow_Akkoord2Approved_InitierenPSU</bpmn:incoming>
       <bpmn:outgoing>Flow_InitierenPSU_Relatics</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_AanvullenProjectplan4" name="Aanvullen Projectplan&#10;4. Uitgangspunten VO-fase" camunda:formRef="rip-pdp-aanvullen" camunda:formRefBinding="latest" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-pdp">
+    <bpmn:userTask id="Task_AanvullenProjectplan4" name="Aanvullen Projectplan&#10;4. Uitgangspunten VO-fase" camunda:formRef="rip-pdp-aanvullen" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-pdp">
       <bpmn:incoming>Flow_Planning_Aanvullen4</bpmn:incoming>
       <bpmn:incoming>Flow_Akkoord4Rejected_Aanvullen4</bpmn:incoming>
       <bpmn:outgoing>Flow_Aanvullen4_OverlegVO</bpmn:outgoing>
@@ -84,7 +84,7 @@
       <bpmn:incoming>Flow_InitierenPSU_Relatics</bpmn:incoming>
       <bpmn:outgoing>Flow_Relatics_Risicodossier</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:userTask id="Task_UitvoerenIntakeoverleg" name="Uitvoeren intake-overleg" camunda:formRef="rip-uitvoer-intake" camunda:formRefBinding="latest" camunda:candidateGroups="rip-ao,rip-aandrager,rip-projectleider">
+    <bpmn:userTask id="Task_UitvoerenIntakeoverleg" name="Uitvoeren intake-overleg" camunda:formRef="rip-uitvoer-intake" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-ao,rip-aandrager,rip-projectleider">
       <bpmn:incoming>Flow_Organiseren_Uitvoeren</bpmn:incoming>
       <bpmn:outgoing>Flow_Uitvoeren_Gateway</bpmn:outgoing>
     </bpmn:userTask>
@@ -93,7 +93,7 @@
       <bpmn:outgoing>Flow_IntakeJa_Aanvullen2</bpmn:outgoing>
       <bpmn:outgoing>Flow_IntakeNee_Verbeteren</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:userTask id="Task_AccorderenProjectplan2" name="Accorderen Projectplan&#10;2. Intake-verslag" camunda:formRef="rip-approval" camunda:formRefBinding="latest" camunda:candidateGroups="rip-aandrager,rip-projectleider">
+    <bpmn:userTask id="Task_AccorderenProjectplan2" name="Accorderen Projectplan&#10;2. Intake-verslag" camunda:formRef="rip-approval" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-aandrager,rip-projectleider">
       <bpmn:incoming>Flow_Aanvullen2_Accorderen2</bpmn:incoming>
       <bpmn:incoming>Flow_Verbeteren_Accorderen2</bpmn:incoming>
       <bpmn:outgoing>Flow_Accorderen2_Gateway</bpmn:outgoing>
@@ -103,15 +103,15 @@
       <bpmn:outgoing>Flow_Akkoord2Approved_InitierenPSU</bpmn:outgoing>
       <bpmn:outgoing>Flow_Akkoord2Rejected_Aanvullen2</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:userTask id="Task_UitvoerenPSU" name="Uitvoeren PSU en aanvullen&#10;Projectplan 3. PSU-verslag" camunda:formRef="rip-psu-execution" camunda:formRefBinding="latest" camunda:candidateGroups="rip-deelnemers-psu" ronl:documentRef="rip-psu-report">
+    <bpmn:userTask id="Task_UitvoerenPSU" name="Uitvoeren PSU en aanvullen&#10;Projectplan 3. PSU-verslag" camunda:formRef="rip-psu-execution" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-deelnemers-psu" ronl:documentRef="rip-psu-report">
       <bpmn:incoming>Flow_Risicodossier_UitvoerenPSU</bpmn:incoming>
       <bpmn:outgoing>Flow_UitvoerenPSU_Planning</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_HoudenOverlegVO" name="Houden overleg&#10;uitgangspunten VO-fase" camunda:formRef="rip-overleg-vo" camunda:formRefBinding="latest" camunda:candidateGroups="rip-team">
+    <bpmn:userTask id="Task_HoudenOverlegVO" name="Houden overleg&#10;uitgangspunten VO-fase" camunda:formRef="rip-overleg-vo" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-team">
       <bpmn:incoming>Flow_Aanvullen4_OverlegVO</bpmn:incoming>
       <bpmn:outgoing>Flow_OverlegVO_Accorderen4</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_AccorderenProjectplan4" name="Accorderen Projectplan&#10;4. Uitgangspunten VO-fase" camunda:formRef="rip-approval" camunda:formRefBinding="latest" camunda:candidateGroups="rip-projectleider,rip-aandrager,rip-ao" ronl:signatureRef="rip-pdp">
+    <bpmn:userTask id="Task_AccorderenProjectplan4" name="Accorderen Projectplan&#10;4. Uitgangspunten VO-fase" camunda:formRef="rip-approval" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider,rip-aandrager,rip-ao" ronl:signatureRef="rip-pdp">
       <bpmn:incoming>Flow_OverlegVO_Accorderen4</bpmn:incoming>
       <bpmn:outgoing>Flow_Accorderen4_Gateway</bpmn:outgoing>
     </bpmn:userTask>

--- a/examples/organizations/flevoland/rip-phase-22/RipR22Process.bpmn
+++ b/examples/organizations/flevoland/rip-phase-22/RipR22Process.bpmn
@@ -42,23 +42,23 @@
       <bpmn:outgoing>Flow_Gateway_UitgangspuntenSplit_Task_InventariserenKabelsLeidingen</bpmn:outgoing>
       <bpmn:outgoing>Flow_Gateway_UitgangspuntenSplit_Task_AanvragenRaamvergunning</bpmn:outgoing>
     </bpmn:parallelGateway>
-    <bpmn:userTask id="Task_UitvoerenConditionerendeOnderzoeken" name="Uitvoeren conditionerende onderzoeken" camunda:formRef="rip-conditionerende-onderzoeken" camunda:formRefBinding="latest" camunda:candidateGroups="rip-projectleider">
+    <bpmn:userTask id="Task_UitvoerenConditionerendeOnderzoeken" name="Uitvoeren conditionerende onderzoeken" camunda:formRef="rip-conditionerende-onderzoeken" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
       <bpmn:incoming>Flow_Gateway_UitgangspuntenSplit_Task_UitvoerenConditionerendeOnderzoeken</bpmn:incoming>
       <bpmn:outgoing>Flow_Task_UitvoerenConditionerendeOnderzoeken_Gateway_UitgangspuntenJoin</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_OpstellenConceptVO" name="Opstellen concept VO" camunda:formRef="rip-concept-vo" camunda:formRefBinding="latest" camunda:candidateGroups="rip-ontwerper" ronl:documentRef="rip-ontwerptoelichting">
+    <bpmn:userTask id="Task_OpstellenConceptVO" name="Opstellen concept VO" camunda:formRef="rip-concept-vo" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-ontwerper" ronl:documentRef="rip-ontwerptoelichting">
       <bpmn:incoming>Flow_Gateway_UitgangspuntenSplit_Task_OpstellenConceptVO</bpmn:incoming>
       <bpmn:outgoing>Flow_Task_OpstellenConceptVO_Gateway_UitgangspuntenJoin</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_VerzamelenKlanteisen" name="Verzamelen klanteisen" camunda:formRef="rip-verzamelen-klanteisen" camunda:formRefBinding="latest" camunda:candidateGroups="rip-omgevingsmanager" ronl:documentRef="rip-kes">
+    <bpmn:userTask id="Task_VerzamelenKlanteisen" name="Verzamelen klanteisen" camunda:formRef="rip-verzamelen-klanteisen" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-omgevingsmanager" ronl:documentRef="rip-kes">
       <bpmn:incoming>Flow_Gateway_UitgangspuntenSplit_Task_VerzamelenKlanteisen</bpmn:incoming>
       <bpmn:outgoing>Flow_Task_VerzamelenKlanteisen_Gateway_UitgangspuntenJoin</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_InventariserenKabelsLeidingen" name="Inventariseren&#10;kabels en leidingen" camunda:formRef="rip-inventariseren-kabels-leidingen" camunda:formRefBinding="latest" camunda:candidateGroups="rip-omgevingsmanager">
+    <bpmn:userTask id="Task_InventariserenKabelsLeidingen" name="Inventariseren&#10;kabels en leidingen" camunda:formRef="rip-inventariseren-kabels-leidingen" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-omgevingsmanager">
       <bpmn:incoming>Flow_Gateway_UitgangspuntenSplit_Task_InventariserenKabelsLeidingen</bpmn:incoming>
       <bpmn:outgoing>Flow_Task_InventariserenKabelsLeidingen_Gateway_UitgangspuntenJoin</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_AanvragenRaamvergunning" name="Aanvragen raamvergunning" camunda:formRef="rip-aanvragen-raamvergunning" camunda:formRefBinding="latest" camunda:candidateGroups="rip-omgevingsmanager">
+    <bpmn:userTask id="Task_AanvragenRaamvergunning" name="Aanvragen raamvergunning" camunda:formRef="rip-aanvragen-raamvergunning" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-omgevingsmanager">
       <bpmn:incoming>Flow_Gateway_UitgangspuntenSplit_Task_AanvragenRaamvergunning</bpmn:incoming>
       <bpmn:outgoing>Flow_Task_AanvragenRaamvergunning_Gateway_UitgangspuntenJoin</bpmn:outgoing>
     </bpmn:userTask>
@@ -75,11 +75,11 @@
       <bpmn:outgoing>Flow_Gateway_BesprekenSplit_Task_BesprekenConceptVO</bpmn:outgoing>
       <bpmn:outgoing>Flow_Gateway_BesprekenSplit_Task_BesprekenKlanteisenKL</bpmn:outgoing>
     </bpmn:parallelGateway>
-    <bpmn:userTask id="Task_BesprekenConceptVO" name="Bespreken concept VO" camunda:formRef="rip-bespreken-concept-vo" camunda:formRefBinding="latest" camunda:candidateGroups="rip-team,rip-aandrager,rip-adviseur" ronl:documentRef="rip-bevindingenformulier">
+    <bpmn:userTask id="Task_BesprekenConceptVO" name="Bespreken concept VO" camunda:formRef="rip-bespreken-concept-vo" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-team,rip-aandrager,rip-adviseur" ronl:documentRef="rip-bevindingenformulier">
       <bpmn:incoming>Flow_Gateway_BesprekenSplit_Task_BesprekenConceptVO</bpmn:incoming>
       <bpmn:outgoing>Flow_Task_BesprekenConceptVO_Gateway_BesprekenJoin</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_BesprekenKlanteisenKL" name="Bespreken klanteisen en&#10;kabels en leidingen" camunda:formRef="rip-bespreken-klanteisen-kl" camunda:formRefBinding="latest" camunda:candidateGroups="rip-team,rip-aandrager,rip-adviseur">
+    <bpmn:userTask id="Task_BesprekenKlanteisenKL" name="Bespreken klanteisen en&#10;kabels en leidingen" camunda:formRef="rip-bespreken-klanteisen-kl" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-team,rip-aandrager,rip-adviseur">
       <bpmn:incoming>Flow_Gateway_BesprekenSplit_Task_BesprekenKlanteisenKL</bpmn:incoming>
       <bpmn:outgoing>Flow_Task_BesprekenKlanteisenKL_Gateway_BesprekenJoin</bpmn:outgoing>
     </bpmn:userTask>
@@ -93,11 +93,11 @@
       <bpmn:outgoing>Flow_Gateway_AfrondingSplit_Task_TerugkoppelenKlanteisen</bpmn:outgoing>
       <bpmn:outgoing>Flow_Gateway_AfrondingSplit_Task_OpstellenDefinitiefVO</bpmn:outgoing>
     </bpmn:parallelGateway>
-    <bpmn:userTask id="Task_TerugkoppelenKlanteisen" name="Terugkoppelen klanteisen" camunda:formRef="rip-terugkoppelen-klanteisen" camunda:formRefBinding="latest" camunda:candidateGroups="rip-omgevingsmanager">
+    <bpmn:userTask id="Task_TerugkoppelenKlanteisen" name="Terugkoppelen klanteisen" camunda:formRef="rip-terugkoppelen-klanteisen" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-omgevingsmanager">
       <bpmn:incoming>Flow_Gateway_AfrondingSplit_Task_TerugkoppelenKlanteisen</bpmn:incoming>
       <bpmn:outgoing>Flow_Task_TerugkoppelenKlanteisen_EndEvent_KlanteisenTeruggekoppeld</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_OpstellenDefinitiefVO" name="Opstellen definitief VO" camunda:formRef="rip-definitief-vo" camunda:formRefBinding="latest" camunda:candidateGroups="rip-ontwerper" ronl:documentRef="rip-hoeveelheidsbepaling">
+    <bpmn:userTask id="Task_OpstellenDefinitiefVO" name="Opstellen definitief VO" camunda:formRef="rip-definitief-vo" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-ontwerper" ronl:documentRef="rip-hoeveelheidsbepaling">
       <bpmn:incoming>Flow_Gateway_AfrondingSplit_Task_OpstellenDefinitiefVO</bpmn:incoming>
       <bpmn:outgoing>Flow_Task_OpstellenDefinitiefVO_EndEvent_VOGereed</bpmn:outgoing>
     </bpmn:userTask>

--- a/packages/frontend/public/examples/dvtp/DvtpToestemmingGevenProcess.bpmn
+++ b/packages/frontend/public/examples/dvtp/DvtpToestemmingGevenProcess.bpmn
@@ -52,7 +52,7 @@
     <!-- Start: private dienstverlener redirects citizen with context -->
     <bpmn:startEvent id="StartEvent_Dvtp" name="Toestemming aangevraagd"
                      camunda:formRef="dvtp-consent-start"
-                     camunda:formRefBinding="latest">
+                     camunda:formRefBinding="deployment">
       <bpmn:outgoing>Flow_Start_Identity</bpmn:outgoing>
     </bpmn:startEvent>
 
@@ -183,7 +183,7 @@
     <bpmn:userTask id="UT_ConsentInfo"
                    name="Toon dienstinformatie (FR-05/06/07/08)"
                    camunda:formRef="dvtp-consent-info"
-                   camunda:formRefBinding="latest">
+                   camunda:formRefBinding="deployment">
       <bpmn:incoming>Flow_Deleg_OK</bpmn:incoming>
       <bpmn:outgoing>Flow_ConsentInfo_Decision</bpmn:outgoing>
     </bpmn:userTask>
@@ -192,7 +192,7 @@
     <bpmn:userTask id="UT_ConsentDecision"
                    name="Vraag toestemming (FR-09/10)"
                    camunda:formRef="dvtp-consent-decision"
-                   camunda:formRefBinding="latest"
+                   camunda:formRefBinding="deployment"
                    ronl:documentRef="example_dvtp_consent_receipt">
       <bpmn:incoming>Flow_ConsentInfo_Decision</bpmn:incoming>
       <bpmn:outgoing>Flow_Decision_Gateway</bpmn:outgoing>

--- a/packages/frontend/public/examples/flevoland/AwbShellProcess.bpmn
+++ b/packages/frontend/public/examples/flevoland/AwbShellProcess.bpmn
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:ronl="http://ronl.nl/schema/1.0" id="Definitions_AWB" targetNamespace="http://example.com/awb" exporter="Camunda Modeler" exporterVersion="5.43.1">
   <bpmn:process id="AwbShellProcess" name="AWB General Administrative Law Act - Generic Process" isExecutable="true" camunda:historyTimeToLive="365">
-    <bpmn:startEvent id="StartEvent_AWB" name="Application submitted" camunda:formRef="kapvergunning-start" camunda:formRefBinding="latest">
+    <bpmn:startEvent id="StartEvent_AWB" name="Application submitted" camunda:formRef="kapvergunning-start" camunda:formRefBinding="deployment">
       <bpmn:outgoing>Flow_Start_Phase1</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:scriptTask id="Task_Phase1_Identity" name="Phase 1: Determine legal relationship (identification)" scriptFormat="javascript">
@@ -83,7 +83,7 @@
       <bpmn:incoming>Flow_Recheck_Process</bpmn:incoming>
       <bpmn:outgoing>Flow_Phase45_Phase6</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:userTask id="Task_Phase6_Notify" name="Phase 6: Notify applicant of decision (Awb 3:6)" camunda:formRef="awb-notify-applicant" camunda:formRefBinding="latest" camunda:candidateGroups="caseworker" ronl:documentRef="example_treefelling_beschikking">
+    <bpmn:userTask id="Task_Phase6_Notify" name="Phase 6: Notify applicant of decision (Awb 3:6)" camunda:formRef="awb-notify-applicant" camunda:formRefBinding="deployment" camunda:candidateGroups="caseworker" ronl:documentRef="example_treefelling_beschikking">
       <bpmn:incoming>Flow_Phase45_Phase6</bpmn:incoming>
       <bpmn:incoming>Flow_Refuse_Notify</bpmn:incoming>
       <bpmn:outgoing>Flow_Phase6_PaymentGateway</bpmn:outgoing>

--- a/packages/frontend/public/examples/flevoland/HR-capacity/nl/ManagementCapacityClaimProcess.nl.bpmn
+++ b/packages/frontend/public/examples/flevoland/HR-capacity/nl/ManagementCapacityClaimProcess.nl.bpmn
@@ -4,7 +4,7 @@
     <bpmn:startEvent id="StartEvent_CapacityClaim" name="Start capaciteitsclaim">
       <bpmn:outgoing>Flow_Start_Intake</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:userTask id="Task_ConsultAndClassify" name="Overleggen en classificeren" camunda:formRef="capacity-claim-intake-nl" camunda:formRefBinding="latest" camunda:candidateGroups="manager">
+    <bpmn:userTask id="Task_ConsultAndClassify" name="Overleggen en classificeren" camunda:formRef="capacity-claim-intake-nl" camunda:formRefBinding="deployment" camunda:candidateGroups="manager">
       <bpmn:incoming>Flow_Start_Intake</bpmn:incoming>
       <bpmn:outgoing>Flow_Intake_RequestTypeGateway</bpmn:outgoing>
     </bpmn:userTask>
@@ -14,11 +14,11 @@
       <bpmn:outgoing>Flow_Gateway_Staffing</bpmn:outgoing>
       <bpmn:outgoing>Flow_Gateway_Hiring</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:userTask id="Task_PrepareStaffingClaim" name="Formatieclaim opstellen" camunda:formRef="capacity-claim-staffing-nl" camunda:formRefBinding="latest" camunda:candidateGroups="manager">
+    <bpmn:userTask id="Task_PrepareStaffingClaim" name="Formatieclaim opstellen" camunda:formRef="capacity-claim-staffing-nl" camunda:formRefBinding="deployment" camunda:candidateGroups="manager">
       <bpmn:incoming>Flow_Gateway_Staffing</bpmn:incoming>
       <bpmn:outgoing>Flow_Staffing_MergePrepare</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_PrepareHiringClaim" name="Inhuurclaim opstellen" camunda:formRef="capacity-claim-hiring-nl" camunda:formRefBinding="latest" camunda:candidateGroups="manager">
+    <bpmn:userTask id="Task_PrepareHiringClaim" name="Inhuurclaim opstellen" camunda:formRef="capacity-claim-hiring-nl" camunda:formRefBinding="deployment" camunda:candidateGroups="manager">
       <bpmn:incoming>Flow_Gateway_Hiring</bpmn:incoming>
       <bpmn:outgoing>Flow_Hiring_MergePrepare</bpmn:outgoing>
     </bpmn:userTask>
@@ -40,11 +40,11 @@
         execution.setVariable("advisoryGroup",   routingResult.get("advisoryGroup"));
       </bpmn:script>
     </bpmn:scriptTask>
-    <bpmn:userTask id="Task_SubmitToBoardAgenda" name="Agenderen Directievergadering" camunda:formRef="capacity-claim-submit-nl" camunda:formRefBinding="latest" camunda:candidateGroups="board-secretary">
+    <bpmn:userTask id="Task_SubmitToBoardAgenda" name="Agenderen Directievergadering" camunda:formRef="capacity-claim-submit-nl" camunda:formRefBinding="deployment" camunda:candidateGroups="board-secretary">
       <bpmn:incoming>Flow_MapOutputs_Submit</bpmn:incoming>
       <bpmn:outgoing>Flow_Submit_BoardDecision</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_BoardDecision" name="Directiebesluit" camunda:formRef="capacity-claim-board-decision-nl" camunda:formRefBinding="latest" camunda:candidateGroups="board-director" ronl:documentRef="board-decision-notification-nl">
+    <bpmn:userTask id="Task_BoardDecision" name="Directiebesluit" camunda:formRef="capacity-claim-board-decision-nl" camunda:formRefBinding="deployment" camunda:candidateGroups="board-director" ronl:documentRef="board-decision-notification-nl">
       <bpmn:incoming>Flow_Submit_BoardDecision</bpmn:incoming>
       <bpmn:outgoing>Flow_BoardDecision_Gateway</bpmn:outgoing>
     </bpmn:userTask>
@@ -53,7 +53,7 @@
       <bpmn:outgoing>Flow_Gateway_Approved</bpmn:outgoing>
       <bpmn:outgoing>Flow_Gateway_Rejected</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:userTask id="Task_ReconsiderationMeeting" name="Heroverwegingsoverleg" camunda:formRef="capacity-claim-reconsideration-nl" camunda:formRefBinding="latest" camunda:candidateGroups="manager,hr-business-partner,personnel-controller">
+    <bpmn:userTask id="Task_ReconsiderationMeeting" name="Heroverwegingsoverleg" camunda:formRef="capacity-claim-reconsideration-nl" camunda:formRefBinding="deployment" camunda:candidateGroups="manager,hr-business-partner,personnel-controller">
       <bpmn:incoming>Flow_Gateway_Rejected</bpmn:incoming>
       <bpmn:outgoing>Flow_Reconsider_OutcomeGateway</bpmn:outgoing>
     </bpmn:userTask>
@@ -70,11 +70,11 @@
       <bpmn:outgoing>Flow_Route_Recruitment</bpmn:outgoing>
       <bpmn:outgoing>Flow_Route_Procurement</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:userTask id="Task_HandoverToRecruitment" name="Overdracht naar werving &amp; selectie" camunda:formRef="capacity-claim-handover-nl" camunda:formRefBinding="latest" camunda:candidateGroups="hrm-unit" ronl:documentRef="capacity-claim-handover-nl">
+    <bpmn:userTask id="Task_HandoverToRecruitment" name="Overdracht naar werving &amp; selectie" camunda:formRef="capacity-claim-handover-nl" camunda:formRefBinding="deployment" camunda:candidateGroups="hrm-unit" ronl:documentRef="capacity-claim-handover-nl">
       <bpmn:incoming>Flow_Route_Recruitment</bpmn:incoming>
       <bpmn:outgoing>Flow_Recruitment_MergeHandover</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:userTask id="Task_HandoverToProcurement" name="Overdracht naar inkoop" camunda:formRef="capacity-claim-handover-nl" camunda:formRefBinding="latest" camunda:candidateGroups="procurement-unit,planning-control-officer" ronl:documentRef="capacity-claim-handover-nl">
+    <bpmn:userTask id="Task_HandoverToProcurement" name="Overdracht naar inkoop" camunda:formRef="capacity-claim-handover-nl" camunda:formRefBinding="deployment" camunda:candidateGroups="procurement-unit,planning-control-officer" ronl:documentRef="capacity-claim-handover-nl">
       <bpmn:incoming>Flow_Route_Procurement</bpmn:incoming>
       <bpmn:outgoing>Flow_Procurement_MergeHandover</bpmn:outgoing>
     </bpmn:userTask>
@@ -83,7 +83,7 @@
       <bpmn:incoming>Flow_Procurement_MergeHandover</bpmn:incoming>
       <bpmn:outgoing>Flow_MergeHandover_Reservation</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:userTask id="Task_RegisterReservation" name="Financiële reservering registreren" camunda:formRef="capacity-claim-register-reservation-nl" camunda:formRefBinding="latest" camunda:candidateGroups="financial-controller">
+    <bpmn:userTask id="Task_RegisterReservation" name="Financiële reservering registreren" camunda:formRef="capacity-claim-register-reservation-nl" camunda:formRefBinding="deployment" camunda:candidateGroups="financial-controller">
       <bpmn:incoming>Flow_MergeHandover_Reservation</bpmn:incoming>
       <bpmn:outgoing>Flow_Reservation_End</bpmn:outgoing>
     </bpmn:userTask>

--- a/packages/frontend/public/examples/flevoland/TreeFellingPermitSubProcess.bpmn
+++ b/packages/frontend/public/examples/flevoland/TreeFellingPermitSubProcess.bpmn
@@ -68,7 +68,7 @@
       Caseworker must claim via POST /v1/task/:id/claim before completing.
       candidateGroups routes this task to the caseworker group in Operaton.
     -->
-      <bpmn:userTask id="Sub_CaseReview" name="Case review: tree felling permit decision" camunda:formRef="tree-felling-review" camunda:formRefBinding="latest" camunda:candidateGroups="caseworker">      <bpmn:incoming>Flow_Sub_Replacement_Review</bpmn:incoming>
+      <bpmn:userTask id="Sub_CaseReview" name="Case review: tree felling permit decision" camunda:formRef="tree-felling-review" camunda:formRefBinding="deployment" camunda:candidateGroups="caseworker">      <bpmn:incoming>Flow_Sub_Replacement_Review</bpmn:incoming>
       <bpmn:outgoing>Flow_Sub_Review_Resolve</bpmn:outgoing>
     </bpmn:userTask>
 

--- a/packages/frontend/public/examples/toeslagen/AwbZorgtoeslagProcess.bpmn
+++ b/packages/frontend/public/examples/toeslagen/AwbZorgtoeslagProcess.bpmn
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:ronl="http://ronl.nl/schema/1.0" id="Definitions_AWB_Zorgtoeslag" targetNamespace="http://example.com/zorgtoeslag/awb" exporter="Camunda Modeler" exporterVersion="5.43.1">
   <bpmn:process id="AwbZorgtoeslagProcess" name="AWB Zorgtoeslag — Provisional Entitlement Process" isExecutable="true" camunda:historyTimeToLive="365">
-    <bpmn:startEvent id="StartEvent_AWB" name="Application submitted" camunda:formRef="zorgtoeslag-provisional-start" camunda:formRefBinding="latest">
+    <bpmn:startEvent id="StartEvent_AWB" name="Application submitted" camunda:formRef="zorgtoeslag-provisional-start" camunda:formRefBinding="deployment">
       <bpmn:outgoing>Flow_Start_Phase1</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:scriptTask id="Task_Phase1_Identity" name="Phase 1: Determine legal relationship (identification)" scriptFormat="javascript">
@@ -82,7 +82,7 @@
       <bpmn:incoming>Flow_Recheck_Process</bpmn:incoming>
       <bpmn:outgoing>Flow_Phase45_Phase6</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:userTask id="Task_Phase6_Notify" name="Phase 6: Notify applicant of decision (Awb 3:6)" camunda:formRef="zorgtoeslag-notify-applicant" camunda:formRefBinding="latest" camunda:candidateGroups="caseworker" ronl:documentRef="example_zorgtoeslag_provisional_beschikking">
+    <bpmn:userTask id="Task_Phase6_Notify" name="Phase 6: Notify applicant of decision (Awb 3:6)" camunda:formRef="zorgtoeslag-notify-applicant" camunda:formRefBinding="deployment" camunda:candidateGroups="caseworker" ronl:documentRef="example_zorgtoeslag_provisional_beschikking">
       <bpmn:incoming>Flow_Phase45_Phase6</bpmn:incoming>
       <bpmn:incoming>Flow_Refuse_Notify</bpmn:incoming>
       <bpmn:outgoing>Flow_Phase6_PaymentGateway</bpmn:outgoing>

--- a/packages/frontend/public/examples/toeslagen/ZorgtoeslagFinalSubProcess.bpmn
+++ b/packages/frontend/public/examples/toeslagen/ZorgtoeslagFinalSubProcess.bpmn
@@ -92,7 +92,7 @@
     <bpmn:userTask id="Sub_CaseReview"
                    name="Case review: final settlement decision"
                    camunda:formRef="zorgtoeslag-final-review"
-                   camunda:formRefBinding="latest"
+                   camunda:formRefBinding="deployment"
                    camunda:candidateGroups="caseworker">
       <bpmn:incoming>Flow_Sub_Calc_Review</bpmn:incoming>
       <bpmn:outgoing>Flow_Sub_Review_Resolve</bpmn:outgoing>

--- a/packages/frontend/public/examples/toeslagen/ZorgtoeslagProvisionalSubProcess.bpmn
+++ b/packages/frontend/public/examples/toeslagen/ZorgtoeslagProvisionalSubProcess.bpmn
@@ -53,7 +53,7 @@
         execution.setVariable("amountYear", amountYear != null ? Number(amountYear) : 0);
       </bpmn:script>
     </bpmn:scriptTask>
-    <bpmn:userTask id="Sub_CaseReview" name="Case review: provisional entitlement decision" camunda:formRef="zorgtoeslag-provisional-review" camunda:formRefBinding="latest" camunda:candidateGroups="caseworker">
+    <bpmn:userTask id="Sub_CaseReview" name="Case review: provisional entitlement decision" camunda:formRef="zorgtoeslag-provisional-review" camunda:formRefBinding="deployment" camunda:candidateGroups="caseworker">
       <bpmn:incoming>Flow_Sub_Extract_Review</bpmn:incoming>
       <bpmn:outgoing>Flow_Sub_Review_Resolve</bpmn:outgoing>
     </bpmn:userTask>

--- a/packages/frontend/src/utils/exampleVersions.ts
+++ b/packages/frontend/src/utils/exampleVersions.ts
@@ -17,12 +17,12 @@
  */
 export const EXAMPLE_VERSIONS: Record<string, number> = {
   // BPMN processes
-  example_awb_process: 4, // v4: organization=flevoland tagging
-  example_tree_felling: 7, // v7: shellId added (fixes stale copies rendering under the wrong shell)
-  example_awb_zorgtoeslag: 3, // v3: organization=toeslagen tagging
-  example_zorgtoeslag_provisional: 5, // v5: shellId added (fixes stale copies rendering under the wrong shell)
-  example_zorgtoeslag_final: 5, // v5: shellId added (fixes stale copies rendering under the wrong shell)
-  example_hr_capacity_nl: 1, // v1: HR-capacity Dutch BPMN sibling (multilingualism release)
+  example_awb_process: 5, // v5: formRefBinding=deployment (tenant-safe form resolution)
+  example_tree_felling: 8, // v8: formRefBinding=deployment (tenant-safe form resolution)
+  example_awb_zorgtoeslag: 4, // v4: formRefBinding=deployment (tenant-safe form resolution)
+  example_zorgtoeslag_provisional: 6, // v6: formRefBinding=deployment (tenant-safe form resolution)
+  example_zorgtoeslag_final: 6, // v6: formRefBinding=deployment (tenant-safe form resolution)
+  example_hr_capacity_nl: 2, // v2: formRefBinding=deployment (tenant-safe form resolution)
 
   // Camunda Forms
   example_kapvergunning_start: 4, // v4: force re-seed for ACC users with stale localStorage from v1.6.0 testing
@@ -48,7 +48,7 @@ export const EXAMPLE_VERSIONS: Record<string, number> = {
   example_hr_capacity_handover_doc_nl: 1,
 
   // DvTP consent bundle
-  example_dvtp_toestemming: 2, // v2: organization=bzk tagging
+  example_dvtp_toestemming: 3, // v3: formRefBinding=deployment (tenant-safe form resolution)
   example_dvtp_consent_start: 2, // v2: organization=bzk tagging
   example_dvtp_consent_info: 2, // v2: organization=bzk tagging
   example_dvtp_consent_decision: 2, // v2: organization=bzk tagging


### PR DESCRIPTION
## Why

Tenanting a process definition made the process unambiguous and its forms ambiguous. `camunda:formRefBinding="latest"` resolves a form key across the whole repository rather than within the bundle, so a tenanted and an untenanted copy of the same bundle collide. Deploying `AwbShellProcess` under tenant `flevoland` produced:

```
ENGINE-03109 Cannot resolve a unique Operaton Form definition for key
'kapvergunning-start' because it exists for multiple tenants.
```

`"deployment"` resolves the form from the process definition's own deployment, unique by construction, so tenanted and untenanted copies coexist and no deployment history has to be destroyed.

## What changed

91 of 109 references converted across the three trees that hold BPMN:

| Tree | Refs | Role |
|---|---|---|
| `packages/frontend/public/examples/` | 19 | seed + deploy source for the Awb/Zorgtoeslag/DvTP/HR bundles |
| `examples/organizations/` | 44 | authoring source for RIP and HR-capacity |
| `e2e-fixtures/` | 28 | what ronl-business-api's E2E suite deploys |

Only the binding attribute changed — the deliberate `e2e-fixtures` variants (`TreeFellingPermitSubProcessE2E`, `decisionRefTenantId="${null}"`) are preserved. `dist/` is gitignored build output and was not touched.

**Deliberately left on `"latest"`:** `examples/organizations/flevoland/thuisbatterij/` (3) and `examples/organizations/ind/Asiel en Migratie procedure 001.bpmn` (15). Their form keys resolve nowhere in the repository, so deployment binding would have had nothing to bind against; had those forms been authored engine-side, converting them would have broken them.

## EXAMPLE_VERSIONS bump

`public/examples` is seeded into localStorage and re-fetched only when its version number rises. Without the bump the BPMN edit is **invisible to every existing user** — the repository looks correct while the browser keeps deploying the stale copy and reproducing the same 500. All seven seeded BPMN entries bumped; no form version moved, as no form changed.

## Already-deployed definitions do not heal

Process definitions are immutable once deployed, so every copy already in an engine keeps binding `"latest"` until redeployed:

- ACC users get the fix only after a frontend deploy **and** a page load that re-seeds localStorage.
- The six `e2e-fixtures` bundles must be re-imported through LDE's BPMN Modeler before an E2E run exercises them. `ronl-business-api`'s `packages/frontend/e2e/global-setup.ts` already prints those instructions; `required-processes.ts` needs no edit, as it keys on process-definition keys.
- `RipR21Process` is deployed on ACC tenant-scoped to `flevoland` and still binds `"latest"` until redeployed; `RipR22Process` is not on ACC at all.

## Verification

- Backend Jest: **1134/1134**, 51 suites
- Frontend Vitest: **573/573**, 60 files
- Frontend ESLint: clean; Prettier check clean (pre-push)
- Diff discipline: zero changed lines outside `formRefBinding` values and `exampleVersions.ts`
- Redeployed and confirmed by hand against a live engine, including the ronl-business-api E2E journey

## Follow-up, not in this PR

While tracing an unrelated missing signing panel, a separate LDE defect surfaced: `BpmnCanvas.tsx` silently drops document templates that are absent from browser storage when building a deploy. Forms surface an `unmatchedForms` warning; `unmatchedDocuments` does not exist, so a deployment can ship with zero `.document` resources and still show a green "Resources to deploy" panel. `extractDocumentRefs` also reads only `ronl:documentRef`, never `ronl:signatureRef`. Worth its own branch.
