### PR TITLE
fix(deploy): block deploying a bundle whose forms or documents are missing

### DIFF
--- a/packages/frontend/src/components/BpmnModeler/BpmnCanvas.test.tsx
+++ b/packages/frontend/src/components/BpmnModeler/BpmnCanvas.test.tsx
@@ -482,3 +482,75 @@ describe('BpmnCanvas — deploy modal', () => {
     expect(screen.queryByText('Deploy to Operaton')).toBeNull();
   });
 });
+
+describe('BpmnCanvas — deploy modal, unmatched resources', () => {
+  // A bundle whose board and organization are both already satisfied, so the
+  // ONLY thing left that can disable Deploy is the unmatched-resource guard.
+  // Without that isolation these tests would pass on the pre-existing
+  // organization guard and prove nothing.
+  const NS =
+    'xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" ' +
+    'xmlns:camunda="http://camunda.org/schema/1.0/bpmn" ' +
+    'xmlns:ronl="https://regels.overheid.nl/schema"';
+
+  const bundle = (taskAttrs: string) =>
+    `<bpmn:definitions ${NS}><bpmn:process id="MyProcess" ronl:organization="flevoland">` +
+    `<bpmn:userTask id="t1" camunda:candidateGroups="rip-projectleider" ${taskAttrs} />` +
+    `</bpmn:process></bpmn:definitions>`;
+
+  async function openModalWithBoard(
+    xml: string,
+    opts: { forms?: unknown[]; templates?: unknown[] }
+  ) {
+    await renderCanvas({ xml, forms: opts.forms ?? [], templates: opts.templates ?? [] });
+    await userEvent.click(screen.getByText('Deploy'));
+    await screen.findByText('Deploy to Operaton');
+    await userEvent.click(screen.getByRole('button', { name: 'Infra-board' }));
+  }
+
+  test('blocks deploy when a referenced document template is missing from storage', async () => {
+    await openModalWithBoard(bundle('ronl:documentRef="doc-missing"'), { templates: [] });
+
+    expect(document.body.textContent).toContain('doc-missing.document');
+    expect(screen.getAllByRole('button', { name: /Deploy/ })[1]).toBeDisabled();
+  });
+
+  test('blocks deploy when a referenced form is missing from storage', async () => {
+    await openModalWithBoard(bundle('camunda:formRef="form-missing"'), { forms: [] });
+
+    expect(document.body.textContent).toContain('form-missing.form');
+    expect(screen.getAllByRole('button', { name: /Deploy/ })[1]).toBeDisabled();
+  });
+
+  test('allows deploy once every referenced resource is present in storage', async () => {
+    await openModalWithBoard(bundle('camunda:formRef="form-1" ronl:documentRef="doc-1"'), {
+      forms: [{ id: 'f1', schema: { id: 'form-1' } }],
+      templates: [{ id: 'doc-1', name: 'Beschikking' }],
+    });
+
+    expect(screen.getAllByRole('button', { name: /Deploy/ })[1]).not.toBeDisabled();
+  });
+
+  test('bundles the template a task references through ronl:signatureRef', async () => {
+    // rip-pdp survived this gap in production only because it happened to carry
+    // ronl:documentRef as well; a signature-only task shipped without its
+    // template and failed at runtime with SIGNATURE_TEMPLATE_NOT_FOUND.
+    await openModalWithBoard(bundle('ronl:signatureRef="doc-1"'), {
+      templates: [{ id: 'doc-1', name: 'Projectplan' }],
+    });
+
+    expect(document.body.textContent).toContain('doc-1.document');
+  });
+
+  test('reports the resource count once, including documents', async () => {
+    await openModalWithBoard(bundle('camunda:formRef="form-1" ronl:documentRef="doc-1"'), {
+      forms: [{ id: 'f1', schema: { id: 'form-1' } }],
+      templates: [{ id: 'doc-1', name: 'Beschikking' }],
+    });
+
+    // 1 bpmn + 1 form + 1 document. The footer used to print the count twice,
+    // the first omitting documents entirely: "2 resource(s) · 3 resource(s)".
+    expect(document.body.textContent).toContain('3 resource(s) · process key:');
+    expect(document.body.textContent).not.toMatch(/resource\(s\)\s*·\s*\d+\s*resource\(s\)/);
+  });
+});

--- a/packages/frontend/src/components/BpmnModeler/BpmnCanvas.tsx
+++ b/packages/frontend/src/components/BpmnModeler/BpmnCanvas.tsx
@@ -120,7 +120,16 @@ const BpmnCanvas: React.FC<BpmnCanvasProps> = ({
     bpmnFiles: string[];
     formFiles: string[];
     documentFiles: string[];
-  }>({ processKey: '', bpmnFiles: [], formFiles: [], documentFiles: [] });
+    unmatchedForms: string[];
+    unmatchedDocuments: string[];
+  }>({
+    processKey: '',
+    bpmnFiles: [],
+    formFiles: [],
+    documentFiles: [],
+    unmatchedForms: [],
+    unmatchedDocuments: [],
+  });
 
   // To make the endpoint user-configurable we need to thread it through the
   // full chain: modal state → request body → backend route → service method
@@ -438,7 +447,14 @@ const BpmnCanvas: React.FC<BpmnCanvasProps> = ({
     ];
 
     const extractDocumentRefs = (bpmnXml: string) => [
-      ...new Set([...bpmnXml.matchAll(/ronl:documentRef="([^"]+)"/g)].map((m) => m[1])),
+      ...new Set(
+        [
+          ...bpmnXml.matchAll(/ronl:documentRef="([^"]+)"/g),
+          // A signature task binds its template through signatureRef alone;
+          // reading only documentRef left such a template out of the bundle.
+          ...bpmnXml.matchAll(/ronl:signatureRef="([^"]+)"/g),
+        ].map((m) => m[1])
+      ),
     ];
 
     const extractCalledElements = (bpmnXml: string) => [
@@ -480,6 +496,13 @@ const BpmnCanvas: React.FC<BpmnCanvasProps> = ({
     const matchedDocuments = [...allDocumentRefs].filter((ref) =>
       allDocumentTemplates.some((d) => d.id === ref)
     );
+    // A referenced template that is not in local storage was previously dropped
+    // from the payload without a word, so the deployment shipped without its
+    // .document resource and the signing panel silently degraded to a plain
+    // form at runtime. Surfaced and blocked here instead.
+    const unmatchedDocuments = [...allDocumentRefs].filter(
+      (ref) => !allDocumentTemplates.some((d) => d.id === ref)
+    );
 
     // ─── Language consistency check ─────────────────────────────────────
     // Collect all distinct non-null language codes across the bundle.
@@ -511,12 +534,12 @@ const BpmnCanvas: React.FC<BpmnCanvasProps> = ({
       bpmnFiles: [`${processKey}.bpmn`, ...subProcessXmls.map((sp) => sp.filename)],
       formFiles: matchedForms.map((ref) => `${ref}.form`),
       documentFiles: matchedDocuments.map((ref) => `${ref}.document`),
-      ...(unmatchedForms.length ? { unmatchedForms } : {}),
+      unmatchedForms,
+      unmatchedDocuments,
       ropaRefMissing,
       languageMismatch,
       languageList,
     } as typeof deployResources & {
-      unmatchedForms?: string[];
       ropaRefMissing?: boolean;
       languageMismatch?: boolean;
       languageList?: string[];
@@ -561,7 +584,14 @@ const BpmnCanvas: React.FC<BpmnCanvasProps> = ({
       ];
 
       const extractDocumentRefs = (bpmnXml: string) => [
-        ...new Set([...bpmnXml.matchAll(/ronl:documentRef="([^"]+)"/g)].map((m) => m[1])),
+        ...new Set(
+          [
+            ...bpmnXml.matchAll(/ronl:documentRef="([^"]+)"/g),
+            // A signature task binds its template through signatureRef alone;
+            // reading only documentRef left such a template out of the bundle.
+            ...bpmnXml.matchAll(/ronl:signatureRef="([^"]+)"/g),
+          ].map((m) => m[1])
+        ),
       ];
 
       const extractCalledElements = (bpmnXml: string) => [
@@ -882,6 +912,28 @@ const BpmnCanvas: React.FC<BpmnCanvasProps> = ({
                   </li>
                 ))}
               </ul>
+              {(deployResources.unmatchedForms.length > 0 ||
+                deployResources.unmatchedDocuments.length > 0) && (
+                <div className="mb-3 mt-3 p-3 rounded-lg bg-red-50 border border-red-300 text-xs text-red-800">
+                  <div className="font-semibold mb-1">
+                    ⛔ Referenced resources are missing from local storage
+                  </div>
+                  <ul className="mb-2 space-y-0.5">
+                    {deployResources.unmatchedForms.map((ref) => (
+                      <li key={`uf-${ref}`} className="font-mono">
+                        {ref}.form
+                      </li>
+                    ))}
+                    {deployResources.unmatchedDocuments.map((ref) => (
+                      <li key={`ud-${ref}`} className="font-mono">
+                        {ref}.document
+                      </li>
+                    ))}
+                  </ul>
+                  Deploying without them produces a bundle the engine cannot resolve at runtime.
+                  Import them in the Form editor or Document composer first.
+                </div>
+              )}
               {(deployResources as any).ropaRefMissing && (
                 <div className="mb-3 p-3 rounded-lg bg-amber-50 border border-amber-200 text-xs text-amber-800">
                   ⚠️ No <code className="font-mono">ronl:ropaRef</code> found on the process
@@ -900,7 +952,6 @@ const BpmnCanvas: React.FC<BpmnCanvasProps> = ({
                 </div>
               )}
               <div className="mt-2 text-xs text-slate-500">
-                {deployResources.bpmnFiles.length + deployResources.formFiles.length} resource(s) ·
                 {deployResources.bpmnFiles.length +
                   deployResources.formFiles.length +
                   deployResources.documentFiles.length}{' '}
@@ -978,7 +1029,9 @@ const BpmnCanvas: React.FC<BpmnCanvasProps> = ({
                   isDeploying ||
                   deployResult?.success === true ||
                   !resolvedBoard ||
-                  !deployOrganization
+                  !deployOrganization ||
+                  deployResources.unmatchedForms.length > 0 ||
+                  deployResources.unmatchedDocuments.length > 0
                 }
                 className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors font-medium"
               >


### PR DESCRIPTION
## The failure this prevents

The deploy modal filtered referenced forms and document templates against the browser's own storage and dropped every miss **without a word** — so a bundle could deploy with none of its `.document` resources and still show a green "Resources to deploy" panel.

The symptom surfaced far from the cause. `RipR21Process` deployed with its BPMN and twelve forms but none of its three documents. At runtime, in `ronl-business-api`:

```
getTaskSignatureSpec reads ronl:signatureRef from the engine  → "rip-pdp"   ✓
fetchDeployedTemplate looks for rip-pdp.document               → absent      ✗
  → throws SIGNATURE_TEMPLATE_NOT_FOUND
  → GET /v1/validsign/task/:id/spec → 500
  → ProjectDetail's Promise.allSettled degrades a failed spec to
    "no signature required"
  → the phase-exit approval task rendered an ordinary form, not SigningPanel
  → the E2E journey failed on a missing signing panel
```

Confirmed live against the engine: the deployment held `RipR21Process.bpmn` + 12 `.form` and **zero** `.document`, and the spec endpoint returned `500 SIGNATURE_SPEC_FAILED`.

## What changed

| Change | Effect |
|---|---|
| `unmatchedDocuments` computed and rendered | missing templates are named in the modal |
| Deploy button gated on unmatched forms/documents | the broken bundle can no longer ship |
| `unmatchedForms` surfaced | it was computed and stored but **rendered nowhere** — dead since introduction |
| `extractDocumentRefs` follows `ronl:signatureRef` | a signature-only task now contributes its template |
| Resources footer | printed its count twice, the first total omitting documents |

The guard mirrors the existing board-owner and organization guards.

### The `signatureRef` extractor changes no bundle in this repo

`rip-pdp` is the only `ronl:signatureRef` in the repository and it carries a `ronl:documentRef` too, in both copies. `allDocumentRefs` is a `Set`, so it dedupes — same payload, byte for byte. The change is purely defensive: a task binding a template through `signatureRef` alone previously never contributed it, and `rip-pdp` survived that gap only by coincidence.

## Tests — written first, watched fail

Five new tests. Each fixture sets `ronl:organization` **and** clicks a board, so the pre-existing organization/board guards cannot disable the button; without that isolation the tests would pass on those guards and prove nothing.

RED output confirmed the doubled-count defect verbatim: `"1 resource(s) ·1 resource(s) · process key: MyProcess"`.

One test is a control — all resources present → Deploy stays **enabled** — so the guard is not just disabling the button unconditionally. It passed before and after.

- `BpmnCanvas.test.tsx`: **24/24** (19 pre-existing + 5 new)
- Full frontend Vitest: **578/578**, 60 files (was 573)
- ESLint clean; Prettier clean

## One deliberate asymmetry

The board and organization guards each have *both* a disabled button and an early return inside `handleDeploy`. This adds only the button gate. Behind a disabled button such a return is unreachable from the UI, so no test could fail on it — I'd rather flag the asymmetry than add production code no test covers. Easy to add if you want it for defence-in-depth.

## Relationship to #49

Independent, branched from `acc`. #49 fixes form *binding*; this fixes what the deploy *ships*. Worth landing this one before any bulk redeploys — it's the guard that catches the silent drop during hand-imports.
