### PR TITLE
chore: bump release to v2026.09.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linked-data-explorer-monorepo",
-  "version": "2026.08.9",
+  "version": "2026.09.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linked-data-explorer-monorepo",
-      "version": "2026.08.9",
+      "version": "2026.09.0",
       "hasInstallScript": true,
       "license": "EUPL-1.2",
       "workspaces": [
@@ -16995,7 +16995,7 @@
     },
     "packages/frontend": {
       "name": "@linked-data-explorer/frontend",
-      "version": "2026.08.9",
+      "version": "2026.09.0",
       "dependencies": {
         "@bpmn-io/form-js": "^1.20.0",
         "@bpmn-io/properties-panel": "^3.38.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linked-data-explorer-monorepo",
-  "version": "2026.08.9",
+  "version": "2026.09.0",
   "private": true,
   "description": "Monorepo for Linked Data Explorer - RONL DMN Orchestration Platform",
   "workspaces": [

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@linked-data-explorer/frontend",
   "private": true,
-  "version": "2026.08.9",
+  "version": "2026.09.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/frontend/src/changelog.json
+++ b/packages/frontend/src/changelog.json
@@ -2,6 +2,37 @@
   "versions": [
     {
       "format": "commits",
+      "version": "2026.09.0",
+      "status": "Released",
+      "date": "1 sep 2026",
+      "scope": "frontend",
+      "commits": [
+        {
+          "sha": "9abc2f2",
+          "author": "Steven Gort",
+          "type": "fix",
+          "subject": "Deploy refuses a bundle whose forms or documents are missing from local storage",
+          "details": [
+            "The deploy modal filtered referenced forms and document templates against the browser’s own storage and dropped every miss without a word, so a bundle could deploy with none of its .document resources and still show a green \"Resources to deploy\" panel.",
+            "The failure surfaced far from its cause. RipR21Process deployed with its BPMN and twelve forms but none of its three documents; at runtime ronl-business-api read ronl:signatureRef from the engine, looked for rip-pdp.document in the deployment, threw SIGNATURE_TEMPLATE_NOT_FOUND and returned 500 from the task spec endpoint. ProjectDetail fetches that spec inside a Promise.allSettled and degrades a failure to \"no signature required\", so the phase-exit approval task rendered an ordinary form instead of the signing panel and the E2E journey failed on a missing panel.",
+            "Missing resources are now listed by name and the deploy button is disabled while any remain, matching the existing board-owner and organization guards. unmatchedForms was already computed but rendered nowhere, and is surfaced alongside it. extractDocumentRefs now also follows ronl:signatureRef: a task binding a template through that attribute alone never contributed it, and rip-pdp survived only because it carries both. No bundle in the repository changes as a result. The resources footer, which printed its count twice with the first total omitting documents, is collapsed to one."
+          ]
+        },
+        {
+          "sha": "45d3d2f",
+          "author": "Steven Gort",
+          "type": "fix",
+          "subject": "Forms bind to their own deployment instead of the latest version",
+          "details": [
+            "Tenanting a process definition made the process unambiguous and its forms ambiguous. camunda:formRefBinding=\"latest\" resolves a form key across the whole repository rather than within the bundle, so deploying AwbShellProcess under tenant flevoland produced ENGINE-03109: the key ‘kapvergunning-start’ existed for multiple tenants. \"deployment\" resolves the form from the process definition’s own deployment, unique by construction, so tenanted and untenanted copies coexist and no deployment history has to be destroyed.",
+            "91 of 109 references converted across the three trees that hold BPMN: packages/frontend/public/examples/ (seed and deploy source for the Awb/Zorgtoeslag/DvTP/HR bundles), examples/organizations/ (authoring source for RIP and HR-capacity), and e2e-fixtures/ (what ronl-business-api’s E2E suite deploys). thuisbatterij and ind stay on \"latest\" because their form keys resolve nowhere in the repository.",
+            "Also bumps the seven seeded BPMN entries in EXAMPLE_VERSIONS. public/examples is seeded into localStorage and re-fetched only when its version rises, so without the bump the edit would be invisible to every existing user. Already-deployed definitions do not heal: ACC users get the fix only after a frontend deploy and a page load that re-seeds, and the e2e-fixtures bundles must be re-imported through the BPMN Modeler before an E2E run exercises them."
+          ]
+        }
+      ]
+    },
+    {
+      "format": "commits",
       "version": "2026.08.9",
       "status": "Released",
       "date": "29 aug 2026",


### PR DESCRIPTION
Cuts **v2026.09.0**, scope `frontend`. First release of September, so CalVer resets the patch to `0`.

## Entry

Two fixes, both from the same investigation:

| SHA | Fix |
|---|---|
| `45d3d2f` | Forms bind to their own deployment instead of the latest version — 91 of 109 `formRefBinding` refs, plus the seven seeded `EXAMPLE_VERSIONS` bumps |
| `9abc2f2` | Deploy refuses a bundle whose forms or documents are missing from local storage |

## Versions

| File | Change |
|---|---|
| `package.json` (root) | 2026.08.9 → **2026.09.0** |
| `packages/frontend/package.json` | 2026.08.9 → **2026.09.0** |
| `packages/backend/package.json` | **unchanged at 2026.08.9** |
| `package-lock.json` | top-level, `packages[""]`, `packages["packages/frontend"]` |

Nothing under `packages/backend` changed, so its version — and its lockfile entry — legitimately lag this release.

Versions were edited by hand rather than with `npm version`, which coerces to strict SemVer and would have written `2026.9.0`.

## Verification

- `npm ci --dry-run` — exit 0, lockfile still resolves
- Lockfile diff is 3 lines, **zero** non-`"version"` lines — no dependency churn
- Frontend Vitest **578/578** across 60 files, including `Changelog.test.tsx` rendering the new entry
- `npm run format` no-op; `npm run check-format` clean in both workspaces
- Nothing outside the four release files touched

## Scope reconciliation

Renovate's five open PRs — #39, #40, #43, #44, #48 — were deliberately left out and will be gathered by the next release. Four of them rewrite `package-lock.json`, the same file this PR edits, so they were kept out of the version bump rather than merged alongside it.

## Merge method

**Merge commit only — not squash, not rebase.** The changelog entry names `45d3d2f` and `9abc2f2` by SHA; both alternatives rewrite those hashes and would leave the entry citing commits that do not exist on `acc`. The ruleset pins merge-only, but the default button is otherwise "Squash and merge".
