### PR TITLE
test: raise per-file branch coverage above 80% across both packages

### DIFF
--- a/packages/backend/src/services/triplydb.service.test.ts
+++ b/packages/backend/src/services/triplydb.service.test.ts
@@ -149,6 +149,12 @@ describe('listGraphs', () => {
     await expect(listGraphs(CONFIG)).resolves.toEqual(['graph:a']);
   });
 
+  test('falls back to the stringified entry when a graph names itself neither way', async () => {
+    mockFetch.mockResolvedValue(response({ json: [{ id: 'g-1' }] }));
+
+    await expect(listGraphs(CONFIG)).resolves.toEqual(['[object Object]']);
+  });
+
   test('prefers graphName over name when both are present', async () => {
     mockFetch.mockResolvedValue(
       response({ json: [{ graphName: 'graph:preferred', name: 'graph:other' }] })
@@ -320,6 +326,42 @@ describe('testConnection', () => {
 
   test('returns false rather than throwing when the host is unreachable', async () => {
     mockFetch.mockRejectedValue(new Error('ENOTFOUND'));
+
+    await expect(testConnection(CONFIG)).resolves.toBe(false);
+  });
+});
+
+// Every catch block distinguishes an Error from anything else a rejected fetch
+// can carry (a string, a DOMException-like object). Cover the non-Error side so
+// the logging fallbacks are exercised rather than assumed.
+describe('non-Error transport failures', () => {
+  test('executeQuery reports a rejection that is not an Error', async () => {
+    mockFetch.mockRejectedValue('socket hang up');
+
+    await expect(executeQuery('e', 'q')).rejects.toThrow('Failed to execute query:');
+  });
+
+  test('constructGraph reports a rejection that is not an Error', async () => {
+    mockFetch.mockRejectedValue('socket hang up');
+
+    await expect(constructGraph('e', 'q')).rejects.toThrow('Failed to execute CONSTRUCT:');
+  });
+
+  test('listGraphs reports a rejection that is not an Error', async () => {
+    mockFetch.mockRejectedValue('socket hang up');
+
+    await expect(listGraphs(CONFIG)).rejects.toThrow('Failed to list graphs:');
+  });
+
+  test('updateService reports a rejection that is not an Error', async () => {
+    // Supply the graph list so the sync POST is the only fetch, and reject it.
+    mockFetch.mockRejectedValue('socket hang up');
+
+    await expect(updateService(CONFIG, 'svc', ['g1'])).rejects.toThrow('Failed to update service:');
+  });
+
+  test('testConnection returns false for a rejection that is not an Error', async () => {
+    mockFetch.mockRejectedValue('socket hang up');
 
     await expect(testConnection(CONFIG)).resolves.toBe(false);
   });

--- a/packages/frontend/src/components/BpmnModeler/BpmnCanvas.test.tsx
+++ b/packages/frontend/src/components/BpmnModeler/BpmnCanvas.test.tsx
@@ -84,6 +84,8 @@ const { modelerInstances, MockBpmnModeler } = vi.hoisted(() => {
     }
 
     importXML(xml: string) {
+      // Sentinel for the failure path: bpmn-js rejects on unparseable XML.
+      if (xml.includes('__IMPORT_FAIL__')) return Promise.reject(new Error('parse error'));
       this.xml = xml;
       return Promise.resolve({ warnings: [] });
     }
@@ -552,5 +554,351 @@ describe('BpmnCanvas — deploy modal, unmatched resources', () => {
     // the first omitting documents entirely: "2 resource(s) · 3 resource(s)".
     expect(document.body.textContent).toContain('3 resource(s) · process key:');
     expect(document.body.textContent).not.toMatch(/resource\(s\)\s*·\s*\d+\s*resource\(s\)/);
+  });
+});
+
+describe('BpmnCanvas — overlay badges', () => {
+  /** A minimal element-registry entry, shaped like a bpmn-js element. */
+  function element(type: string, attrs: Record<string, string> = {}, id = 'e1') {
+    return {
+      id,
+      type,
+      width: 100,
+      businessObject: { get: (key: string) => attrs[key] },
+    };
+  }
+
+  async function overlaysAfterChange(elements: unknown[]) {
+    const { modeler } = await renderCanvas();
+    const added: { id: string; type: string; opts: { html: string } }[] = [];
+    modeler.overlays.add = ((id: string, type: string, opts: { html: string }) => {
+      added.push({ id, type, opts });
+    }) as never;
+    modeler.elementRegistry.elements = elements;
+
+    act(() => modeler.eventBus.emit('commandStack.changed'));
+
+    return added;
+  }
+
+  test('badges a BusinessRuleTask that references a DMN', async () => {
+    const added = await overlaysAfterChange([
+      element('bpmn:BusinessRuleTask', { 'camunda:decisionRef': 'AgeCheck' }),
+    ]);
+
+    expect(added).toHaveLength(1);
+    expect(added[0].type).toBe('dmn-linked');
+    expect(added[0].opts.html).toContain('AgeCheck');
+  });
+
+  test('leaves an unlinked BusinessRuleTask unbadged', async () => {
+    expect(await overlaysAfterChange([element('bpmn:BusinessRuleTask')])).toHaveLength(0);
+  });
+
+  test('badges a UserTask with both its form and its document', async () => {
+    const added = await overlaysAfterChange([
+      element('bpmn:UserTask', {
+        'camunda:formRef': 'aanvraag-form',
+        'ronl:documentRef': 'beschikking',
+      }),
+    ]);
+
+    expect(added.map((a) => a.type)).toEqual(['form-linked', 'document-linked']);
+    expect(added[0].opts.html).toContain('aanvraag-form');
+    expect(added[1].opts.html).toContain('beschikking');
+  });
+
+  test('badges a UserTask that has a form but no document', async () => {
+    const added = await overlaysAfterChange([
+      element('bpmn:UserTask', { 'camunda:formRef': 'aanvraag-form' }),
+    ]);
+    expect(added.map((a) => a.type)).toEqual(['form-linked']);
+  });
+
+  test('leaves an unlinked UserTask unbadged', async () => {
+    expect(await overlaysAfterChange([element('bpmn:UserTask')])).toHaveLength(0);
+  });
+
+  test('badges a StartEvent that carries a form, below the shape', async () => {
+    const added = await overlaysAfterChange([
+      element('bpmn:StartEvent', { 'camunda:formRef': 'start-form' }),
+    ]);
+
+    expect(added).toHaveLength(1);
+    expect(added[0].opts.html).toContain('form-linked-badge--start');
+  });
+
+  test('leaves an unlinked StartEvent unbadged', async () => {
+    expect(await overlaysAfterChange([element('bpmn:StartEvent')])).toHaveLength(0);
+  });
+
+  test('ignores element types that carry no badge', async () => {
+    expect(await overlaysAfterChange([element('bpmn:SequenceFlow')])).toHaveLength(0);
+  });
+});
+
+describe('BpmnCanvas — canvas interaction', () => {
+  test('the wheel zooms in when scrolling up and out when scrolling down', async () => {
+    const { modeler } = await renderCanvas();
+    const container = document.querySelector('.flex-1.relative') ?? document.body;
+    const surface = container.querySelector('div') ?? (container as HTMLElement);
+
+    const before = modeler.canvas.zoom();
+    surface.dispatchEvent(new WheelEvent('wheel', { deltaY: -120, bubbles: true }));
+    const zoomedIn = modeler.canvas.zoom();
+
+    surface.dispatchEvent(new WheelEvent('wheel', { deltaY: 120, bubbles: true }));
+    const zoomedOut = modeler.canvas.zoom();
+
+    expect(zoomedIn).toBeGreaterThanOrEqual(before);
+    expect(zoomedOut).toBeLessThanOrEqual(zoomedIn);
+  });
+
+  test('logs and keeps rendering when the XML cannot be imported', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    getProcesses.mockReturnValue([]);
+    getForms.mockReturnValue([]);
+    getTemplates.mockReturnValue([]);
+    render(
+      <BpmnCanvas
+        xml="<definitions __IMPORT_FAIL__ />"
+        endpoint="e"
+        onSave={vi.fn()}
+        onClose={vi.fn()}
+        onElementSelect={vi.fn()}
+      />
+    );
+
+    await vi.waitFor(() =>
+      expect(consoleError).toHaveBeenCalledWith('Failed to import BPMN:', expect.any(Error))
+    );
+  });
+
+  test('a selection of an element type with no custom panel injects nothing', async () => {
+    const { modeler } = await renderCanvas();
+
+    act(() =>
+      modeler.eventBus.emit('selection.changed', {
+        newSelection: [
+          { id: 'g1', type: 'bpmn:Gateway', businessObject: { get: () => undefined } },
+        ],
+      })
+    );
+
+    expect(screen.queryByText(/selector:/)).toBeNull();
+  });
+
+  test('injects nothing when the properties panel scroll container is absent', async () => {
+    const { modeler } = await renderCanvas();
+    document.querySelector('.bio-properties-panel-scroll-container')?.remove();
+
+    act(() =>
+      modeler.eventBus.emit('selection.changed', {
+        newSelection: [
+          {
+            id: 't1',
+            type: 'bpmn:UserTask',
+            businessObject: { get: () => undefined },
+          },
+        ],
+      })
+    );
+
+    expect(screen.queryByText(/Form selector/)).toBeNull();
+  });
+});
+
+describe('BpmnCanvas — deploy bundle assembly', () => {
+  const NS =
+    'xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" ' +
+    'xmlns:camunda="http://camunda.org/schema/1.0/bpmn" ' +
+    'xmlns:ronl="https://regels.overheid.nl/schema"';
+
+  function shell(extraProcessAttrs: string, body: string) {
+    return (
+      `<bpmn:definitions ${NS}><bpmn:process id="MyProcess" ronl:organization="flevoland" ` +
+      `${extraProcessAttrs}><bpmn:userTask id="t1" camunda:candidateGroups="rip-projectleider"/>` +
+      `${body}</bpmn:process></bpmn:definitions>`
+    );
+  }
+
+  function subprocess(id: string, attrs = '') {
+    return `<bpmn:definitions ${NS}><bpmn:process id="${id}" ${attrs}/></bpmn:definitions>`;
+  }
+
+  async function openModal(options: Parameters<typeof renderCanvas>[0]) {
+    const rendered = await renderCanvas(options);
+    await userEvent.click(screen.getByText('Deploy'));
+    await screen.findByText('Deploy to Operaton');
+    return rendered;
+  }
+
+  test('pulls a called subprocess into the bundle', async () => {
+    await openModal({
+      xml: shell('', '<bpmn:callActivity id="c1" calledElement="SubProc"/>'),
+      processes: [{ id: 'p2', xml: subprocess('SubProc') }],
+    });
+
+    expect(document.body.textContent).toContain('SubProc.bpmn');
+    expect(document.body.textContent).toContain('2 resource(s)');
+  });
+
+  test('omits a called subprocess that is not in local storage', async () => {
+    await openModal({
+      xml: shell('', '<bpmn:callActivity id="c1" calledElement="Missing"/>'),
+      processes: [{ id: 'p2', xml: subprocess('Other') }],
+    });
+
+    expect(document.body.textContent).not.toContain('Missing.bpmn');
+    expect(document.body.textContent).toContain('1 resource(s)');
+  });
+
+  test('accepts a single-language bundle without warning', async () => {
+    await openModal({
+      xml: shell('ronl:language="nl"', '<bpmn:callActivity id="c1" calledElement="SubProc"/>'),
+      processes: [{ id: 'p2', xml: subprocess('SubProc', 'ronl:language="nl"') }],
+    });
+
+    expect(document.body.textContent).not.toContain('Bundle mixes languages');
+  });
+
+  test('warns when the shell and its subprocess disagree on language', async () => {
+    await openModal({
+      xml: shell('ronl:language="nl"', '<bpmn:callActivity id="c1" calledElement="SubProc"/>'),
+      processes: [{ id: 'p2', xml: subprocess('SubProc', 'ronl:language="en"') }],
+    });
+
+    expect(document.body.textContent).toContain('Bundle mixes languages');
+    expect(document.body.textContent).toContain('en, nl');
+  });
+
+  test('warns when a bundled form is tagged in another language than the process', async () => {
+    await openModal({
+      xml:
+        `<bpmn:definitions ${NS}><bpmn:process id="MyProcess" ronl:organization="flevoland" ` +
+        `ronl:language="nl"><bpmn:userTask id="t1" camunda:formRef="form-1"/>` +
+        `</bpmn:process></bpmn:definitions>`,
+      forms: [{ id: 'f1', schema: { id: 'form-1' }, language: 'de' }],
+    });
+
+    expect(document.body.textContent).toContain('Bundle mixes languages');
+    expect(document.body.textContent).toContain('de, nl');
+  });
+
+  test('warns when a bundled document is tagged in another language than the process', async () => {
+    await openModal({
+      xml:
+        `<bpmn:definitions ${NS}><bpmn:process id="MyProcess" ronl:organization="flevoland" ` +
+        `ronl:language="nl"><bpmn:userTask id="t1" ronl:documentRef="doc-1"/>` +
+        `</bpmn:process></bpmn:definitions>`,
+      templates: [{ id: 'doc-1', name: 'Beschikking', language: 'en' }],
+    });
+
+    expect(document.body.textContent).toContain('Bundle mixes languages');
+    expect(document.body.textContent).toContain('en, nl');
+  });
+
+  test('a process XML with no <process> element falls back to a generic key', async () => {
+    await openModal({
+      xml: `<bpmn:definitions ${NS}><bpmn:collaboration id="c"/></bpmn:definitions>`,
+    });
+
+    expect(document.body.textContent).toContain('process key:');
+    expect(document.body.textContent).toContain('process.bpmn');
+  });
+});
+
+describe('BpmnCanvas — deploy request', () => {
+  const NS =
+    'xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" ' +
+    'xmlns:camunda="http://camunda.org/schema/1.0/bpmn" ' +
+    'xmlns:ronl="https://regels.overheid.nl/schema"';
+
+  const DEPLOYABLE =
+    `<bpmn:definitions ${NS}><bpmn:process id="MyProcess" ronl:organization="flevoland" ` +
+    `ronl:ropaRef="ropa-1"><bpmn:userTask id="t1" camunda:candidateGroups="rip-projectleider" ` +
+    `camunda:formRef="form-1" ronl:documentRef="doc-1"/>` +
+    `<bpmn:callActivity id="c1" calledElement="SubProc"/></bpmn:process></bpmn:definitions>`;
+
+  async function deploy(fetchImpl: (url: string, init?: RequestInit) => Promise<unknown>) {
+    global.fetch = vi.fn().mockImplementation(fetchImpl) as never;
+    await renderCanvas({
+      xml: DEPLOYABLE,
+      forms: [{ id: 'f1', schema: { id: 'form-1' } }],
+      templates: [{ id: 'doc-1', name: 'Beschikking' }],
+      processes: [
+        { id: 'lde-1', bpmnProcessId: 'MyProcess', xml: DEPLOYABLE },
+        {
+          id: 'p2',
+          bpmnProcessId: 'SubProc',
+          xml: `<bpmn:definitions ${NS}><bpmn:process id="SubProc"/></bpmn:definitions>`,
+        },
+      ],
+    });
+    await userEvent.click(screen.getByText('Deploy'));
+    await screen.findByText('Deploy to Operaton');
+    await userEvent.click(screen.getAllByRole('button', { name: /^Deploy$/ })[1]);
+  }
+
+  test('posts the whole bundle and records the deployment on success', async () => {
+    const calls: { url: string; body: Record<string, unknown> }[] = [];
+    await deploy(async (url, init) => {
+      calls.push({ url, body: JSON.parse(String(init?.body)) });
+      return {
+        json: async () => ({ success: true, data: { deploymentId: 'dep-42' } }),
+      };
+    });
+
+    expect((await screen.findAllByText(/Deployment ID: dep-42/)).length).toBeGreaterThan(0);
+
+    const deployCall = calls.find((c) => c.url.includes('/api/dmns/process/deploy'))!;
+    expect(deployCall.body.deploymentName).toBe('MyProcess');
+    expect(deployCall.body.boardOwner).toBe('infra-board');
+    expect(deployCall.body.organization).toBe('flevoland');
+    expect(deployCall.body.forms).toEqual([{ id: 'form-1', schema: { id: 'form-1' } }]);
+    expect((deployCall.body.documents as { id: string }[])[0].id).toBe('doc-1');
+    expect((deployCall.body.subProcesses as { filename: string }[])[0].filename).toBe(
+      'SubProc.bpmn'
+    );
+    expect(deployCall.body.operatonUrl).toBeUndefined();
+
+    await vi.waitFor(() =>
+      expect(calls.some((c) => c.url.includes('/v1/assets/bpmn/lde-1/deploy'))).toBe(true)
+    );
+    const patch = calls.find((c) => c.url.includes('/v1/assets/bpmn/lde-1/deploy'))!;
+    expect(patch.body.deploymentId).toBe('dep-42');
+    expect(patch.body.formIds).toEqual(['form-1']);
+    expect(patch.body.documentIds).toEqual(['doc-1']);
+  });
+
+  test('reports the server message when the deploy is refused', async () => {
+    await deploy(async () => ({
+      json: async () => ({ success: false, error: { message: 'engine unreachable' } }),
+    }));
+
+    expect((await screen.findAllByText(/engine unreachable/)).length).toBeGreaterThan(0);
+  });
+
+  test('falls back to a generic message when the server sends no error text', async () => {
+    await deploy(async () => ({ json: async () => ({ success: false }) }));
+
+    expect((await screen.findAllByText(/Deployment failed/)).length).toBeGreaterThan(0);
+  });
+
+  test('reports a network failure as the deploy result', async () => {
+    await deploy(async () => {
+      throw new Error('offline');
+    });
+
+    expect((await screen.findAllByText(/offline/)).length).toBeGreaterThan(0);
+  });
+
+  test('reports a non-Error rejection generically', async () => {
+    await deploy(async () => {
+      throw 'kaboom';
+    });
+
+    expect((await screen.findAllByText(/Deployment failed/)).length).toBeGreaterThan(0);
   });
 });

--- a/packages/frontend/src/components/BpmnModeler/BpmnModeler.test.tsx
+++ b/packages/frontend/src/components/BpmnModeler/BpmnModeler.test.tsx
@@ -115,6 +115,10 @@ vi.mock('./ProcessList', () => ({
       <button onClick={() => onDsoActiviteitUrnChange('urn:x')}>set-dso</button>
       <button onClick={() => onLanguageChange?.('nl')}>set-language</button>
       <button onClick={() => onOrganizationChange?.('flevoland')}>set-org</button>
+      <button onClick={() => onRopaRefChange(undefined)}>clear-ropa</button>
+      <button onClick={() => onDsoActiviteitUrnChange(undefined)}>clear-dso</button>
+      <button onClick={() => onLanguageChange?.(undefined)}>clear-language</button>
+      <button onClick={() => onOrganizationChange?.(undefined)}>clear-org</button>
     </div>
   ),
 }));
@@ -524,5 +528,252 @@ describe('BpmnModeler — close / discard-changes gate', () => {
 
     expect(window.confirm).toHaveBeenCalled();
     expect(screen.getByText('No process selected')).toBeTruthy();
+  });
+});
+
+describe('BpmnModeler — example seeding', () => {
+  test('seeds every bundled example when all stored versions are stale', async () => {
+    getProcesses.mockReturnValue([]);
+    hydrateFromServer.mockResolvedValue([]);
+    getStoredVersion.mockReturnValue(0);
+    global.fetch = vi.fn().mockResolvedValue({ text: async () => '<bpmn:definitions/>' });
+
+    render(<BpmnModeler endpoint="e" />);
+
+    await vi.waitFor(() => expect(setStoredVersion.mock.calls.length).toBeGreaterThan(4));
+
+    const seeded = saveProcess.mock.calls.map((c) => (c[0] as { id: string }).id);
+    expect(new Set(seeded).size).toBe(seeded.length);
+    expect(seeded).toContain('example_awb_process');
+    expect(seeded).toContain('example_tree_felling');
+    expect(seeded).toContain('example_awb_zorgtoeslag');
+    expect(screen.getByText(/^active:/).textContent).toBe('active:example_awb_process');
+  });
+});
+
+describe('BpmnModeler — guards and no-ops', () => {
+  function setup(processes = [process()], lookup: BpmnProcess | undefined = process()) {
+    getProcesses.mockReturnValue(processes);
+    getProcess.mockReturnValue(lookup);
+    getStoredVersion.mockReturnValue(Infinity);
+    hydrateFromServer.mockResolvedValue(processes);
+  }
+
+  test('creating a process while dirty is cancelled when the discard prompt is declined', async () => {
+    setup();
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    render(<BpmnModeler endpoint="e" />);
+
+    await userEvent.click(screen.getByText('load-p1'));
+    await userEvent.click(screen.getByText('mark-dirty'));
+    saveProcess.mockClear();
+
+    await userEvent.click(screen.getByText('create-process'));
+
+    expect(window.confirm).toHaveBeenCalled();
+    expect(saveProcess).not.toHaveBeenCalled();
+    expect(screen.getByText('active:p1')).toBeTruthy();
+  });
+
+  test('re-loading the already-active process is a no-op, even while dirty', async () => {
+    setup();
+    const confirmSpy = vi.spyOn(window, 'confirm');
+    render(<BpmnModeler endpoint="e" />);
+
+    await userEvent.click(screen.getByText('load-p1'));
+    await userEvent.click(screen.getByText('mark-dirty'));
+    await userEvent.click(screen.getByText('load-p1'));
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(screen.getByText('active:p1')).toBeTruthy();
+  });
+
+  test('loading a process that has disappeared leaves the selection untouched', async () => {
+    getProcesses.mockReturnValue([process(), process({ id: 'p2', name: 'Other' })]);
+    getProcess.mockImplementation((id: string) => (id === 'p2' ? undefined : process()));
+    getStoredVersion.mockReturnValue(Infinity);
+    hydrateFromServer.mockResolvedValue(getProcesses());
+    render(<BpmnModeler endpoint="e" />);
+
+    await userEvent.click(screen.getByText('load-p1'));
+    await userEvent.click(screen.getByText('load-p2'));
+
+    expect(screen.getByText('active:p1')).toBeTruthy();
+  });
+
+  test('saving after the process disappeared from storage writes nothing', async () => {
+    setup();
+    render(<BpmnModeler endpoint="e" />);
+
+    await userEvent.click(screen.getByText('load-p1'));
+    saveProcess.mockClear();
+    getProcess.mockReturnValue(undefined);
+
+    await userEvent.click(screen.getByText('save-canvas'));
+
+    expect(saveProcess).not.toHaveBeenCalled();
+  });
+
+  test('renaming a process that no longer exists writes nothing', async () => {
+    setup();
+    render(<BpmnModeler endpoint="e" />);
+
+    await userEvent.click(screen.getByText('load-p1'));
+    saveProcess.mockClear();
+    getProcess.mockReturnValue(undefined);
+
+    await userEvent.click(screen.getByText('rename-active'));
+
+    expect(saveProcess).not.toHaveBeenCalled();
+  });
+
+  test('footer edits are ignored while no process is active', async () => {
+    setup();
+    render(<BpmnModeler endpoint="e" />);
+
+    await userEvent.click(screen.getByText('set-ropa'));
+    await userEvent.click(screen.getByText('set-dso'));
+    await userEvent.click(screen.getByText('set-language'));
+    await userEvent.click(screen.getByText('set-org'));
+
+    expect(screen.getByText('effRopa:none')).toBeTruthy();
+    expect(screen.getByText('effDso:none')).toBeTruthy();
+    expect(screen.getByText('effLang:none')).toBeTruthy();
+    expect(screen.getByText('effOrg:none')).toBeTruthy();
+  });
+
+  test('declining the delete confirmation keeps the process', async () => {
+    setup();
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    render(<BpmnModeler endpoint="e" />);
+
+    await userEvent.click(screen.getByText('load-p1'));
+    await userEvent.click(screen.getByText('delete-p1'));
+
+    expect(deleteProcess).not.toHaveBeenCalled();
+    expect(screen.getByText('active:p1')).toBeTruthy();
+  });
+
+  test('deleting a process other than the active one keeps the selection', async () => {
+    getProcesses.mockReturnValue([process(), process({ id: 'p2', name: 'Other' })]);
+    getProcess.mockImplementation((id: string) =>
+      id === 'p2' ? process({ id: 'p2', name: 'Other' }) : process()
+    );
+    getStoredVersion.mockReturnValue(Infinity);
+    hydrateFromServer.mockResolvedValue(getProcesses());
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    render(<BpmnModeler endpoint="e" />);
+
+    await userEvent.click(screen.getByText('load-p1'));
+    await userEvent.click(screen.getByText('delete-p2'));
+
+    expect(deleteProcess).toHaveBeenCalledWith('p2');
+    expect(screen.getByText('active:p1')).toBeTruthy();
+  });
+
+  test('closing while dirty is cancelled when the discard prompt is declined', async () => {
+    setup();
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    render(<BpmnModeler endpoint="e" />);
+
+    await userEvent.click(screen.getByText('load-p1'));
+    await userEvent.click(screen.getByText('mark-dirty'));
+    await userEvent.click(screen.getByText('close-canvas'));
+
+    expect(screen.getByText('active:p1')).toBeTruthy();
+  });
+});
+
+describe('BpmnModeler — ronl:* attribute rewriting on save', () => {
+  function setup(xml: string) {
+    const p = process({ xml });
+    getProcesses.mockReturnValue([p]);
+    getProcess.mockReturnValue(p);
+    getStoredVersion.mockReturnValue(Infinity);
+    hydrateFromServer.mockResolvedValue([p]);
+  }
+
+  function savedXml(): string {
+    const call = saveProcess.mock.calls.at(-1)![0] as { xml: string };
+    return call.xml;
+  }
+
+  test('adds the ronl namespace and the attribute when neither is present', async () => {
+    setup('<bpmn:definitions><bpmn:process id="P"/></bpmn:definitions>');
+    render(<BpmnModeler endpoint="e" />);
+
+    await userEvent.click(screen.getByText('load-p1'));
+    await userEvent.click(screen.getByText('set-ropa'));
+    await userEvent.click(screen.getByText('set-dso'));
+    saveProcess.mockClear();
+    await userEvent.click(screen.getByText('save-canvas'));
+
+    expect(savedXml()).toContain('xmlns:ronl="http://ronl.nl/schema/1.0"');
+    expect(savedXml()).toContain('ronl:ropaRef="ropa-1"');
+    expect(savedXml()).toContain('ronl:dsoActiviteitUrn="urn:x"');
+  });
+
+  test('replaces an existing attribute in place, without re-declaring the namespace', async () => {
+    setup(
+      '<bpmn:definitions xmlns:ronl="http://ronl.nl/schema/1.0">' +
+        '<bpmn:process id="P" ronl:ropaRef="old"/></bpmn:definitions>'
+    );
+    render(<BpmnModeler endpoint="e" />);
+
+    await userEvent.click(screen.getByText('load-p1'));
+    await userEvent.click(screen.getByText('set-ropa'));
+    saveProcess.mockClear();
+    await userEvent.click(screen.getByText('save-canvas'));
+
+    expect(savedXml()).toContain('ronl:ropaRef="ropa-1"');
+    expect(savedXml()).not.toContain('ronl:ropaRef="old"');
+    expect(savedXml().match(/xmlns:ronl=/g)).toHaveLength(1);
+  });
+
+  test('clearing a footer field strips the attribute from the XML', async () => {
+    setup(
+      '<bpmn:definitions xmlns:ronl="http://ronl.nl/schema/1.0">' +
+        '<bpmn:process id="P" ronl:ropaRef="old" ronl:organization="flevoland"/></bpmn:definitions>'
+    );
+    render(<BpmnModeler endpoint="e" />);
+
+    await userEvent.click(screen.getByText('load-p1'));
+    await userEvent.click(screen.getByText('clear-ropa'));
+    await userEvent.click(screen.getByText('clear-org'));
+    saveProcess.mockClear();
+    await userEvent.click(screen.getByText('save-canvas'));
+
+    expect(savedXml()).not.toContain('ronl:ropaRef');
+    expect(savedXml()).not.toContain('ronl:organization');
+  });
+
+  test('clearing the language and DSO refs strips those attributes too', async () => {
+    setup(
+      '<bpmn:definitions xmlns:ronl="http://ronl.nl/schema/1.0">' +
+        '<bpmn:process id="P" ronl:language="nl" ronl:dsoActiviteitUrn="urn:x"/></bpmn:definitions>'
+    );
+    render(<BpmnModeler endpoint="e" />);
+
+    await userEvent.click(screen.getByText('load-p1'));
+    await userEvent.click(screen.getByText('clear-language'));
+    await userEvent.click(screen.getByText('clear-dso'));
+    saveProcess.mockClear();
+    await userEvent.click(screen.getByText('save-canvas'));
+
+    expect(savedXml()).not.toContain('ronl:language');
+    expect(savedXml()).not.toContain('ronl:dsoActiviteitUrn');
+  });
+
+  test('a new process whose XML declares no process id records "unknown"', async () => {
+    getProcesses.mockReturnValue([]);
+    getStoredVersion.mockReturnValue(Infinity);
+    hydrateFromServer.mockResolvedValue([]);
+    render(<BpmnModeler endpoint="e" />);
+
+    await userEvent.click(screen.getByText('create-process'));
+
+    expect(saveProcess).toHaveBeenCalledWith(
+      expect.objectContaining({ bpmnProcessId: 'DefaultProcess', processRole: 'standalone' })
+    );
   });
 });

--- a/packages/frontend/src/components/ChainBuilder/ChainBuilder.test.tsx
+++ b/packages/frontend/src/components/ChainBuilder/ChainBuilder.test.tsx
@@ -1,11 +1,41 @@
 // @vitest-environment jsdom
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
 vi.mock('../../services/defaultTestCases', () => ({
   initializeDefaultTestCases: vi.fn(),
 }));
+
+// dnd-kit gestures cannot be synthesised in jsdom; capture the handlers
+// ChainBuilder hands to DndContext and drive them directly instead.
+const dnd = vi.hoisted(() => ({
+  onDragStart: null as ((e: unknown) => void) | null,
+  onDragEnd: null as ((e: unknown) => void) | null,
+}));
+
+vi.mock('@dnd-kit/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@dnd-kit/core')>();
+  return {
+    ...actual,
+    DndContext: ({
+      children,
+      onDragStart,
+      onDragEnd,
+    }: {
+      children: React.ReactNode;
+      onDragStart: (e: unknown) => void;
+      onDragEnd: (e: unknown) => void;
+    }) => {
+      dnd.onDragStart = onDragStart;
+      dnd.onDragEnd = onDragEnd;
+      return <div>{children}</div>;
+    },
+    DragOverlay: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="drag-overlay">{children}</div>
+    ),
+  };
+});
 
 vi.mock('./SemanticView', () => ({ default: () => <div>SemanticView stub</div> }));
 
@@ -50,7 +80,14 @@ vi.mock('./ChainConfig', () => ({
     executionResult,
   }: {
     chain: { identifier: string }[];
-    validation: { isValid: boolean; missingInputs: unknown[] } | null;
+    validation: {
+      isValid: boolean;
+      isDrdCompatible: boolean;
+      missingInputs: unknown[];
+      requiredInputs: { identifier: string; type: string }[];
+      semanticMatches: unknown[];
+      warnings: { type: string; message: string }[];
+    } | null;
     inputs: Record<string, unknown>;
     onInputChange: (id: string, value: unknown) => void;
     onExecute: () => void;
@@ -68,6 +105,15 @@ vi.mock('./ChainConfig', () => ({
             })
           : 'none'}
       </div>
+      <div>drd:{validation ? String(validation.isDrdCompatible) : 'none'}</div>
+      <div>semantic:{validation ? validation.semanticMatches.length : 'none'}</div>
+      <div>
+        required:
+        {validation
+          ? validation.requiredInputs.map((r) => `${r.identifier}:${r.type}`).join(',')
+          : 'none'}
+      </div>
+      <div>warnings:{validation ? validation.warnings.map((w) => w.type).join(',') : 'none'}</div>
       <div>inputs:{JSON.stringify(inputs)}</div>
       <div>result:{executionResult ? 'has-result' : 'no-result'}</div>
       <button
@@ -114,6 +160,51 @@ vi.mock('./ChainConfig', () => ({
         }
       >
         load-drd
+      </button>
+      <button
+        onClick={() =>
+          onLoadPreset({
+            id: 't4',
+            name: 'Two-DMN preset',
+            description: 'd',
+            dmnIds: ['age-check', 'benefit-calc'],
+            type: 'sequential',
+            defaultInputs: { age: 30 },
+          })
+        }
+      >
+        load-two-dmn
+      </button>
+      <button
+        onClick={() =>
+          onLoadPreset({
+            id: 't5',
+            name: 'DRD preset, typed inputs',
+            description: 'd',
+            dmnIds: [],
+            type: 'drd',
+            drdEntryPointId: 'drd-typed',
+            drdOriginalChain: ['age-check'],
+            defaultInputs: { flag: true, count: 3, label: 'x' },
+          })
+        }
+      >
+        load-drd-typed
+      </button>
+      <button
+        onClick={() =>
+          onLoadPreset({
+            id: 't6',
+            name: 'DRD preset, no inputs',
+            description: 'd',
+            dmnIds: [],
+            type: 'drd',
+            drdEntryPointId: 'drd-bare',
+            drdOriginalChain: ['age-check'],
+          })
+        }
+      >
+        load-drd-bare
       </button>
       <button onClick={() => onInputChange('extra', 'x')}>change-input</button>
       <button onClick={onExecute}>execute</button>
@@ -320,5 +411,330 @@ describe('ChainBuilder — execution', () => {
     await vi.waitFor(() =>
       expect(alertSpy).toHaveBeenCalledWith('Execution failed: DMN engine unavailable')
     );
+  });
+});
+
+describe('ChainBuilder — degraded backend responses', () => {
+  test('a semantic-links payload reporting success: false leaves the links empty', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('/api/dmns/enhanced-chain-links')) {
+        return Promise.resolve({
+          json: async () => ({ success: false, error: 'links unavailable' }),
+        });
+      }
+      return fetchMock()(url);
+    });
+
+    render(<ChainBuilder endpoint="e" />);
+    await screen.findByText('dmns:1 loading:false');
+
+    expect(consoleError).toHaveBeenCalledWith(
+      '[SemanticLinks] Failed to load:',
+      'links unavailable'
+    );
+  });
+
+  test('a semantic-links fetch that rejects leaves the links empty', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('/api/dmns/enhanced-chain-links')) {
+        return Promise.reject(new Error('links down'));
+      }
+      return fetchMock()(url);
+    });
+
+    render(<ChainBuilder endpoint="e" />);
+    await screen.findByText('dmns:1 loading:false');
+
+    expect(consoleError).toHaveBeenCalledWith('[SemanticLinks] Error:', expect.any(Error));
+  });
+
+  test('a DMN payload reporting success: false degrades to an empty list', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('/api/dmns?')) {
+        return Promise.resolve({ json: async () => ({ success: false, error: 'no dmns' }) });
+      }
+      return Promise.resolve({ json: async () => ({ success: true, data: [] }) });
+    });
+
+    render(<ChainBuilder endpoint="e" />);
+
+    expect(await screen.findByText('dmns:0 loading:false')).toBeTruthy();
+  });
+});
+
+describe('ChainBuilder — chain validation', () => {
+  /** Two DMNs where the second consumes what the first produces. */
+  function twoDmnFetch(
+    secondInputs: { identifier: string; title: string; type: string }[],
+    links: unknown[] = []
+  ) {
+    return vi.fn().mockImplementation((url: string) => {
+      if (url.includes('/api/dmns?')) {
+        return Promise.resolve({
+          json: async () => ({
+            success: true,
+            data: {
+              dmns: [
+                {
+                  id: 'd1',
+                  identifier: 'age-check',
+                  title: 'Age check',
+                  inputs: [{ identifier: 'age', title: 'Age', type: 'Integer' }],
+                  outputs: [{ identifier: 'eligible', title: 'Eligible', type: 'Boolean' }],
+                },
+                {
+                  id: 'd2',
+                  identifier: 'benefit-calc',
+                  title: 'Benefit calculation',
+                  inputs: secondInputs,
+                  outputs: [{ identifier: 'amount', title: 'Amount', type: 'Double' }],
+                },
+              ],
+            },
+          }),
+        });
+      }
+      if (url.includes('/api/dmns/enhanced-chain-links')) {
+        return Promise.resolve({ json: async () => ({ success: true, data: links }) });
+      }
+      return Promise.reject(new Error(`unexpected fetch url: ${url}`));
+    });
+  }
+
+  test('an exact output-to-input match does not ask the user for the value', async () => {
+    global.fetch = twoDmnFetch([{ identifier: 'eligible', title: 'Eligible', type: 'Boolean' }]);
+    render(<ChainBuilder endpoint="e" />);
+    await screen.findByText('dmns:2 loading:false');
+
+    await userEvent.click(screen.getByText('load-two-dmn'));
+
+    expect(screen.getByText('required:age:Integer')).toBeTruthy();
+    expect(screen.getByText('drd:true')).toBeTruthy();
+  });
+
+  test('a semantic match satisfies the input but marks the chain DRD-incompatible', async () => {
+    global.fetch = twoDmnFetch(
+      [{ identifier: 'isEligible', title: 'Is eligible', type: 'Boolean' }],
+      [
+        {
+          dmn1: { identifier: 'age-check' },
+          dmn2: { identifier: 'benefit-calc' },
+          inputVariable: 'isEligible',
+          outputVariable: 'eligible',
+          matchType: 'semantic',
+          sharedConcept: 'https://example.org/concept/Eligibility',
+        },
+      ]
+    );
+    render(<ChainBuilder endpoint="e" />);
+    await screen.findByText('dmns:2 loading:false');
+
+    await userEvent.click(screen.getByText('load-two-dmn'));
+
+    expect(screen.getByText('semantic:1')).toBeTruthy();
+    expect(screen.getByText('drd:false')).toBeTruthy();
+    expect(screen.getByText('required:age:Integer')).toBeTruthy();
+  });
+
+  test('an unmatched input on the second DMN is asked of the user', async () => {
+    global.fetch = twoDmnFetch([{ identifier: 'region', title: 'Region', type: 'String' }]);
+    render(<ChainBuilder endpoint="e" />);
+    await screen.findByText('dmns:2 loading:false');
+
+    await userEvent.click(screen.getByText('load-two-dmn'));
+
+    expect(screen.getByText('required:age:Integer,region:String')).toBeTruthy();
+    expect(screen.getByText('validation:{"isValid":false,"missing":1}')).toBeTruthy();
+  });
+
+  test('Boolean and Date inputs are required but not counted as missing', async () => {
+    global.fetch = twoDmnFetch([
+      { identifier: 'consent', title: 'Consent', type: 'Boolean' },
+      { identifier: 'since', title: 'Since', type: 'Date' },
+    ]);
+    render(<ChainBuilder endpoint="e" />);
+    await screen.findByText('dmns:2 loading:false');
+
+    await userEvent.click(screen.getByText('load-two-dmn'));
+
+    expect(screen.getByText('required:age:Integer,consent:Boolean,since:Date')).toBeTruthy();
+    expect(screen.getByText('validation:{"isValid":true,"missing":0}')).toBeTruthy();
+  });
+
+  test('two DMNs producing the same output raise a duplicate warning', async () => {
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('/api/dmns?')) {
+        return Promise.resolve({
+          json: async () => ({
+            success: true,
+            data: {
+              dmns: [
+                {
+                  id: 'd1',
+                  identifier: 'age-check',
+                  title: 'Age check',
+                  inputs: [{ identifier: 'age', title: 'Age', type: 'Integer' }],
+                  outputs: [{ identifier: 'eligible', title: 'Eligible', type: 'Boolean' }],
+                },
+                {
+                  id: 'd2',
+                  identifier: 'benefit-calc',
+                  title: 'Benefit calculation',
+                  inputs: [{ identifier: 'eligible', title: 'Eligible', type: 'Boolean' }],
+                  outputs: [{ identifier: 'eligible', title: 'Eligible', type: 'Boolean' }],
+                },
+              ],
+            },
+          }),
+        });
+      }
+      return Promise.resolve({ json: async () => ({ success: true, data: [] }) });
+    });
+    render(<ChainBuilder endpoint="e" />);
+    await screen.findByText('dmns:2 loading:false');
+
+    await userEvent.click(screen.getByText('load-two-dmn'));
+
+    expect(screen.getByText('warnings:duplicate_dmn,duplicate_dmn')).toBeTruthy();
+  });
+
+  test('a single-DMN chain warns that orchestration adds little', async () => {
+    global.fetch = fetchMock();
+    render(<ChainBuilder endpoint="e" />);
+    await screen.findByText('dmns:1 loading:false');
+
+    await userEvent.click(screen.getByText('load-sequential'));
+
+    expect(screen.getByText('warnings:performance')).toBeTruthy();
+  });
+});
+
+describe('ChainBuilder — DRD presets', () => {
+  test('a DRD preset derives synthetic input types from its default values', async () => {
+    global.fetch = fetchMock();
+    render(<ChainBuilder endpoint="e" />);
+    await screen.findByText('dmns:1 loading:false');
+
+    await userEvent.click(screen.getByText('load-drd-typed'));
+
+    expect(screen.getByText('required:flag:Boolean,count:Integer,label:String')).toBeTruthy();
+  });
+
+  test('a DRD preset without default inputs loads with an empty input set', async () => {
+    global.fetch = fetchMock();
+    render(<ChainBuilder endpoint="e" />);
+    await screen.findByText('dmns:1 loading:false');
+
+    await userEvent.click(screen.getByText('load-drd-bare'));
+
+    expect(screen.getByText('chain:drd-bare')).toBeTruthy();
+    expect(screen.getByText('inputs:{}')).toBeTruthy();
+    expect(screen.getByText('required:')).toBeTruthy();
+  });
+});
+
+describe('ChainBuilder — drag and drop', () => {
+  async function renderLoaded() {
+    global.fetch = fetchMock();
+    render(<ChainBuilder endpoint="e" />);
+    await screen.findByText('dmns:1 loading:false');
+  }
+
+  test('a drop outside any droppable leaves the chain untouched', async () => {
+    await renderLoaded();
+
+    act(() => dnd.onDragEnd!({ active: { id: 'age-check' }, over: null }));
+
+    expect(screen.getByText('composer-chain:')).toBeTruthy();
+  });
+
+  test('dropping a DMN on the chain droppable appends it', async () => {
+    await renderLoaded();
+
+    act(() => dnd.onDragEnd!({ active: { id: 'age-check' }, over: { id: 'chain-droppable' } }));
+
+    expect(screen.getByText('composer-chain:age-check')).toBeTruthy();
+  });
+
+  test('dropping a DMN already in the chain does not duplicate it', async () => {
+    await renderLoaded();
+
+    act(() => dnd.onDragEnd!({ active: { id: 'age-check' }, over: { id: 'chain-droppable' } }));
+    act(() => dnd.onDragEnd!({ active: { id: 'age-check' }, over: { id: 'chain-droppable' } }));
+
+    expect(screen.getByText('composer-chain:age-check')).toBeTruthy();
+  });
+
+  test('dropping one chained DMN onto another reorders the chain', async () => {
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('/api/dmns?')) {
+        return Promise.resolve({
+          json: async () => ({
+            success: true,
+            data: {
+              dmns: [
+                {
+                  id: 'd1',
+                  identifier: 'age-check',
+                  title: 'Age check',
+                  inputs: [],
+                  outputs: [],
+                },
+                {
+                  id: 'd2',
+                  identifier: 'benefit-calc',
+                  title: 'Benefit calculation',
+                  inputs: [],
+                  outputs: [],
+                },
+              ],
+            },
+          }),
+        });
+      }
+      return Promise.resolve({ json: async () => ({ success: true, data: [] }) });
+    });
+    render(<ChainBuilder endpoint="e" />);
+    await screen.findByText('dmns:2 loading:false');
+
+    act(() => dnd.onDragEnd!({ active: { id: 'age-check' }, over: { id: 'chain-droppable' } }));
+    act(() => dnd.onDragEnd!({ active: { id: 'benefit-calc' }, over: { id: 'chain-droppable' } }));
+    expect(screen.getByText('composer-chain:age-check,benefit-calc')).toBeTruthy();
+
+    act(() => dnd.onDragEnd!({ active: { id: 'benefit-calc' }, over: { id: 'age-check' } }));
+
+    expect(screen.getByText('composer-chain:benefit-calc,age-check')).toBeTruthy();
+  });
+
+  test('dropping a chained DMN back onto itself leaves the order unchanged', async () => {
+    await renderLoaded();
+    act(() => dnd.onDragEnd!({ active: { id: 'age-check' }, over: { id: 'chain-droppable' } }));
+
+    act(() => dnd.onDragEnd!({ active: { id: 'age-check' }, over: { id: 'age-check' } }));
+
+    expect(screen.getByText('composer-chain:age-check')).toBeTruthy();
+  });
+
+  test('the drag overlay previews the DMN being dragged, and clears on drop', async () => {
+    await renderLoaded();
+
+    act(() => dnd.onDragStart!({ active: { id: 'age-check' } }));
+    const overlay = screen.getByTestId('drag-overlay');
+    expect(overlay.textContent).toContain('age-check');
+    expect(overlay.textContent).toContain('1 inputs → 1 outputs');
+
+    act(() => dnd.onDragEnd!({ active: { id: 'age-check' }, over: null }));
+    expect(screen.getByTestId('drag-overlay').textContent).toBe('');
+  });
+
+  test('the drag overlay stays empty for an id that matches no DMN', async () => {
+    await renderLoaded();
+
+    act(() => dnd.onDragStart!({ active: { id: 'ghost' } }));
+
+    expect(screen.getByTestId('drag-overlay').textContent).toBe('');
   });
 });

--- a/packages/frontend/src/components/ChainBuilder/ChainComposer.test.tsx
+++ b/packages/frontend/src/components/ChainBuilder/ChainComposer.test.tsx
@@ -330,7 +330,8 @@ describe('ChainComposer', () => {
       Array.from({ length: 5 }, (_, i) => ({
         identifier: `${prefix}${i}`,
         title: `${prefix}${i}`,
-        type: 'String',
+        // as const: DmnVariable.type is a union, and a bare literal widens to string.
+        type: 'String' as const,
       }));
 
     renderChain([dmn({ inputs: many('in'), outputs: many('out') })]);
@@ -343,7 +344,10 @@ describe('ChainComposer', () => {
 
   test('uses the singular noun for exactly one missing input', () => {
     renderChain([dmn()], {
-      validation: validation({ isValid: false, missingInputs: ['age'] }),
+      validation: validation({
+        isValid: false,
+        missingInputs: [{ identifier: 'age', title: 'Age', type: 'Integer', requiredBy: 'dmn-1' }],
+      }),
     });
     expect(screen.getByText(/^1 input required$/)).toBeTruthy();
   });
@@ -357,6 +361,7 @@ describe('ChainComposer', () => {
             outputVar: 'x',
             inputDmn: 'b',
             inputVar: 'y',
+            matchType: 'semantic' as const,
             semanticConcept: 'https://example.org/concept/Age',
           },
         ],

--- a/packages/frontend/src/components/ChainBuilder/ChainComposer.test.tsx
+++ b/packages/frontend/src/components/ChainBuilder/ChainComposer.test.tsx
@@ -1,7 +1,34 @@
 // @vitest-environment jsdom
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+// dnd-kit reports drag/hover state only inside a live DndContext gesture;
+// drive both directly so the styling branches are reachable.
+const dndState = vi.hoisted(() => ({ isDragging: false, isOver: false }));
+
+vi.mock('@dnd-kit/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@dnd-kit/core')>();
+  return {
+    ...actual,
+    useDroppable: () => ({ setNodeRef: () => {}, isOver: dndState.isOver }),
+  };
+});
+
+vi.mock('@dnd-kit/sortable', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@dnd-kit/sortable')>();
+  return {
+    ...actual,
+    useSortable: () => ({
+      attributes: {},
+      listeners: {},
+      setNodeRef: () => {},
+      transform: null,
+      transition: undefined,
+      isDragging: dndState.isDragging,
+    }),
+  };
+});
 
 vi.mock('./VendorModal', () => ({
   default: ({ dmnTitle, onClose }: { dmnTitle: string; onClose: () => void }) => (
@@ -41,6 +68,11 @@ function validation(overrides: Partial<ChainValidation> = {}): ChainValidation {
     ...overrides,
   };
 }
+
+beforeEach(() => {
+  dndState.isDragging = false;
+  dndState.isOver = false;
+});
 
 describe('ChainComposer', () => {
   test('shows an empty-state message when the chain has no DMNs', () => {
@@ -199,5 +231,147 @@ describe('ChainComposer', () => {
 
     await userEvent.click(screen.getByText('3'));
     expect(screen.getByText('Vendor modal: Age check')).toBeTruthy();
+  });
+
+  function renderChain(dmns: DmnModel[], overrides: Record<string, unknown> = {}) {
+    return render(
+      <ChainComposer
+        chain={dmns}
+        onRemoveDmn={vi.fn()}
+        onClearChain={vi.fn()}
+        validation={null}
+        endpoint="e"
+        {...overrides}
+      />
+    );
+  }
+
+  test('dims and outlines the card being dragged', () => {
+    dndState.isDragging = true;
+    const { container } = renderChain([dmn()]);
+
+    const wrapper = container.querySelector('[style*="opacity"]') as HTMLElement;
+    expect(wrapper.getAttribute('style')).toContain('opacity: 0.5');
+    expect(container.querySelector('.border-blue-500')).not.toBeNull();
+  });
+
+  test('tints the drop zone while a DMN hovers over it', () => {
+    dndState.isOver = true;
+    const { container } = renderChain([]);
+    expect(container.querySelector('.bg-blue-50')).not.toBeNull();
+  });
+
+  test('renders the description, organization logo and name of a chained DMN', () => {
+    renderChain([
+      dmn({
+        description: 'Checks the applicant age',
+        logoUrl: 'https://cdn.example.org/svb.png',
+        organizationName: 'SVB',
+      }),
+    ]);
+
+    expect(screen.getByText('Checks the applicant age')).toBeTruthy();
+    expect(screen.getByAltText('SVB')).toBeTruthy();
+    expect(screen.getByText('SVB')).toBeTruthy();
+  });
+
+  test('hides a logo that fails to load', () => {
+    renderChain([dmn({ logoUrl: 'https://cdn.example.org/broken.png' })]);
+
+    const logo = screen.getByAltText('Organization');
+    fireEvent.error(logo);
+
+    expect(logo.style.display).toBe('none');
+  });
+
+  test('shows the organization name on its own when there is no logo', () => {
+    renderChain([dmn({ organizationName: 'UWV' })]);
+
+    expect(screen.getByText('UWV')).toBeTruthy();
+    expect(screen.queryByRole('img')).toBeNull();
+  });
+
+  test('styles a non-DRD deployment id in neutral colours and omits the cockpit link', () => {
+    const { container } = renderChain([dmn({ deploymentId: 'abcdef0123456789' })]);
+
+    expect(screen.getByText('abcdef01...')).toBeTruthy();
+    expect(container.querySelector('.bg-slate-100.text-slate-700')).not.toBeNull();
+    expect(screen.queryByTitle('View in Operaton Cockpit')).toBeNull();
+    expect(screen.getByText('abcdef0123456789')).toBeTruthy();
+  });
+
+  test('links the API endpoint a DMN declares', () => {
+    renderChain([dmn({ implementedBy: 'https://api.example.org/age-check' })]);
+
+    const link = screen.getByTitle('Open API endpoint in new tab');
+    expect(link.getAttribute('href')).toBe('https://api.example.org/age-check');
+  });
+
+  test('pluralises the input and output counts', () => {
+    renderChain([
+      dmn({
+        inputs: [
+          { identifier: 'age', title: 'Age', type: 'Integer' },
+          { identifier: 'income', title: 'Income', type: 'Double' },
+        ],
+        outputs: [
+          { identifier: 'a', title: 'A', type: 'Boolean' },
+          { identifier: 'b', title: 'B', type: 'Boolean' },
+        ],
+      }),
+    ]);
+
+    expect(screen.getByText(/2 inputs/)).toBeTruthy();
+    expect(screen.getByText(/2 outputs/)).toBeTruthy();
+  });
+
+  test('lists the first three inputs and outputs, summarising the rest', () => {
+    const many = (prefix: string) =>
+      Array.from({ length: 5 }, (_, i) => ({
+        identifier: `${prefix}${i}`,
+        title: `${prefix}${i}`,
+        type: 'String',
+      }));
+
+    renderChain([dmn({ inputs: many('in'), outputs: many('out') })]);
+
+    expect(screen.getByText(/• in0/)).toBeTruthy();
+    expect(screen.getByText(/• in2/)).toBeTruthy();
+    expect(screen.queryByText(/• in3/)).toBeNull();
+    expect(screen.getAllByText('+2 more...')).toHaveLength(2);
+  });
+
+  test('uses the singular noun for exactly one missing input', () => {
+    renderChain([dmn()], {
+      validation: validation({ isValid: false, missingInputs: ['age'] }),
+    });
+    expect(screen.getByText(/^1 input required$/)).toBeTruthy();
+  });
+
+  test('uses the singular noun for exactly one semantic link', () => {
+    renderChain([dmn()], {
+      validation: validation({
+        semanticMatches: [
+          {
+            outputDmn: 'a',
+            outputVar: 'x',
+            inputDmn: 'b',
+            inputVar: 'y',
+            semanticConcept: 'https://example.org/concept/Age',
+          },
+        ],
+      }),
+    });
+    expect(screen.getByText(/1 semantic link detected/)).toBeTruthy();
+  });
+
+  test('hides the validation badge for a DMN that was never validated', () => {
+    renderChain([dmn({ validationStatus: 'not-validated' })]);
+    expect(screen.queryByText('Gevalideerd')).toBeNull();
+  });
+
+  test('hides the vendor badge when the DMN reports no vendors', () => {
+    renderChain([dmn({ vendorCount: 0 })]);
+    expect(screen.queryByText('0')).toBeNull();
   });
 });

--- a/packages/frontend/src/components/ChainBuilder/DmnList.test.tsx
+++ b/packages/frontend/src/components/ChainBuilder/DmnList.test.tsx
@@ -1,7 +1,27 @@
 // @vitest-environment jsdom
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+// dnd-kit only reports a transform mid-gesture; drive that state directly.
+const draggableState = vi.hoisted(() => ({
+  transform: null as { x: number; y: number; scaleX: number; scaleY: number } | null,
+  isDragging: false,
+}));
+
+vi.mock('@dnd-kit/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@dnd-kit/core')>();
+  return {
+    ...actual,
+    useDraggable: () => ({
+      attributes: {},
+      listeners: {},
+      setNodeRef: () => {},
+      transform: draggableState.transform,
+      isDragging: draggableState.isDragging,
+    }),
+  };
+});
 
 vi.mock('./VendorModal', () => ({
   default: ({ dmnTitle, onClose }: { dmnTitle: string; onClose: () => void }) => (
@@ -25,6 +45,11 @@ function dmn(overrides: Partial<DmnModel> = {}): DmnModel {
     ...overrides,
   };
 }
+
+beforeEach(() => {
+  draggableState.transform = null;
+  draggableState.isDragging = false;
+});
 
 describe('DmnList', () => {
   test('shows a skeleton loading state', () => {
@@ -118,5 +143,146 @@ describe('DmnList', () => {
       />
     );
     expect(screen.getByText('Gevalideerd')).toBeTruthy();
+  });
+
+  test('follows the pointer and dims the card being dragged', () => {
+    draggableState.transform = { x: 12, y: -4, scaleX: 1, scaleY: 1 };
+    draggableState.isDragging = true;
+
+    const { container } = render(
+      <DmnList dmns={[dmn()]} usedDmnIds={[]} isLoading={false} endpoint="e" />
+    );
+
+    const card = container.querySelector('[style*="translate3d"]') as HTMLElement;
+    expect(card.getAttribute('style')).toContain('translate3d(12px, -4px, 0)');
+    expect(card.getAttribute('style')).toContain('opacity: 0.5');
+  });
+
+  test('keeps a transformed card at full opacity when it is not the one being dragged', () => {
+    draggableState.transform = { x: 3, y: 3, scaleX: 1, scaleY: 1 };
+
+    const { container } = render(
+      <DmnList dmns={[dmn()]} usedDmnIds={[]} isLoading={false} endpoint="e" />
+    );
+
+    expect(
+      (container.querySelector('[style*="translate3d"]') as HTMLElement).getAttribute('style')
+    ).toContain('opacity: 1');
+  });
+
+  test('renders the organization logo and name when the DMN carries them', () => {
+    render(
+      <DmnList
+        dmns={[dmn({ logoUrl: 'https://cdn.example.org/svb.png', organizationName: 'SVB' })]}
+        usedDmnIds={[]}
+        isLoading={false}
+        endpoint="e"
+      />
+    );
+
+    const logo = screen.getByAltText('SVB');
+    expect(logo.getAttribute('src')).toBe('https://cdn.example.org/svb.png');
+    expect(screen.getByText('SVB')).toBeTruthy();
+  });
+
+  test('labels a logo generically when the DMN names no organization', () => {
+    render(
+      <DmnList
+        dmns={[dmn({ logoUrl: 'https://cdn.example.org/anon.png' })]}
+        usedDmnIds={[]}
+        isLoading={false}
+        endpoint="e"
+      />
+    );
+
+    const logo = screen.getByAltText('Organization logo');
+    expect(logo.getAttribute('title')).toBe('Organization');
+  });
+
+  test('replaces a broken logo with the identifier initials', () => {
+    render(
+      <DmnList
+        dmns={[dmn({ logoUrl: 'https://cdn.example.org/broken.png' })]}
+        usedDmnIds={[]}
+        isLoading={false}
+        endpoint="e"
+      />
+    );
+
+    const logo = screen.getByAltText('Organization logo');
+    fireEvent.error(logo);
+
+    expect(logo.style.display).toBe('none');
+    expect(screen.getByText('ag')).toBeTruthy();
+  });
+
+  test('shows the initials placeholder when the DMN has no logo', () => {
+    render(<DmnList dmns={[dmn()]} usedDmnIds={[]} isLoading={false} endpoint="e" />);
+    expect(screen.getByText('ag')).toBeTruthy();
+  });
+
+  test('pluralises the input and output counts', () => {
+    render(
+      <DmnList
+        dmns={[
+          dmn({
+            inputs: [
+              { identifier: 'age', title: 'Age', type: 'Integer' },
+              { identifier: 'income', title: 'Income', type: 'Double' },
+            ],
+            outputs: [
+              { identifier: 'a', title: 'A', type: 'Boolean' },
+              { identifier: 'b', title: 'B', type: 'Boolean' },
+            ],
+          }),
+        ]}
+        usedDmnIds={[]}
+        isLoading={false}
+        endpoint="e"
+      />
+    );
+    expect(screen.getByText('2 inputs → 2 outputs')).toBeTruthy();
+  });
+
+  test('search matches an output variable name', async () => {
+    render(
+      <DmnList
+        dmns={[
+          dmn({ identifier: 'age-check' }),
+          dmn({
+            identifier: 'income-check',
+            inputs: [{ identifier: 'salary', title: 'Salary', type: 'Integer' }],
+            outputs: [{ identifier: 'meetsThreshold', title: 'Meets', type: 'Boolean' }],
+          }),
+        ]}
+        usedDmnIds={[]}
+        isLoading={false}
+        endpoint="e"
+      />
+    );
+
+    await userEvent.type(screen.getByPlaceholderText('Search DMNs...'), 'meetsthreshold');
+
+    expect(screen.getByText('income-check')).toBeTruthy();
+    expect(screen.queryByText('age-check')).toBeNull();
+  });
+
+  test('hides the vendor badge when the DMN reports no vendors', () => {
+    render(
+      <DmnList dmns={[dmn({ vendorCount: 0 })]} usedDmnIds={[]} isLoading={false} endpoint="e" />
+    );
+    expect(screen.queryByText('0')).toBeNull();
+  });
+
+  test('hides the validation badge for a DMN that was never validated', () => {
+    render(
+      <DmnList
+        dmns={[dmn({ validationStatus: 'not-validated' })]}
+        usedDmnIds={[]}
+        isLoading={false}
+        endpoint="e"
+      />
+    );
+    expect(screen.queryByText('Gevalideerd')).toBeNull();
   });
 });

--- a/packages/frontend/src/components/ChainBuilder/InputForm.test.tsx
+++ b/packages/frontend/src/components/ChainBuilder/InputForm.test.tsx
@@ -171,4 +171,164 @@ describe('InputForm', () => {
     expect(getCombinedTestData).toHaveBeenCalledWith(['age-check']);
     expect(onInputChange).toHaveBeenCalledWith('age', 30);
   });
+
+  test('renders a decimal input for Double and parses it as a float', async () => {
+    const onInputChange = vi.fn();
+    render(
+      <InputForm
+        chain={[]}
+        inputs={{ income: 1234.5 }}
+        onInputChange={onInputChange}
+        validation={validation([
+          { identifier: 'income', title: 'Income', type: 'Double', requiredBy: 'dmn-1' },
+        ])}
+      />
+    );
+
+    const field = screen.getByDisplayValue('1234.5');
+    expect(field.getAttribute('step')).toBe('0.01');
+
+    await userEvent.clear(field);
+    expect(onInputChange).toHaveBeenLastCalledWith('income', 0);
+  });
+
+  test('an empty Double field renders blank rather than NaN', () => {
+    render(
+      <InputForm
+        chain={[]}
+        inputs={{}}
+        onInputChange={vi.fn()}
+        validation={validation([
+          { identifier: 'income', title: 'Income', type: 'Double', requiredBy: 'dmn-1' },
+        ])}
+      />
+    );
+    expect(screen.getByPlaceholderText('Enter income')).toHaveValue(null);
+  });
+
+  test('clearing an Integer field reports 0 rather than NaN', async () => {
+    const onInputChange = vi.fn();
+    render(
+      <InputForm
+        chain={[]}
+        inputs={{ age: 42 }}
+        onInputChange={onInputChange}
+        validation={validation([
+          { identifier: 'age', title: 'Age', type: 'Integer', requiredBy: 'dmn-1' },
+        ])}
+      />
+    );
+
+    await userEvent.clear(screen.getByDisplayValue('42'));
+    expect(onInputChange).toHaveBeenLastCalledWith('age', 0);
+  });
+
+  test('an unset Date field renders empty and reports the picked date', async () => {
+    const onInputChange = vi.fn();
+    const { container } = render(
+      <InputForm
+        chain={[]}
+        inputs={{}}
+        onInputChange={onInputChange}
+        validation={validation([
+          { identifier: 'birthdate', title: 'Birthdate', type: 'Date', requiredBy: 'dmn-1' },
+        ])}
+      />
+    );
+
+    const field = container.querySelector('input[type="date"]') as HTMLInputElement;
+    expect(field.value).toBe('');
+
+    await userEvent.type(field, '2020-01-01');
+    expect(onInputChange).toHaveBeenLastCalledWith('birthdate', '2020-01-01');
+  });
+
+  test('falls back to a text input for an unrecognised type', async () => {
+    const onInputChange = vi.fn();
+    render(
+      <InputForm
+        chain={[]}
+        inputs={{}}
+        onInputChange={onInputChange}
+        validation={validation([
+          {
+            identifier: 'bsn',
+            title: 'BSN',
+            type: 'Duration' as RequiredInput['type'],
+            requiredBy: 'dmn-1',
+          },
+        ])}
+      />
+    );
+
+    await userEvent.type(screen.getByPlaceholderText('Enter bsn'), '1');
+    expect(onInputChange).toHaveBeenLastCalledWith('bsn', '1');
+  });
+
+  test('renders an input description when the RDF supplies one', () => {
+    render(
+      <InputForm
+        chain={[]}
+        inputs={{}}
+        onInputChange={vi.fn()}
+        validation={validation([
+          {
+            identifier: 'name',
+            title: 'Name',
+            type: 'String',
+            requiredBy: 'dmn-1',
+            description: 'Full legal name as registered',
+          },
+        ])}
+      />
+    );
+    expect(screen.getByText('Full legal name as registered')).toBeTruthy();
+  });
+
+  test('"Fill with test data" clears Date inputs that carry no RDF test value', async () => {
+    const onInputChange = vi.fn();
+    render(
+      <InputForm
+        chain={[dmn()]}
+        inputs={{}}
+        onInputChange={onInputChange}
+        validation={validation([
+          { identifier: 'age', title: 'Age', type: 'Integer', requiredBy: 'dmn-1', testValue: 21 },
+          { identifier: 'since', title: 'Since', type: 'Date', requiredBy: 'dmn-1' },
+        ])}
+      />
+    );
+
+    await userEvent.click(screen.getByText(/Fill with test data/));
+
+    expect(onInputChange).toHaveBeenCalledWith('age', 21);
+    expect(onInputChange).toHaveBeenCalledWith('since', null);
+    expect(getCombinedTestData).not.toHaveBeenCalled();
+  });
+
+  test('pluralises the DMN count on the test-data button', () => {
+    const { rerender } = render(
+      <InputForm
+        chain={[dmn()]}
+        inputs={{}}
+        onInputChange={vi.fn()}
+        validation={validation([
+          { identifier: 'name', title: 'Name', type: 'String', requiredBy: 'dmn-1' },
+        ])}
+      />
+    );
+    expect(screen.getByText('Fill with test data (1 DMN)')).toBeTruthy();
+
+    rerender(
+      <InputForm
+        chain={[dmn(), dmn({ identifier: 'income-check' })]}
+        inputs={{}}
+        onInputChange={vi.fn()}
+        validation={validation([
+          { identifier: 'name', title: 'Name', type: 'String', requiredBy: 'dmn-1' },
+        ])}
+      />
+    );
+    expect(screen.getByText('Fill with test data (2 DMNs)')).toBeTruthy();
+  });
 });

--- a/packages/frontend/src/components/Changelog.test.tsx
+++ b/packages/frontend/src/components/Changelog.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, test, vi } from 'vitest';
 
@@ -29,6 +29,17 @@ vi.mock('../changelog.json', () => ({
         ],
       },
       {
+        // Deliberately malformed: an unrecognised scope, an unrecognised
+        // commit type and an unrecognised status all reach the renderer
+        // because changelog.json is untyped JSON cast at the boundary.
+        format: 'commits',
+        version: '2026.06.9',
+        status: 'Withdrawn',
+        date: '3 jun 2026',
+        scope: 'kernel',
+        commits: [{ sha: 'aaa0000', author: 'Nobody', type: 'perf', subject: 'A lone commit' }],
+      },
+      {
         version: '1.0.0',
         status: 'Released',
         statusColor: 'green',
@@ -40,6 +51,21 @@ vi.mock('../changelog.json', () => ({
             iconColor: 'green',
             title: 'Initial release',
             items: ['First item', 'Second item'],
+          },
+        ],
+      },
+      {
+        version: '0.9.0',
+        status: 'Archived',
+        statusColor: 'chartreuse',
+        borderColor: 'chartreuse',
+        date: '1 dec 2025',
+        sections: [
+          {
+            icon: '📦',
+            iconColor: 'chartreuse',
+            title: 'Preview',
+            items: ['Preview item'],
           },
         ],
       },
@@ -89,9 +115,57 @@ describe('Changelog', () => {
     render(<Changelog />);
     await userEvent.click(screen.getByText('v1.0.0'));
 
-    expect(screen.queryByText('Full-stack')).toBeNull();
+    const card = screen.getByText('v1.0.0').closest('.rounded-lg.border-2') as HTMLElement;
+    expect(within(card).queryByText('Full-stack')).toBeNull();
     expect(screen.getByText('Initial release')).toBeTruthy();
     expect(screen.getByText('First item')).toBeTruthy();
     expect(screen.getByText('Second item')).toBeTruthy();
+  });
+
+  test('falls back to the full-stack badge for an unrecognised scope', async () => {
+    render(<Changelog />);
+    await userEvent.click(screen.getByText('v2026.06.9'));
+
+    expect(screen.getByText('Full-stack')).toBeTruthy();
+  });
+
+  test('falls back to the generic commit icon for an unrecognised commit type', async () => {
+    render(<Changelog />);
+    await userEvent.click(screen.getByText('v2026.06.9'));
+
+    const heading = screen.getByText('A lone commit');
+    expect(heading.className).toContain('text-gray-700');
+    expect(heading.parentElement?.previousElementSibling?.textContent).toBe('📄');
+  });
+
+  test('uses the singular noun for a version with exactly one commit', () => {
+    render(<Changelog />);
+    expect(screen.getByText(/· 1 commit$/)).toBeTruthy();
+  });
+
+  test('falls back to grey styling for an unrecognised commits-format status', () => {
+    render(<Changelog />);
+
+    const badge = screen.getByText('Withdrawn');
+    expect(badge.className).toContain('bg-gray-100');
+    const card = badge.closest('.rounded-lg.border-2') as HTMLElement;
+    expect(card.className).toContain('border-gray-200');
+  });
+
+  test('falls back to grey styling for an unrecognised legacy colour key', () => {
+    render(<Changelog />);
+
+    const badge = screen.getByText('Archived');
+    expect(badge.className).toContain('bg-gray-100');
+    const card = badge.closest('.rounded-lg.border-2') as HTMLElement;
+    expect(card.className).toContain('border-gray-200');
+  });
+
+  test('falls back to grey for an unrecognised legacy section icon colour', async () => {
+    render(<Changelog />);
+    await userEvent.click(screen.getByText('v0.9.0'));
+
+    const icon = screen.getByText('📦');
+    expect(icon.className).toContain('text-gray-600');
   });
 });

--- a/packages/frontend/src/components/DmnValidator.test.tsx
+++ b/packages/frontend/src/components/DmnValidator.test.tsx
@@ -1,0 +1,480 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import DmnValidator from './DmnValidator';
+
+const API = 'http://api.test';
+
+type Issue = {
+  severity: 'error' | 'warning' | 'info';
+  code: string;
+  message: string;
+  location?: string;
+  line?: number;
+  column?: number;
+};
+
+function layers(overrides: Partial<Record<string, Issue[]>> = {}) {
+  const build = (label: string, key: string) => ({ label, issues: overrides[key] ?? [] });
+  return {
+    base: build('Base', 'base'),
+    business: build('Business', 'business'),
+    execution: build('Execution', 'execution'),
+    interaction: build('Interaction', 'interaction'),
+    content: build('Content', 'content'),
+  };
+}
+
+function result(overrides: Record<string, unknown> = {}) {
+  return {
+    valid: true,
+    parseError: null,
+    layers: layers(),
+    summary: { errors: 0, warnings: 0, infos: 0 },
+    ...overrides,
+  };
+}
+
+function dmnFile(name = 'chain.dmn', content = '<definitions />') {
+  return new File([content], name, { type: 'application/xml' });
+}
+
+/** Drops files onto the drop zone, which is the element carrying the dashed border. */
+function dropZone(container: HTMLElement): HTMLElement {
+  return container.querySelector('.border-dashed') as HTMLElement;
+}
+
+function dataTransfer(files: File[]) {
+  return { files, items: [], types: ['Files'] } as unknown as DataTransfer;
+}
+
+async function addFiles(container: HTMLElement, files: File[]) {
+  const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+  await userEvent.upload(input, files);
+  for (const file of files) {
+    await screen.findByTitle(file.name);
+  }
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('DmnValidator drop zone', () => {
+  test('shows the empty prompt before any file is added', () => {
+    render(<DmnValidator apiBaseUrl={API} />);
+
+    expect(screen.getByText('Drop DMN files here')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Clear all/ })).toBeNull();
+    expect(screen.queryByText(/E = error/)).toBeNull();
+  });
+
+  test('switches to the compact prompt once a file is loaded', async () => {
+    const { container } = render(<DmnValidator apiBaseUrl={API} />);
+    await addFiles(container, [dmnFile()]);
+
+    expect(screen.getByText(/Drop more files or click to browse/)).toBeTruthy();
+    expect(screen.queryByText('Drop DMN files here')).toBeNull();
+    expect(screen.getByText(/E = error/)).toBeTruthy();
+  });
+
+  test('highlights while dragging and clears the highlight on leave', () => {
+    const { container } = render(<DmnValidator apiBaseUrl={API} />);
+    const zone = dropZone(container);
+
+    fireEvent.dragOver(zone);
+    expect(zone.className).toContain('border-blue-400');
+
+    fireEvent.dragLeave(zone);
+    expect(zone.className).toContain('border-slate-300');
+  });
+
+  test('accepts .dmn and .xml files dropped on the zone', async () => {
+    const { container } = render(<DmnValidator apiBaseUrl={API} />);
+
+    fireEvent.drop(dropZone(container), {
+      dataTransfer: dataTransfer([dmnFile('a.dmn'), dmnFile('b.xml')]),
+    });
+
+    expect(await screen.findByTitle('a.dmn')).toBeTruthy();
+    expect(await screen.findByTitle('b.xml')).toBeTruthy();
+    expect(dropZone(container).className).toContain('border-slate-300');
+  });
+
+  test('rejects other extensions with a transient warning', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const { container } = render(<DmnValidator apiBaseUrl={API} />);
+
+    fireEvent.drop(dropZone(container), {
+      dataTransfer: dataTransfer([dmnFile('notes.txt'), dmnFile('readme.md')]),
+    });
+
+    expect(
+      await screen.findByText('Skipped 2 file(s) — only .dmn and .xml are accepted.')
+    ).toBeTruthy();
+    expect(screen.queryByTitle('notes.txt')).toBeNull();
+
+    await act(() => vi.advanceTimersByTimeAsync(4000));
+    await waitFor(() => expect(screen.queryByText(/Skipped 2 file/)).toBeNull());
+  });
+
+  test('keeps the accepted files from a mixed drop', async () => {
+    const { container } = render(<DmnValidator apiBaseUrl={API} />);
+
+    fireEvent.drop(dropZone(container), {
+      dataTransfer: dataTransfer([dmnFile('good.dmn'), dmnFile('bad.pdf')]),
+    });
+
+    expect(await screen.findByTitle('good.dmn')).toBeTruthy();
+    expect(await screen.findByText(/Skipped 1 file/)).toBeTruthy();
+  });
+
+  test('clicking the zone opens the hidden file picker', async () => {
+    const { container } = render(<DmnValidator apiBaseUrl={API} />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const click = vi.spyOn(input, 'click');
+
+    await userEvent.click(dropZone(container));
+
+    expect(click).toHaveBeenCalled();
+  });
+
+  test('renders the file size in kilobytes', async () => {
+    const { container } = render(<DmnValidator apiBaseUrl={API} />);
+    await addFiles(container, [dmnFile('big.dmn', 'x'.repeat(2048))]);
+
+    expect(screen.getByText('2.0 KB')).toBeTruthy();
+  });
+});
+
+describe('DmnValidator validation', () => {
+  test('reports a valid file with an all-clear badge', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, data: result() }),
+    });
+
+    const { container } = render(<DmnValidator apiBaseUrl={API} />);
+    await addFiles(container, [dmnFile()]);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Validate' }));
+
+    expect(await screen.findByText('Valid')).toBeTruthy();
+    expect(screen.getByText('All checks passed')).toBeTruthy();
+    expect(fetchMock).toHaveBeenCalledWith(`${API}/v1/dmns/validate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: '<definitions />' }),
+    });
+  });
+
+  test('shows per-severity counts for an invalid file', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        success: true,
+        data: result({
+          valid: false,
+          summary: { errors: 2, warnings: 3, infos: 1 },
+          layers: layers({
+            base: [{ severity: 'error', code: 'BASE-001', message: 'Missing decision' }],
+          }),
+        }),
+      }),
+    });
+
+    const { container } = render(<DmnValidator apiBaseUrl={API} />);
+    await addFiles(container, [dmnFile()]);
+    await userEvent.click(screen.getByRole('button', { name: 'Validate' }));
+
+    expect(await screen.findByText('Invalid')).toBeTruthy();
+    expect(screen.getByText('2E')).toBeTruthy();
+    expect(screen.getByText('3W')).toBeTruthy();
+    expect(screen.getByText('1I')).toBeTruthy();
+    expect(screen.queryByText('All checks passed')).toBeNull();
+  });
+
+  test('omits the all-clear badge when a valid file still has warnings', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        success: true,
+        data: result({ summary: { errors: 0, warnings: 1, infos: 0 } }),
+      }),
+    });
+
+    const { container } = render(<DmnValidator apiBaseUrl={API} />);
+    await addFiles(container, [dmnFile()]);
+    await userEvent.click(screen.getByRole('button', { name: 'Validate' }));
+
+    expect(await screen.findByText('Valid')).toBeTruthy();
+    expect(screen.queryByText('All checks passed')).toBeNull();
+  });
+
+  test('surfaces a parse error alongside the summary', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        success: true,
+        data: result({ valid: false, parseError: 'Unexpected token at line 4' }),
+      }),
+    });
+
+    const { container } = render(<DmnValidator apiBaseUrl={API} />);
+    await addFiles(container, [dmnFile()]);
+    await userEvent.click(screen.getByRole('button', { name: 'Validate' }));
+
+    expect(await screen.findByText('Unexpected token at line 4')).toBeTruthy();
+  });
+
+  test('shows the spinner while the request is in flight', async () => {
+    let release: (value: unknown) => void = () => {};
+    fetchMock.mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve;
+      })
+    );
+
+    const { container } = render(<DmnValidator apiBaseUrl={API} />);
+    await addFiles(container, [dmnFile()]);
+    await userEvent.click(screen.getByRole('button', { name: 'Validate' }));
+
+    expect(await screen.findByText('Running validation…')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Validating/ })).toHaveProperty('disabled', true);
+
+    release({ ok: true, status: 200, json: async () => ({ success: true, data: result() }) });
+    await screen.findByText('Valid');
+  });
+
+  test('reports the server error message when validation fails', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 422,
+      json: async () => ({ success: false, error: { message: 'Not a DMN document' } }),
+    });
+
+    const { container } = render(<DmnValidator apiBaseUrl={API} />);
+    await addFiles(container, [dmnFile()]);
+    await userEvent.click(screen.getByRole('button', { name: 'Validate' }));
+
+    expect(await screen.findByText('Not a DMN document')).toBeTruthy();
+  });
+
+  test('falls back to the status code when the server sends no message', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ success: false }),
+    });
+
+    const { container } = render(<DmnValidator apiBaseUrl={API} />);
+    await addFiles(container, [dmnFile()]);
+    await userEvent.click(screen.getByRole('button', { name: 'Validate' }));
+
+    expect(await screen.findByText('Server error: 503')).toBeTruthy();
+  });
+
+  test('treats an unsuccessful 200 body as an error', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: false, error: { message: 'Validator offline' } }),
+    });
+
+    const { container } = render(<DmnValidator apiBaseUrl={API} />);
+    await addFiles(container, [dmnFile()]);
+    await userEvent.click(screen.getByRole('button', { name: 'Validate' }));
+
+    expect(await screen.findByText('Validator offline')).toBeTruthy();
+  });
+
+  test('falls back to a generic message when the rejection is not an Error', async () => {
+    fetchMock.mockRejectedValue('network down');
+
+    const { container } = render(<DmnValidator apiBaseUrl={API} />);
+    await addFiles(container, [dmnFile()]);
+    await userEvent.click(screen.getByRole('button', { name: 'Validate' }));
+
+    expect(await screen.findByText('Validation request failed.')).toBeTruthy();
+  });
+});
+
+describe('DmnValidator layer sections', () => {
+  async function renderWithIssues(issues: Issue[]) {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        success: true,
+        data: result({ valid: false, layers: layers({ base: issues }) }),
+      }),
+    });
+
+    const { container } = render(<DmnValidator apiBaseUrl={API} />);
+    await addFiles(container, [dmnFile()]);
+    await userEvent.click(screen.getByRole('button', { name: 'Validate' }));
+    await screen.findByText('Invalid');
+    return container;
+  }
+
+  test('starts collapsed and expands on click', async () => {
+    await renderWithIssues([{ severity: 'error', code: 'BASE-001', message: 'Missing decision' }]);
+
+    expect(screen.queryByText('Missing decision')).toBeNull();
+
+    await userEvent.click(screen.getByRole('button', { name: /Base/ }));
+    expect(screen.getByText('Missing decision')).toBeTruthy();
+    expect(screen.getByText('BASE-001')).toBeTruthy();
+
+    await userEvent.click(screen.getByRole('button', { name: /Base/ }));
+    expect(screen.queryByText('Missing decision')).toBeNull();
+  });
+
+  test('marks a clean layer OK and says so when expanded', async () => {
+    await renderWithIssues([]);
+
+    const clean = screen.getByRole('button', { name: /Business/ });
+    expect(within(clean).getByText('OK')).toBeTruthy();
+
+    await userEvent.click(clean);
+    expect(screen.getByText('No issues found.')).toBeTruthy();
+  });
+
+  test('counts each severity in the layer header', async () => {
+    await renderWithIssues([
+      { severity: 'error', code: 'E1', message: 'e' },
+      { severity: 'warning', code: 'W1', message: 'w' },
+      { severity: 'warning', code: 'W2', message: 'w2' },
+      { severity: 'info', code: 'I1', message: 'i' },
+    ]);
+
+    const header = screen.getByRole('button', { name: /Base/ });
+    expect(within(header).getByText('1E')).toBeTruthy();
+    expect(within(header).getByText('2W')).toBeTruthy();
+    expect(within(header).getByText('1I')).toBeTruthy();
+  });
+
+  test('leads a warning-only layer with the warning icon rather than the error one', async () => {
+    await renderWithIssues([{ severity: 'warning', code: 'W1', message: 'w' }]);
+
+    const header = screen.getByRole('button', { name: /Base/ });
+    expect(within(header).queryByText(/^\d+E$/)).toBeNull();
+    expect(within(header).getByText('1W')).toBeTruthy();
+  });
+
+  test('renders an info-only layer without error or warning counts', async () => {
+    await renderWithIssues([{ severity: 'info', code: 'I1', message: 'fyi' }]);
+
+    const header = screen.getByRole('button', { name: /Base/ });
+    expect(within(header).getByText('1I')).toBeTruthy();
+    expect(within(header).queryByText('OK')).toBeNull();
+  });
+
+  test('shows an issue location and its line and column', async () => {
+    await renderWithIssues([
+      {
+        severity: 'error',
+        code: 'E1',
+        message: 'bad input',
+        location: '/definitions/decision[1]',
+        line: 12,
+        column: 4,
+      },
+    ]);
+
+    await userEvent.click(screen.getByRole('button', { name: /Base/ }));
+    expect(screen.getByText('/definitions/decision[1]')).toBeTruthy();
+    expect(screen.getByText('Line 12, col 4')).toBeTruthy();
+  });
+
+  test('omits the column when the issue has none', async () => {
+    await renderWithIssues([{ severity: 'error', code: 'E1', message: 'bad', line: 7 }]);
+
+    await userEvent.click(screen.getByRole('button', { name: /Base/ }));
+    expect(screen.getByText('Line 7')).toBeTruthy();
+  });
+
+  test('omits location and line when the issue carries neither', async () => {
+    await renderWithIssues([{ severity: 'error', code: 'E1', message: 'bad' }]);
+
+    await userEvent.click(screen.getByRole('button', { name: /Base/ }));
+    expect(screen.queryByText(/^Line /)).toBeNull();
+  });
+});
+
+describe('DmnValidator multi-file actions', () => {
+  test('validates every pending entry at once, then hides the bulk button', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, data: result() }),
+    });
+
+    const { container } = render(<DmnValidator apiBaseUrl={API} />);
+    await addFiles(container, [dmnFile('a.dmn'), dmnFile('b.dmn')]);
+
+    await userEvent.click(screen.getByRole('button', { name: /Validate all/ }));
+
+    await waitFor(() => expect(screen.getAllByText('Valid')).toHaveLength(2));
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(screen.queryByRole('button', { name: /Validate all/ })).toBeNull();
+  });
+
+  test('keeps the bulk button visible while one entry is still pending', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, data: result() }),
+    });
+
+    const { container } = render(<DmnValidator apiBaseUrl={API} />);
+    await addFiles(container, [dmnFile('a.dmn'), dmnFile('b.dmn')]);
+
+    const cards = screen.getAllByRole('button', { name: 'Validate' });
+    await userEvent.click(cards[0]);
+    await screen.findByText('Valid');
+
+    expect(screen.getByRole('button', { name: /Validate all/ })).toBeTruthy();
+  });
+
+  test('removes a single entry', async () => {
+    const { container } = render(<DmnValidator apiBaseUrl={API} />);
+    await addFiles(container, [dmnFile('a.dmn'), dmnFile('b.dmn')]);
+
+    const card = screen.getByTitle('a.dmn').closest('.flex-col') as HTMLElement;
+    await userEvent.click(within(card).getByTitle('Remove'));
+
+    await waitFor(() => expect(screen.queryByTitle('a.dmn')).toBeNull());
+    expect(screen.getByTitle('b.dmn')).toBeTruthy();
+  });
+
+  test('clears every entry at once', async () => {
+    const { container } = render(<DmnValidator apiBaseUrl={API} />);
+    await addFiles(container, [dmnFile('a.dmn'), dmnFile('b.dmn')]);
+
+    await userEvent.click(screen.getByRole('button', { name: /Clear all/ }));
+
+    await waitFor(() => expect(screen.getByText('Drop DMN files here')).toBeTruthy());
+  });
+
+  test('prompts for validation on a freshly added entry', async () => {
+    const { container } = render(<DmnValidator apiBaseUrl={API} />);
+    await addFiles(container, [dmnFile()]);
+
+    expect(screen.getByText('Press Validate to run checks.')).toBeTruthy();
+  });
+});

--- a/packages/frontend/src/components/DocumentComposer/ContentLibrary.test.tsx
+++ b/packages/frontend/src/components/DocumentComposer/ContentLibrary.test.tsx
@@ -1,8 +1,38 @@
 // @vitest-environment jsdom
 import { render, screen } from '@testing-library/react';
-import { describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+// dnd-kit only reports a transform mid-gesture; drive that state directly.
+const draggableState = vi.hoisted(() => ({
+  transform: null as { x: number; y: number; scaleX: number; scaleY: number } | null,
+  isDragging: false,
+}));
+
+vi.mock('@dnd-kit/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@dnd-kit/core')>();
+  return {
+    ...actual,
+    useDraggable: () => ({
+      attributes: {},
+      listeners: {},
+      setNodeRef: () => {},
+      transform: draggableState.transform,
+      isDragging: draggableState.isDragging,
+    }),
+  };
+});
 
 import ContentLibrary from './ContentLibrary';
+
+function cardFor(label: string): HTMLElement {
+  // The draggable wrapper is the element carrying the inline transform style.
+  return screen.getByText(label).closest('[style]') ?? screen.getByText(label).parentElement!;
+}
+
+beforeEach(() => {
+  draggableState.transform = null;
+  draggableState.isDragging = false;
+});
 
 describe('ContentLibrary', () => {
   test('renders every content block type as a draggable card', () => {
@@ -22,5 +52,30 @@ describe('ContentLibrary', () => {
     expect(screen.getByText('Logo or illustration')).toBeTruthy();
     expect(screen.getByText('Horizontal line')).toBeTruthy();
     expect(screen.getByText('Empty space')).toBeTruthy();
+  });
+
+  test('leaves cards unstyled while nothing is being dragged', () => {
+    const { container } = render(<ContentLibrary />);
+    expect(container.querySelector('[style*="translate3d"]')).toBeNull();
+  });
+
+  test('follows the pointer and dims the card being dragged', () => {
+    draggableState.transform = { x: 24, y: -8, scaleX: 1, scaleY: 1 };
+    draggableState.isDragging = true;
+
+    render(<ContentLibrary />);
+
+    const card = cardFor('Text');
+    expect(card.getAttribute('style')).toContain('translate3d(24px, -8px, 0)');
+    expect(card.getAttribute('style')).toContain('opacity: 0.5');
+  });
+
+  test('keeps a transformed card at full opacity when it is not the one being dragged', () => {
+    draggableState.transform = { x: 5, y: 5, scaleX: 1, scaleY: 1 };
+    draggableState.isDragging = false;
+
+    render(<ContentLibrary />);
+
+    expect(cardFor('Text').getAttribute('style')).toContain('opacity: 1');
   });
 });

--- a/packages/frontend/src/components/DocumentComposer/DocumentCanvas.test.tsx
+++ b/packages/frontend/src/components/DocumentComposer/DocumentCanvas.test.tsx
@@ -5,12 +5,26 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, test, vi } from 'vitest';
 
 vi.mock('./ZonePanel', () => ({
-  default: ({ zoneId, blocks }: { zoneId: string; blocks: { id: string; label?: string }[] }) => (
+  default: ({
+    zoneId,
+    blocks,
+    onUpdateBlock,
+    onDeleteBlock,
+  }: {
+    zoneId: string;
+    blocks: { id: string; label?: string }[];
+    onUpdateBlock: (zoneId: string, blockId: string, updates: Record<string, unknown>) => void;
+    onDeleteBlock: (zoneId: string, blockId: string) => void;
+  }) => (
     <div>
       <span>zone:{zoneId}</span>
       <span>
         blocks:{zoneId}:{blocks.map((b) => b.label ?? b.id).join(',')}
       </span>
+      <button onClick={() => onUpdateBlock(zoneId, 'blk1', { label: 'Renamed' })}>
+        update-{zoneId}
+      </button>
+      <button onClick={() => onDeleteBlock(zoneId, 'blk1')}>delete-{zoneId}</button>
     </div>
   ),
 }));
@@ -335,5 +349,285 @@ describe('DocumentCanvas — drag-end resolution', () => {
         }),
       })
     );
+  });
+});
+
+describe('DocumentCanvas — block editing', () => {
+  test('updating a block rewrites only that block in its zone', async () => {
+    const onTemplateChange = vi.fn();
+    render(
+      <DocumentCanvas
+        {...baseProps}
+        template={template({
+          zones: zones({
+            body: {
+              blocks: [
+                { id: 'blk1', type: 'text', label: 'First' },
+                { id: 'blk2', type: 'text', label: 'Second' },
+              ],
+            },
+          }),
+        })}
+        onTemplateChange={onTemplateChange}
+      />
+    );
+
+    await userEvent.click(screen.getByText('update-body'));
+
+    expect(onTemplateChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        zones: expect.objectContaining({
+          body: {
+            blocks: [
+              { id: 'blk1', type: 'text', label: 'Renamed' },
+              { id: 'blk2', type: 'text', label: 'Second' },
+            ],
+          },
+        }),
+      })
+    );
+  });
+
+  test('deleting a block removes it from its zone', async () => {
+    const onTemplateChange = vi.fn();
+    render(
+      <DocumentCanvas
+        {...baseProps}
+        template={template({
+          zones: zones({ body: { blocks: [{ id: 'blk1', type: 'text', label: 'First' }] } }),
+        })}
+        onTemplateChange={onTemplateChange}
+      />
+    );
+
+    await userEvent.click(screen.getByText('delete-body'));
+
+    expect(onTemplateChange).toHaveBeenCalledWith(
+      expect.objectContaining({ zones: expect.objectContaining({ body: { blocks: [] } }) })
+    );
+  });
+
+  test('editing a zone the template does not carry leaves the zones untouched', async () => {
+    const onTemplateChange = vi.fn();
+    render(
+      <DocumentCanvas
+        {...baseProps}
+        template={template({ zones: zones({ annex: { blocks: [] } }) })}
+        onTemplateChange={onTemplateChange}
+      />
+    );
+
+    // Drop the annex zone out from under the panel, then act on it.
+    const withoutAnnex = template({ zones: zones() });
+    onTemplateChange.mockClear();
+
+    render(
+      <DocumentCanvas
+        {...baseProps}
+        template={{ ...withoutAnnex, zones: { ...withoutAnnex.zones, annex: { blocks: [] } } }}
+        onTemplateChange={onTemplateChange}
+      />
+    );
+
+    await userEvent.click(screen.getAllByText('update-annex')[0]);
+    expect(onTemplateChange).toHaveBeenCalled();
+  });
+
+  test('a null annex renders no annex panel', () => {
+    render(
+      <DocumentCanvas {...baseProps} template={template({ zones: zones({ annex: null }) })} />
+    );
+    expect(screen.queryByText('zone:annex')).toBeNull();
+  });
+});
+
+describe('DocumentCanvas — createBlock per library type', () => {
+  function dropNewBlock(dragData: Record<string, unknown>) {
+    const onTemplateChange = vi.fn();
+    const { rerender } = render(
+      <DocumentCanvas {...baseProps} template={template()} onTemplateChange={onTemplateChange} />
+    );
+
+    rerender(
+      <DocumentCanvas
+        {...baseProps}
+        template={template()}
+        onTemplateChange={onTemplateChange}
+        dragEndEvent={dragEnd('new', { type: 'new-block', ...dragData }, 'zone-body')}
+      />
+    );
+
+    return onTemplateChange.mock.calls[0][0].zones.body.blocks[0];
+  }
+
+  test('an image block carries its asset URL and label', () => {
+    expect(
+      dropNewBlock({ blockType: 'image', assetUrl: 'https://cdn/logo.png', label: 'Logo' })
+    ).toMatchObject({ type: 'image', label: 'Logo', assetUrl: 'https://cdn/logo.png' });
+  });
+
+  test('an image block without a label falls back to "Image"', () => {
+    expect(dropNewBlock({ blockType: 'image' })).toMatchObject({
+      type: 'image',
+      label: 'Image',
+      assetUrl: undefined,
+    });
+  });
+
+  test('a variable block carries its process variable key', () => {
+    expect(
+      dropNewBlock({ blockType: 'variable', variableKey: 'applicantId', label: 'Applicant' })
+    ).toMatchObject({ type: 'variable', label: 'Applicant', variableKey: 'applicantId' });
+  });
+
+  test('a variable block without a key falls back to an empty key and "Variable"', () => {
+    expect(dropNewBlock({ blockType: 'variable' })).toMatchObject({
+      type: 'variable',
+      label: 'Variable',
+      variableKey: '',
+    });
+  });
+
+  test('a separator block', () => {
+    expect(dropNewBlock({ blockType: 'separator' })).toMatchObject({
+      type: 'separator',
+      label: 'Separator',
+    });
+  });
+
+  test('a spacer block', () => {
+    expect(dropNewBlock({ blockType: 'spacer' })).toMatchObject({
+      type: 'spacer',
+      label: 'Space',
+    });
+  });
+
+  test('an unrecognised block type falls back to an empty text block', () => {
+    expect(dropNewBlock({ blockType: 'hologram' })).toMatchObject({
+      type: 'text',
+      label: 'Block',
+    });
+  });
+
+  test('block ids are unique across drops', () => {
+    const a = dropNewBlock({ blockType: 'separator' });
+    const b = dropNewBlock({ blockType: 'separator' });
+    expect(a.id).not.toBe(b.id);
+    expect(a.id).toMatch(/^blk_\d+_[a-z0-9]+$/);
+  });
+});
+
+describe('DocumentCanvas — drag-end guards', () => {
+  function drop(startTemplate: DocumentTemplate, event: DragEndEvent) {
+    const onTemplateChange = vi.fn();
+    const { rerender } = render(
+      <DocumentCanvas {...baseProps} template={startTemplate} onTemplateChange={onTemplateChange} />
+    );
+    rerender(
+      <DocumentCanvas
+        {...baseProps}
+        template={startTemplate}
+        onTemplateChange={onTemplateChange}
+        dragEndEvent={event}
+      />
+    );
+    return onTemplateChange;
+  }
+
+  test('a new block dropped onto another block, not a zone, is ignored', () => {
+    expect(
+      drop(template(), dragEnd('new', { type: 'new-block', blockType: 'text' }, 'blk1'))
+    ).not.toHaveBeenCalled();
+  });
+
+  test('a new block dropped onto an unknown zone id is ignored', () => {
+    expect(
+      drop(template(), dragEnd('new', { type: 'new-block', blockType: 'text' }, 'zone-basement'))
+    ).not.toHaveBeenCalled();
+  });
+
+  test('a new block can seed the annex zone the template has not materialised', () => {
+    const onTemplateChange = drop(
+      template({ zones: zones({ annex: null }) }),
+      dragEnd('new', { type: 'new-block', blockType: 'separator' }, 'zone-annex')
+    );
+
+    expect(onTemplateChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        zones: expect.objectContaining({
+          annex: { blocks: [expect.objectContaining({ type: 'separator' })] },
+        }),
+      })
+    );
+  });
+
+  test('dropping an existing block back onto its own zone is a no-op', () => {
+    expect(
+      drop(
+        template({ zones: zones({ body: { blocks: [{ id: 'blk1', type: 'text' }] } }) }),
+        dragEnd(
+          'blk1',
+          { type: 'existing-block', blockId: 'blk1', sourceZoneId: 'body' },
+          'zone-body'
+        )
+      )
+    ).not.toHaveBeenCalled();
+  });
+
+  test('moving a block whose source zone no longer holds it leaves the zones unchanged', () => {
+    const onTemplateChange = drop(
+      template({ zones: zones({ body: { blocks: [] } }) }),
+      dragEnd(
+        'ghost',
+        { type: 'existing-block', blockId: 'ghost', sourceZoneId: 'body' },
+        'zone-closing'
+      )
+    );
+
+    const updated = onTemplateChange.mock.calls[0][0];
+    expect(updated.zones.body.blocks).toEqual([]);
+    expect(updated.zones.closing.blocks).toEqual([]);
+  });
+
+  test('dropping an existing block onto an unknown block id leaves the zones unchanged', () => {
+    const onTemplateChange = drop(
+      template({ zones: zones({ body: { blocks: [{ id: 'blk1', type: 'text' }] } }) }),
+      dragEnd('blk1', { type: 'existing-block', blockId: 'blk1', sourceZoneId: 'body' }, 'nowhere')
+    );
+
+    expect(onTemplateChange.mock.calls[0][0].zones.body.blocks).toEqual([
+      { id: 'blk1', type: 'text' },
+    ]);
+  });
+
+  test('a same-zone reorder whose dragged block has vanished leaves the zone unchanged', () => {
+    const onTemplateChange = drop(
+      template({ zones: zones({ body: { blocks: [{ id: 'blk1', type: 'text' }] } }) }),
+      dragEnd('ghost', { type: 'existing-block', blockId: 'ghost', sourceZoneId: 'body' }, 'blk1')
+    );
+
+    expect(onTemplateChange.mock.calls[0][0].zones.body.blocks).toEqual([
+      { id: 'blk1', type: 'text' },
+    ]);
+  });
+
+  test('a cross-zone move whose dragged block has vanished leaves both zones unchanged', () => {
+    const onTemplateChange = drop(
+      template({
+        zones: zones({
+          body: { blocks: [] },
+          closing: { blocks: [{ id: 'blk2', type: 'text' }] },
+        }),
+      }),
+      dragEnd('ghost', { type: 'existing-block', blockId: 'ghost', sourceZoneId: 'body' }, 'blk2')
+    );
+
+    const updated = onTemplateChange.mock.calls[0][0];
+    expect(updated.zones.body.blocks).toEqual([]);
+    expect(updated.zones.closing.blocks).toEqual([{ id: 'blk2', type: 'text' }]);
+  });
+
+  test('a drag with no recognised payload type is ignored', () => {
+    expect(drop(template(), dragEnd('x', { type: 'mystery' }, 'zone-body'))).not.toHaveBeenCalled();
   });
 });

--- a/packages/frontend/src/components/DocumentComposer/DocumentComposer.test.tsx
+++ b/packages/frontend/src/components/DocumentComposer/DocumentComposer.test.tsx
@@ -385,3 +385,202 @@ describe('DocumentComposer — bindings and left-panel tabs', () => {
     expect(screen.getByText('AssetLibrary stub:https://example.com/sparql')).toBeTruthy();
   });
 });
+
+describe('DocumentComposer — guards and no-ops', () => {
+  /** Load the first seeded template and mark the canvas dirty. */
+  async function renderDirty() {
+    render(<DocumentComposer endpoint="e" />);
+    await userEvent.click(screen.getByText('load-default-2'));
+    await userEvent.click(screen.getByText('edit-canvas'));
+    expect(screen.getByText('hasChanges:true')).toBeTruthy();
+  }
+
+  test('creating a template while dirty is cancelled when the discard prompt is declined', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    await renderDirty();
+    saveTemplate.mockClear();
+
+    await userEvent.click(screen.getByText('create-template'));
+
+    expect(window.confirm).toHaveBeenCalled();
+    expect(saveTemplate).not.toHaveBeenCalled();
+    expect(screen.getByText('active:default-2')).toBeTruthy();
+  });
+
+  test('importing a template while dirty is cancelled when the discard prompt is declined', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    await renderDirty();
+    saveTemplate.mockClear();
+
+    await userEvent.click(screen.getByText('import-template'));
+
+    expect(saveTemplate).not.toHaveBeenCalled();
+    expect(screen.getByText('active:default-2')).toBeTruthy();
+  });
+
+  test('closing while dirty is cancelled when the discard prompt is declined', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    await renderDirty();
+
+    await userEvent.click(screen.getByText('close-canvas'));
+
+    expect(screen.getByText('active:default-2')).toBeTruthy();
+  });
+
+  test('re-loading the already-active template is a no-op, even while dirty', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm');
+    await renderDirty();
+
+    await userEvent.click(screen.getByText('load-default-2'));
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(screen.getByText('hasChanges:true')).toBeTruthy();
+  });
+
+  test('declining the delete confirmation keeps the template', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    render(<DocumentComposer endpoint="e" />);
+
+    await userEvent.click(screen.getByText('delete-default-2'));
+
+    expect(deleteTemplate).not.toHaveBeenCalled();
+    expect(screen.getByText('templates:default-1,default-2')).toBeTruthy();
+  });
+
+  test('deleting a template other than the active one keeps the selection', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    render(<DocumentComposer endpoint="e" />);
+    await userEvent.click(screen.getByText('load-default-2'));
+
+    await userEvent.click(screen.getByText('delete-default-1'));
+
+    expect(deleteTemplate).toHaveBeenCalledWith('default-1');
+    expect(screen.getByText('active:default-2')).toBeTruthy();
+  });
+
+  test('renaming a template that no longer exists writes nothing', async () => {
+    render(<DocumentComposer endpoint="e" />);
+    await userEvent.click(screen.getByText('load-default-2'));
+    saveTemplate.mockClear();
+    getTemplate.mockReturnValue(null);
+
+    await userEvent.click(screen.getByText('rename-active'));
+
+    expect(saveTemplate).not.toHaveBeenCalled();
+  });
+
+  test('footer edits are ignored while no template is active', async () => {
+    render(<DocumentComposer endpoint="e" />);
+    await userEvent.click(screen.getByText('close-canvas'));
+    expect(screen.getByText('active:none')).toBeTruthy();
+
+    await userEvent.click(screen.getByText('set-language'));
+    await userEvent.click(screen.getByText('set-org'));
+
+    expect(screen.getByText('effLang:none')).toBeTruthy();
+    expect(screen.getByText('effOrg:none')).toBeTruthy();
+  });
+
+  test('the footer shows the committed values until the user edits them', async () => {
+    store = [
+      {
+        id: 'doc-1',
+        name: 'Doc',
+        bindings: [],
+        zones: {},
+        language: 'de',
+        organization: 'heusden',
+      },
+    ];
+    render(<DocumentComposer endpoint="e" />);
+    await userEvent.click(screen.getByText('load-doc-1'));
+
+    expect(screen.getByText('effLang:de')).toBeTruthy();
+    expect(screen.getByText('effOrg:heusden')).toBeTruthy();
+
+    await userEvent.click(screen.getByText('set-language'));
+    expect(screen.getByText('effLang:nl')).toBeTruthy();
+  });
+
+  test('Save keeps the committed language and organization when the footer was not touched', async () => {
+    store = [
+      {
+        id: 'doc-1',
+        name: 'Doc',
+        bindings: [],
+        zones: {},
+        language: 'de',
+        organization: 'heusden',
+      },
+    ];
+    render(<DocumentComposer endpoint="e" />);
+    await userEvent.click(screen.getByText('load-doc-1'));
+    saveTemplate.mockClear();
+
+    await userEvent.click(screen.getByText('save-canvas'));
+
+    expect(saveTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({ language: 'de', organization: 'heusden' })
+    );
+  });
+
+  test('Save is refused for a readonly template', async () => {
+    store = [{ id: 'doc-1', name: 'Doc', bindings: [], zones: {}, readonly: true }];
+    render(<DocumentComposer endpoint="e" />);
+    await userEvent.click(screen.getByText('load-doc-1'));
+    saveTemplate.mockClear();
+
+    await userEvent.click(screen.getByText('save-canvas'));
+
+    expect(saveTemplate).not.toHaveBeenCalled();
+  });
+
+  test('Save As carries a pending footer draft into the copy', async () => {
+    vi.spyOn(window, 'prompt').mockReturnValue('Copy of Doc');
+    render(<DocumentComposer endpoint="e" />);
+    await userEvent.click(screen.getByText('load-default-2'));
+    await userEvent.click(screen.getByText('set-org'));
+    saveTemplate.mockClear();
+
+    await userEvent.click(screen.getByText('saveas-canvas'));
+
+    expect(saveTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Copy of Doc',
+        organization: 'flevoland',
+        readonly: false,
+        status: 'wip',
+      })
+    );
+  });
+
+  test('Save As is abandoned when the prompt returns only whitespace', async () => {
+    vi.spyOn(window, 'prompt').mockReturnValue('   ');
+    render(<DocumentComposer endpoint="e" />);
+    await userEvent.click(screen.getByText('load-default-2'));
+    saveTemplate.mockClear();
+
+    await userEvent.click(screen.getByText('saveas-canvas'));
+
+    expect(saveTemplate).not.toHaveBeenCalled();
+  });
+
+  test('clearing the process key stores undefined rather than an empty string', async () => {
+    render(<DocumentComposer endpoint="e" />);
+    await userEvent.click(screen.getByText('load-default-2'));
+    await userEvent.click(screen.getByText('set-processkey'));
+    expect(screen.getByText('processKey:NewProcess')).toBeTruthy();
+  });
+
+  test('deleting a binding removes it from the active template', async () => {
+    render(<DocumentComposer endpoint="e" />);
+    await userEvent.click(screen.getByText('load-default-2'));
+    await userEvent.click(screen.getByText('add-binding'));
+
+    expect(screen.getByText('bindings-count:1')).toBeTruthy();
+
+    await userEvent.click(screen.getByText(/^delete-binding-/));
+
+    expect(screen.getByText('bindings-count:0')).toBeTruthy();
+  });
+});

--- a/packages/frontend/src/components/DocumentComposer/DocumentList.test.tsx
+++ b/packages/frontend/src/components/DocumentComposer/DocumentList.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, test, vi } from 'vitest';
 
@@ -231,5 +231,153 @@ describe('DocumentList', () => {
     );
     expect(screen.getByText('Language')).toBeTruthy();
     expect(screen.getByText('Organization')).toBeTruthy();
+  });
+
+  test('collapsing an organization group hides its cards until expanded again', async () => {
+    render(
+      <DocumentList
+        {...baseProps}
+        templates={[template({ organization: 'flevoland', name: 'Kapvergunning' })]}
+      />
+    );
+
+    expect(screen.getByText('Kapvergunning')).toBeTruthy();
+
+    await userEvent.click(screen.getByRole('button', { name: /flevoland/i }));
+    expect(screen.queryByText('Kapvergunning')).toBeNull();
+
+    await userEvent.click(screen.getByRole('button', { name: /flevoland/i }));
+    expect(screen.getByText('Kapvergunning')).toBeTruthy();
+  });
+
+  test('labels the group of documents with no organization "Ungrouped"', () => {
+    render(<DocumentList {...baseProps} templates={[template()]} />);
+    expect(screen.getByText('Ungrouped')).toBeTruthy();
+  });
+
+  test('reports when the filters exclude every template', async () => {
+    render(<DocumentList {...baseProps} templates={[template()]} />);
+
+    await userEvent.type(screen.getByPlaceholderText(/Search/i), 'nothing-matches-this');
+
+    expect(screen.getByText('No documents match the current filters')).toBeTruthy();
+    expect(screen.queryByText('No documents yet')).toBeNull();
+  });
+
+  test('shows the bound process key on a card that declares one', () => {
+    render(
+      <DocumentList {...baseProps} templates={[template({ processKey: 'AwbShellProcess' })]} />
+    );
+    expect(screen.getByText('AwbShellProcess')).toBeTruthy();
+  });
+
+  test('Escape abandons a rename without committing it', async () => {
+    const onUpdateTemplateName = vi.fn();
+    render(
+      <DocumentList
+        {...baseProps}
+        onUpdateTemplateName={onUpdateTemplateName}
+        templates={[template()]}
+      />
+    );
+
+    await userEvent.dblClick(screen.getByText('Beschikking'));
+    const field = screen.getByDisplayValue('Beschikking');
+    await userEvent.clear(field);
+    await userEvent.type(field, 'Nieuwe naam{Escape}');
+
+    expect(onUpdateTemplateName).not.toHaveBeenCalled();
+    expect(screen.getByText('Beschikking')).toBeTruthy();
+  });
+
+  test('a rename to blank is discarded rather than committed', async () => {
+    const onUpdateTemplateName = vi.fn();
+    render(
+      <DocumentList
+        {...baseProps}
+        onUpdateTemplateName={onUpdateTemplateName}
+        templates={[template()]}
+      />
+    );
+
+    await userEvent.dblClick(screen.getByText('Beschikking'));
+    const field = screen.getByDisplayValue('Beschikking');
+    await userEvent.clear(field);
+    await userEvent.type(field, '   {Enter}');
+
+    expect(onUpdateTemplateName).not.toHaveBeenCalled();
+  });
+
+  test('clicking a card does not start a rename', async () => {
+    const onLoadTemplate = vi.fn();
+    render(
+      <DocumentList {...baseProps} onLoadTemplate={onLoadTemplate} templates={[template()]} />
+    );
+
+    await userEvent.click(screen.getByText('Beschikking'));
+
+    expect(onLoadTemplate).toHaveBeenCalledWith('t1');
+    expect(screen.queryByDisplayValue('Beschikking')).toBeNull();
+  });
+
+  /** The footer selectors sit under the Language / Organization labels. */
+  function footerControls() {
+    const footer = screen.getByText('Language').closest('div')!.parentElement!.parentElement!;
+    return Array.from(footer.querySelectorAll('select, input')) as HTMLElement[];
+  }
+
+  test('the footer selectors are disabled for a readonly template', () => {
+    render(
+      <DocumentList
+        {...baseProps}
+        templates={[template({ readonly: true })]}
+        activeTemplate={template({ readonly: true })}
+        activeTemplateId="t1"
+        onLanguageChange={vi.fn()}
+        onOrganizationChange={vi.fn()}
+      />
+    );
+
+    for (const control of footerControls()) expect(control).toBeDisabled();
+  });
+
+  test('the footer selectors are disabled when the parent supplies no change handlers', () => {
+    render(
+      <DocumentList
+        {...baseProps}
+        templates={[template()]}
+        activeTemplate={template()}
+        activeTemplateId="t1"
+      />
+    );
+
+    for (const control of footerControls()) expect(control).toBeDisabled();
+  });
+
+  test('the footer selectors are enabled for an editable template with handlers', () => {
+    render(
+      <DocumentList
+        {...baseProps}
+        templates={[template()]}
+        activeTemplate={template()}
+        activeTemplateId="t1"
+        onLanguageChange={vi.fn()}
+        onOrganizationChange={vi.fn()}
+      />
+    );
+
+    for (const control of footerControls()) expect(control).not.toBeDisabled();
+  });
+
+  test('choosing no files leaves the import handler idle', () => {
+    const onImportTemplate = vi.fn();
+    const { container } = render(
+      <DocumentList {...baseProps} onImportTemplate={onImportTemplate} templates={[]} />
+    );
+
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [] } });
+
+    expect(onImportTemplate).not.toHaveBeenCalled();
   });
 });

--- a/packages/frontend/src/components/DocumentComposer/ZonePanel.test.tsx
+++ b/packages/frontend/src/components/DocumentComposer/ZonePanel.test.tsx
@@ -1,7 +1,17 @@
 // @vitest-environment jsdom
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+// dnd-kit's hover state is driven by a live DndContext; drive it directly instead.
+const droppableState = vi.hoisted(() => ({ isOver: false }));
+vi.mock('@dnd-kit/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@dnd-kit/core')>();
+  return {
+    ...actual,
+    useDroppable: () => ({ setNodeRef: () => {}, isOver: droppableState.isOver }),
+  };
+});
 
 vi.mock('./BlockItem', () => ({
   default: ({
@@ -26,6 +36,10 @@ import ZonePanel from './ZonePanel';
 function block(overrides: Partial<DocumentBlock> = {}): DocumentBlock {
   return { id: 'b1', type: 'text', ...overrides };
 }
+
+beforeEach(() => {
+  droppableState.isOver = false;
+});
 
 describe('ZonePanel', () => {
   test('renders the zone label, description, and block count', () => {
@@ -113,5 +127,57 @@ describe('ZonePanel', () => {
     expect(screen.getByText('Intro')).toBeTruthy();
     await userEvent.click(screen.getByText('Body'));
     expect(screen.queryByText('Intro')).toBeNull();
+  });
+
+  test('highlights the panel and its placeholder while a block hovers over the zone', () => {
+    droppableState.isOver = true;
+    const { container } = render(
+      <ZonePanel
+        zoneId="body"
+        blocks={[]}
+        readonly={false}
+        onUpdateBlock={vi.fn()}
+        onDeleteBlock={vi.fn()}
+      />
+    );
+
+    expect(container.firstElementChild?.className).toContain('bg-blue-50');
+    expect(screen.getByText('Drag a block here').parentElement?.className).toContain(
+      'border-blue-400'
+    );
+  });
+
+  test('renders in its resting colours when nothing hovers over the zone', () => {
+    const { container } = render(
+      <ZonePanel
+        zoneId="body"
+        blocks={[]}
+        readonly={false}
+        onUpdateBlock={vi.fn()}
+        onDeleteBlock={vi.fn()}
+      />
+    );
+
+    expect(container.firstElementChild?.className).toContain('bg-white');
+    expect(screen.getByText('Drag a block here').parentElement?.className).toContain(
+      'border-slate-200'
+    );
+  });
+
+  test.each([
+    ['letterhead', 'border-l-blue-500'],
+    ['reference', 'border-l-amber-500'],
+    ['annex', 'border-l-slate-400'],
+  ] as const)('gives the %s zone its own accent colour', (zoneId, colour) => {
+    const { container } = render(
+      <ZonePanel
+        zoneId={zoneId}
+        blocks={[]}
+        readonly={false}
+        onUpdateBlock={vi.fn()}
+        onDeleteBlock={vi.fn()}
+      />
+    );
+    expect(container.firstElementChild?.className).toContain(colour);
   });
 });

--- a/packages/frontend/src/components/DocumentComposer/defaultTemplates.test.ts
+++ b/packages/frontend/src/components/DocumentComposer/defaultTemplates.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from 'vitest';
+
+import { DocumentTemplate, ZONE_ORDER, ZoneId } from '../../types/document.types';
+import {
+  DEFAULT_TEMPLATES,
+  DVTP_CONSENT_RECEIPT,
+  emptyDoc,
+  heading,
+  HR_CAPACITY_BOARD_DECISION_NOTIFICATION_NL,
+  HR_CAPACITY_HANDOVER_NL,
+  paragraphs,
+  TREE_FELLING_BESCHIKKING,
+  ZORGTOESLAG_FINAL_BESCHIKKING,
+  ZORGTOESLAG_PROVISIONAL_BESCHIKKING,
+} from './defaultTemplates';
+
+const REQUIRED_ZONES: ZoneId[] = [
+  'letterhead',
+  'contactInformation',
+  'reference',
+  'body',
+  'closing',
+  'signOff',
+];
+
+describe('emptyDoc', () => {
+  test('wraps text in a single paragraph', () => {
+    expect(emptyDoc('Hoogachtend,')).toEqual({
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hoogachtend,' }] }],
+    });
+  });
+
+  test('produces a paragraph with no children when called without text', () => {
+    expect(emptyDoc()).toEqual({
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [] }],
+    });
+  });
+
+  test('treats an explicit empty string as no text', () => {
+    expect(emptyDoc('').content[0].content).toEqual([]);
+  });
+});
+
+describe('heading', () => {
+  test.each([1, 2, 3] as const)('builds a level-%i heading', (level) => {
+    expect(heading(level, 'Beschikking')).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'heading',
+          attrs: { level },
+          content: [{ type: 'text', text: 'Beschikking' }],
+        },
+      ],
+    });
+  });
+});
+
+describe('paragraphs', () => {
+  test('maps each line to a paragraph, leaving blank lines empty', () => {
+    expect(paragraphs(['first', '', 'third'])).toEqual({
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'first' }] },
+        { type: 'paragraph', content: [] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'third' }] },
+      ],
+    });
+  });
+
+  test('accepts an empty list', () => {
+    expect(paragraphs([])).toEqual({ type: 'doc', content: [] });
+  });
+});
+
+describe('DEFAULT_TEMPLATES', () => {
+  test('exports every named template exactly once', () => {
+    expect(DEFAULT_TEMPLATES).toEqual([
+      TREE_FELLING_BESCHIKKING,
+      ZORGTOESLAG_PROVISIONAL_BESCHIKKING,
+      ZORGTOESLAG_FINAL_BESCHIKKING,
+      DVTP_CONSENT_RECEIPT,
+      HR_CAPACITY_BOARD_DECISION_NOTIFICATION_NL,
+      HR_CAPACITY_HANDOVER_NL,
+    ]);
+  });
+
+  test('template ids are unique', () => {
+    const ids = DEFAULT_TEMPLATES.map((t) => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test.each(DEFAULT_TEMPLATES.map((t) => [t.id, t] as [string, DocumentTemplate]))(
+    '%s carries all required zones and a schema version',
+    (_id, template) => {
+      expect(template.schemaVersion).toBeGreaterThanOrEqual(1);
+      expect(template.name).not.toBe('');
+      for (const zone of REQUIRED_ZONES) {
+        expect(Array.isArray(template.zones[zone]?.blocks)).toBe(true);
+      }
+      expect(Object.keys(template.zones).every((z) => ZONE_ORDER.includes(z as ZoneId))).toBe(true);
+    }
+  );
+
+  test.each(DEFAULT_TEMPLATES.map((t) => [t.id, t] as [string, DocumentTemplate]))(
+    '%s has unique block ids and well-formed blocks',
+    (_id, template) => {
+      const blocks = ZONE_ORDER.flatMap((z) => template.zones[z]?.blocks ?? []);
+      expect(blocks.length).toBeGreaterThan(0);
+      expect(new Set(blocks.map((b) => b.id)).size).toBe(blocks.length);
+
+      for (const block of blocks) {
+        expect(['text', 'image', 'variable', 'separator', 'spacer']).toContain(block.type);
+        if (block.type === 'text') expect(block.content?.type).toBe('doc');
+        if (block.type === 'image') expect(typeof block.assetUrl).toBe('string');
+        if (block.type === 'variable') expect(typeof block.variableKey).toBe('string');
+      }
+    }
+  );
+
+  test.each(DEFAULT_TEMPLATES.map((t) => [t.id, t] as [string, DocumentTemplate]))(
+    '%s declares a binding for every placeholder it uses',
+    (_id, template) => {
+      const text = JSON.stringify(template.zones);
+      const used = new Set([...text.matchAll(/\{\{\s*([\w.]+)\s*\}\}/g)].map((m) => m[1]));
+      const bound = new Set(template.bindings.map((b) => b.variableKey));
+
+      for (const placeholder of used) {
+        expect(bound.has(placeholder)).toBe(true);
+      }
+    }
+  );
+
+  test.each(DEFAULT_TEMPLATES.map((t) => [t.id, t] as [string, DocumentTemplate]))(
+    '%s has unique binding ids and ISO timestamps',
+    (_id, template) => {
+      expect(new Set(template.bindings.map((b) => b.id)).size).toBe(template.bindings.length);
+      expect(Number.isNaN(Date.parse(template.createdAt))).toBe(false);
+      expect(Number.isNaN(Date.parse(template.updatedAt))).toBe(false);
+      expect(Array.isArray(template.assets)).toBe(true);
+    }
+  );
+});

--- a/packages/frontend/src/components/DocumentComposer/defaultTemplates.ts
+++ b/packages/frontend/src/components/DocumentComposer/defaultTemplates.ts
@@ -10,7 +10,7 @@
 import { DocumentTemplate } from '../../types/document.types';
 
 /** Helper: create an empty TipTap doc with one paragraph */
-function emptyDoc(text = '') {
+export function emptyDoc(text = '') {
   return {
     type: 'doc' as const,
     content: [
@@ -23,7 +23,7 @@ function emptyDoc(text = '') {
 }
 
 /** Helper: create a heading node */
-function heading(level: 1 | 2 | 3, text: string) {
+export function heading(level: 1 | 2 | 3, text: string) {
   return {
     type: 'doc' as const,
     content: [
@@ -37,7 +37,7 @@ function heading(level: 1 | 2 | 3, text: string) {
 }
 
 /** Helper: create a doc with multiple paragraphs */
-function paragraphs(lines: string[]) {
+export function paragraphs(lines: string[]) {
   return {
     type: 'doc' as const,
     content: lines.map((line) => ({

--- a/packages/frontend/src/components/DsoExplorer/DsoExplorer.test.tsx
+++ b/packages/frontend/src/components/DsoExplorer/DsoExplorer.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen } from '@testing-library/react';
+import { act, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
@@ -410,5 +410,715 @@ describe('DsoExplorer — Activities tab', () => {
     await userEvent.click(childLink);
 
     expect(getActiviteitDetail).toHaveBeenCalledWith('child-1', undefined, 'pre');
+  });
+});
+
+// ─── Shared helpers for the added suites ────────────────────────────────────
+
+async function openTab(name: RegExp | string) {
+  searchBegrippen.mockResolvedValue(emptyResult());
+  render(<DsoExplorer />);
+  await screen.findByPlaceholderText('Search concepts…');
+  if (name !== 'Concepts') {
+    await userEvent.click(screen.getByRole('button', { name }));
+  }
+}
+
+describe('DsoExplorer — concept cards', () => {
+  test('renders validity date, definition, and keywords', async () => {
+    searchBegrippen.mockResolvedValue({
+      items: [
+        {
+          uri: 'urn:begrip:1',
+          naam: 'Kapvergunning',
+          definitie: 'Toestemming om te kappen',
+          begindatumGeldigheid: '2024-01-01',
+          trefwoorden: ['kap', 'boom', 'vergunning', 'groen', 'natuur', 'extra'],
+        },
+      ],
+      page: { number: 1, size: 10 },
+      hasNext: false,
+    });
+    render(<DsoExplorer />);
+
+    expect(await screen.findByText('Kapvergunning')).toBeTruthy();
+    expect(screen.getByText('Toestemming om te kappen')).toBeTruthy();
+    expect(screen.getByText('2024-01-01')).toBeTruthy();
+    // Only the first five keywords are shown.
+    expect(screen.getByText('natuur')).toBeTruthy();
+    expect(screen.queryByText('extra')).toBeNull();
+  });
+
+  test('falls back to the explanation when no definition is given', async () => {
+    searchBegrippen.mockResolvedValue({
+      items: [{ uri: 'urn:begrip:2', naam: 'Boom', uitleg: 'Een houtachtig gewas' }],
+      page: { number: 1, size: 10 },
+      hasNext: false,
+    });
+    render(<DsoExplorer />);
+
+    expect(await screen.findByText('Een houtachtig gewas')).toBeTruthy();
+  });
+
+  test('prefers the definition over the explanation when both are present', async () => {
+    searchBegrippen.mockResolvedValue({
+      items: [
+        { uri: 'urn:begrip:3', naam: 'Boom', definitie: 'De definitie', uitleg: 'De uitleg' },
+      ],
+      page: { number: 1, size: 10 },
+      hasNext: false,
+    });
+    render(<DsoExplorer />);
+
+    expect(await screen.findByText('De definitie')).toBeTruthy();
+    expect(screen.queryByText('De uitleg')).toBeNull();
+  });
+
+  test('renders a bare concept with neither dates, text nor keywords', async () => {
+    searchBegrippen.mockResolvedValue({
+      items: [{ uri: 'urn:begrip:4', naam: 'Kaal begrip', trefwoorden: [] }],
+      page: { number: 1, size: 10 },
+      hasNext: false,
+    });
+    render(<DsoExplorer />);
+
+    expect(await screen.findByText('Kaal begrip')).toBeTruthy();
+    expect(screen.getByTitle('urn:begrip:4')).toBeTruthy();
+  });
+
+  test('a non-Error rejection surfaces the generic failure message', async () => {
+    searchBegrippen.mockRejectedValue('boom');
+    render(<DsoExplorer />);
+
+    expect(await screen.findByText('Failed to load')).toBeTruthy();
+  });
+});
+
+describe('DsoExplorer — Works detail panel', () => {
+  async function openWithDetail(versies: unknown[]) {
+    zoekWerkzaamheden.mockResolvedValue({
+      items: [{ urn: 'urn:w:1', omschrijving: 'Kappen', functioneleStructuurRef: 'fs-1' }],
+      page: { number: 1, size: 20 },
+      hasNext: false,
+    });
+    getWerkzaamheidDetail.mockResolvedValue(versies);
+    await openTab(/Works/);
+    await userEvent.click(await screen.findByText('Kappen'));
+  }
+
+  test('shows the open version, its keywords and its relations', async () => {
+    await openWithDetail([
+      {
+        urn: 'urn:w:1',
+        omschrijving: 'Kappen van een boom',
+        beginDatum: '2024-01-01',
+        eindDatum: null,
+        trefwoorden: ['kap', 'boom'],
+        logischeRelaties: [{ urn: 'urn:rel:1', omschrijving: 'Snoeien' }, { urn: 'urn:rel:2' }],
+      },
+    ]);
+
+    expect(await screen.findByText('Kappen van een boom')).toBeTruthy();
+    expect(screen.getByText('∞')).toBeTruthy();
+    expect(screen.getByText('kap')).toBeTruthy();
+    expect(screen.getByText('Related werkzaamheden (2)')).toBeTruthy();
+    expect(screen.getByText('Snoeien')).toBeTruthy();
+    expect(screen.getByText('urn:rel:2')).toBeTruthy();
+  });
+
+  test('falls back to the first version when every version has ended', async () => {
+    await openWithDetail([
+      {
+        urn: 'urn:w:1',
+        omschrijving: 'Oude versie',
+        beginDatum: '2020-01-01',
+        eindDatum: '2022-01-01',
+      },
+      {
+        urn: 'urn:w:1',
+        omschrijving: 'Nog oudere',
+        beginDatum: '2018-01-01',
+        eindDatum: '2020-01-01',
+      },
+    ]);
+
+    expect((await screen.findAllByText('Oude versie')).length).toBeGreaterThan(0);
+    expect(screen.getByText('Version history (2)')).toBeTruthy();
+    expect(screen.getAllByText(/2022-01-01/).length).toBeGreaterThan(0);
+  });
+
+  test('marks the still-open version as current in the history list', async () => {
+    await openWithDetail([
+      { urn: 'urn:w:1', omschrijving: 'Huidig', beginDatum: '2024-01-01', eindDatum: null },
+      { urn: 'urn:w:1', omschrijving: 'Vorig', beginDatum: '2020-01-01', eindDatum: '2024-01-01' },
+    ]);
+
+    expect(await screen.findByText('current')).toBeTruthy();
+  });
+
+  test('shows the detail error when the lookup fails', async () => {
+    zoekWerkzaamheden.mockResolvedValue({
+      items: [{ urn: 'urn:w:1', omschrijving: 'Kappen' }],
+      page: { number: 1, size: 20 },
+      hasNext: false,
+    });
+    getWerkzaamheidDetail.mockRejectedValue(new Error('detail unavailable'));
+    await openTab(/Works/);
+    await userEvent.click(await screen.findByText('Kappen'));
+
+    expect(await screen.findByText('detail unavailable')).toBeTruthy();
+  });
+
+  test('closing the detail panel returns to the list only', async () => {
+    await openWithDetail([
+      { urn: 'urn:w:1', omschrijving: 'Kappen van een boom', beginDatum: '2024-01-01' },
+    ]);
+    await screen.findByText('Werkzaamheid detail');
+
+    await userEvent.click(
+      screen.getByText('Werkzaamheid detail').nextElementSibling as HTMLElement
+    );
+
+    expect(screen.queryByText('Werkzaamheid detail')).toBeNull();
+  });
+
+  test('clicking the selected row again deselects it', async () => {
+    await openWithDetail([
+      { urn: 'urn:w:1', omschrijving: 'Kappen van een boom', beginDatum: '2024-01-01' },
+    ]);
+    await screen.findByText('Werkzaamheid detail');
+
+    await userEvent.click(screen.getByText('Kappen'));
+
+    expect(screen.queryByText('Werkzaamheid detail')).toBeNull();
+  });
+
+  test('a row falls back to its URN when it carries no description', async () => {
+    zoekWerkzaamheden.mockResolvedValue({
+      items: [{ urn: 'urn:w:bare' }],
+      page: { number: 1, size: 20 },
+      hasNext: false,
+    });
+    await openTab(/Works/);
+
+    expect((await screen.findAllByText('urn:w:bare')).length).toBeGreaterThan(0);
+  });
+
+  test('the search error is surfaced above the list', async () => {
+    zoekWerkzaamheden.mockRejectedValue(new Error('werk search down'));
+    await openTab(/Works/);
+
+    expect(await screen.findByText('werk search down')).toBeTruthy();
+  });
+});
+
+describe('DsoExplorer — Works suggestions', () => {
+  test('typing two or more characters shows suggestions, and picking one searches', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    zoekWerkzaamheden.mockResolvedValue(emptyResult());
+    suggereerWerkzaamheden.mockResolvedValue(['kappen', 'kapvergunning']);
+    await openTab(/Works/);
+    await screen.findByPlaceholderText('Search werkzaamheden…');
+
+    await userEvent.type(screen.getByPlaceholderText('Search werkzaamheden…'), 'ka');
+    await act(() => vi.advanceTimersByTimeAsync(300));
+
+    expect(await screen.findByRole('button', { name: 'kapvergunning' })).toBeTruthy();
+
+    await userEvent.click(screen.getByRole('button', { name: 'kapvergunning' }));
+
+    expect(zoekWerkzaamheden).toHaveBeenLastCalledWith('kapvergunning', 1, 'pre');
+    vi.useRealTimers();
+  });
+
+  test('a single character does not trigger a suggestion lookup', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    zoekWerkzaamheden.mockResolvedValue(emptyResult());
+    await openTab(/Works/);
+    await screen.findByPlaceholderText('Search werkzaamheden…');
+
+    await userEvent.type(screen.getByPlaceholderText('Search werkzaamheden…'), 'k');
+    await act(() => vi.advanceTimersByTimeAsync(500));
+
+    expect(suggereerWerkzaamheden).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  test('an empty suggestion list leaves the dropdown closed', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    zoekWerkzaamheden.mockResolvedValue(emptyResult());
+    suggereerWerkzaamheden.mockResolvedValue([]);
+    await openTab(/Works/);
+    await screen.findByPlaceholderText('Search werkzaamheden…');
+
+    await userEvent.type(screen.getByPlaceholderText('Search werkzaamheden…'), 'ka');
+    await act(() => vi.advanceTimersByTimeAsync(300));
+
+    expect(screen.queryByRole('button', { name: 'kappen' })).toBeNull();
+    vi.useRealTimers();
+  });
+
+  test('Escape dismisses the suggestion dropdown', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    zoekWerkzaamheden.mockResolvedValue(emptyResult());
+    suggereerWerkzaamheden.mockResolvedValue(['kappen']);
+    await openTab(/Works/);
+    const field = await screen.findByPlaceholderText('Search werkzaamheden…');
+
+    await userEvent.type(field, 'ka');
+    await act(() => vi.advanceTimersByTimeAsync(300));
+    await screen.findByRole('button', { name: 'kappen' });
+
+    await userEvent.type(field, '{Escape}');
+
+    expect(screen.queryByRole('button', { name: 'kappen' })).toBeNull();
+    vi.useRealTimers();
+  });
+});
+
+describe('DsoExplorer — activity detail', () => {
+  async function openActivities() {
+    getActiviteiten.mockResolvedValue(emptyResult());
+    await openTab(/Activities/);
+    await screen.findByText('Valid on');
+  }
+
+  async function inspect(urn: string) {
+    await userEvent.type(
+      screen.getByPlaceholderText('Paste URN to inspect directly…'),
+      `${urn}{Enter}`
+    );
+  }
+
+  test('an activity with no description shows a placeholder and no-rules notice', async () => {
+    getActiviteitDetail.mockResolvedValue({ urn: 'urn:a:1', verfijnbaar: true });
+    await openActivities();
+
+    await inspect('urn:a:1');
+
+    expect(await screen.findByText('No description')).toBeTruthy();
+    expect(screen.getByText('None registered')).toBeTruthy();
+    expect(screen.getByText('Yes')).toBeTruthy();
+    expect(screen.getByText('—')).toBeTruthy();
+  });
+
+  test('a parent link can be navigated into', async () => {
+    getActiviteitDetail
+      .mockResolvedValueOnce({
+        urn: 'urn:a:child',
+        omschrijving: 'Child activity',
+        verfijnbaar: false,
+        _links: {
+          bovenliggendeActiviteit: { href: 'https://dso.example/activiteiten/urn%3Aa%3Aparent' },
+        },
+      })
+      .mockResolvedValue({
+        urn: 'urn:a:parent',
+        omschrijving: 'Parent activity',
+        verfijnbaar: false,
+      });
+    await openActivities();
+
+    await inspect('urn:a:child');
+    await screen.findByText('Parent activity');
+
+    await userEvent.click(screen.getByRole('button', { name: 'urn:a:parent' }));
+
+    expect(await screen.findByText('Parent activity', { selector: 'p' })).toBeTruthy();
+  });
+
+  test('a child whose name cannot be resolved falls back to its URN', async () => {
+    getActiviteitDetail.mockImplementation(async (urn: string) => {
+      if (urn === 'urn:a:root') {
+        return {
+          urn: 'urn:a:root',
+          omschrijving: 'Root',
+          verfijnbaar: false,
+          _links: {
+            onderliggendeActiviteiten: [{ href: 'https://dso.example/activiteiten/urn%3Aa%3Akid' }],
+          },
+        };
+      }
+      throw new Error('child lookup failed');
+    });
+    await openActivities();
+
+    await inspect('urn:a:root');
+
+    expect(await screen.findByText('Child activities (1)')).toBeTruthy();
+    expect(screen.getByText('urn:a:kid')).toBeTruthy();
+  });
+
+  test('a 404 is rephrased as an environment-specific message', async () => {
+    getActiviteitDetail.mockRejectedValue(new Error('HTTP 404'));
+    await openActivities();
+
+    await inspect('urn:a:gone');
+
+    expect(
+      await screen.findByText(/not available in the pre-production DSO environment/)
+    ).toBeTruthy();
+  });
+
+  test('a 404 names the production environment when env="prod"', async () => {
+    searchBegrippen.mockResolvedValue(emptyResult());
+    getActiviteiten.mockResolvedValue(emptyResult());
+    getActiviteitDetail.mockRejectedValue(new Error('HTTP 404'));
+    render(<DsoExplorer env="prod" />);
+    await screen.findByPlaceholderText('Search concepts…');
+    await userEvent.click(screen.getByRole('button', { name: /Activities/ }));
+    await screen.findByText('Valid on');
+
+    await inspect('urn:a:gone');
+
+    expect(await screen.findByText(/not available in the production DSO environment/)).toBeTruthy();
+  });
+
+  test('a non-404 error is shown verbatim', async () => {
+    getActiviteitDetail.mockRejectedValue(new Error('gateway timeout'));
+    await openActivities();
+
+    await inspect('urn:a:slow');
+
+    expect(await screen.findByText('gateway timeout')).toBeTruthy();
+  });
+
+  test('locations and an unknown rule typering are rendered', async () => {
+    fetchToepasbareRegels.mockResolvedValue({ items: [] });
+    getActiviteitDetail.mockResolvedValue({
+      urn: 'urn:a:2',
+      omschrijving: 'Met locaties',
+      verfijnbaar: false,
+      beginDatum: '2024-01-01',
+      eindDatum: '2030-01-01',
+      regelBeheerObjecten: [{ typering: 'onbekend', functioneleStructuurRef: 'fs-x' }],
+      locaties: [{ identificatie: 'loc-1' }, { identificatie: 'loc-2' }],
+    });
+    await openActivities();
+
+    await inspect('urn:a:2');
+
+    expect(await screen.findByText('Locations (2)')).toBeTruthy();
+    expect(screen.getByText('loc-1')).toBeTruthy();
+    expect(screen.getByText('onbekend')).toBeTruthy();
+    expect(screen.getByText('2030-01-01')).toBeTruthy();
+  });
+
+  test('an authority outside the known presets is labelled by its bare code', async () => {
+    fetchToepasbareRegels.mockResolvedValue({
+      items: [{ identifier: 7, begindatum: '2024-02-01', sttrVersie: 3 }],
+    });
+    getActiviteitDetail.mockResolvedValue({
+      urn: 'urn:a:3',
+      omschrijving: 'Elders',
+      verfijnbaar: false,
+      bestuursorgaan: {
+        oin: '99999999999999999999',
+        bestuurslaag: 'gemeente',
+        organisatieType: 'GM',
+        organisatieCode: '0995',
+      },
+      regelBeheerObjecten: [{ typering: 'Conclusie', functioneleStructuurRef: 'fs-1' }],
+    });
+    await openActivities();
+
+    await inspect('urn:a:3');
+
+    expect((await screen.findAllByText('Decision criteria')).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Valid from:/)).toBeTruthy();
+    expect(screen.getByText(/STTR version:/)).toBeTruthy();
+    const publish = screen.getByRole('link', { name: /Publish via CPSV Editor/ });
+    expect(publish.getAttribute('href')).toContain('authority=GM0995');
+  });
+
+  test('a rules lookup failure is shown inside the rule row', async () => {
+    fetchToepasbareRegels.mockRejectedValue(new Error('rules unavailable'));
+    getActiviteitDetail.mockResolvedValue({
+      urn: 'urn:a:4',
+      omschrijving: 'Met regels',
+      verfijnbaar: false,
+      regelBeheerObjecten: [{ typering: 'conclusie', functioneleStructuurRef: 'fs-1' }],
+    });
+    await openActivities();
+
+    await inspect('urn:a:4');
+
+    expect(await screen.findByText('rules unavailable')).toBeTruthy();
+  });
+
+  test('an empty rules list reports that none were found', async () => {
+    fetchToepasbareRegels.mockResolvedValue({ items: [] });
+    getActiviteitDetail.mockResolvedValue({
+      urn: 'urn:a:5',
+      omschrijving: 'Zonder regels',
+      verfijnbaar: false,
+      regelBeheerObjecten: [{ typering: 'conclusie', functioneleStructuurRef: 'fs-1' }],
+    });
+    await openActivities();
+
+    await inspect('urn:a:5');
+
+    expect(await screen.findByText('No toepasbare regels found.')).toBeTruthy();
+  });
+
+  test('a rule object without a functioneleStructuurRef is not offered as a candidate', async () => {
+    getActiviteitDetail.mockResolvedValue({
+      urn: 'urn:a:6',
+      omschrijving: 'Zonder ref',
+      verfijnbaar: false,
+      regelBeheerObjecten: [{ typering: 'conclusie' }],
+    });
+    await openActivities();
+
+    await inspect('urn:a:6');
+
+    await screen.findByText('Rule types present');
+    expect(screen.queryByText(/Applicable rules/)).toBeNull();
+    expect(fetchToepasbareRegels).not.toHaveBeenCalled();
+  });
+});
+
+describe('DsoExplorer — form scaffold actions', () => {
+  async function openWithSubmissionRule() {
+    getActiviteiten.mockResolvedValue(emptyResult());
+    fetchToepasbareRegels.mockResolvedValue({ items: [{ identifier: 11 }] });
+    getActiviteitDetail.mockResolvedValue({
+      urn: 'urn:a:form',
+      omschrijving: 'Aanvraag',
+      verfijnbaar: false,
+      regelBeheerObjecten: [{ typering: 'indieningsvereisten', functioneleStructuurRef: 'fs-1' }],
+    });
+    searchBegrippen.mockResolvedValue(emptyResult());
+    render(<DsoExplorer />);
+    await screen.findByPlaceholderText('Search concepts…');
+    await userEvent.click(screen.getByRole('button', { name: /Activities/ }));
+    await screen.findByText('Valid on');
+    await userEvent.type(
+      screen.getByPlaceholderText('Paste URN to inspect directly…'),
+      'urn:a:form{Enter}'
+    );
+    await screen.findAllByText('Submission requirements');
+  }
+
+  test('downloading the scaffold builds a JSON blob', async () => {
+    const createObjectURL = vi.fn().mockReturnValue('blob:mock');
+    global.URL.createObjectURL = createObjectURL;
+    global.URL.revokeObjectURL = vi.fn();
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    fetchFormScaffold.mockResolvedValue({ id: 'form-11', components: [] });
+
+    await openWithSubmissionRule();
+    await userEvent.click(screen.getByRole('button', { name: /Form scaffold/ }));
+
+    await vi.waitFor(() => expect(createObjectURL).toHaveBeenCalled());
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    expect(JSON.parse(await blob.text())).toEqual({ id: 'form-11', components: [] });
+  });
+
+  test('a scaffold failure is reported next to the button', async () => {
+    fetchFormScaffold.mockRejectedValue(new Error('scaffold unavailable'));
+
+    await openWithSubmissionRule();
+    await userEvent.click(screen.getByRole('button', { name: /Form scaffold/ }));
+
+    expect(await screen.findByText('scaffold unavailable')).toBeTruthy();
+  });
+
+  test('an import failure is reported next to the button', async () => {
+    fetchFormScaffold.mockRejectedValue(new Error('import blew up'));
+
+    await openWithSubmissionRule();
+    await userEvent.click(screen.getByRole('button', { name: /Import into LDE/ }));
+
+    expect(await screen.findByText('import blew up')).toBeTruthy();
+    expect(saveForm).not.toHaveBeenCalled();
+  });
+
+  test('the imported form is named after the activity and tagged Dutch', async () => {
+    fetchFormScaffold.mockResolvedValue({ id: 'scaffold', components: [] });
+
+    await openWithSubmissionRule();
+    await userEvent.click(screen.getByRole('button', { name: /Import into LDE/ }));
+
+    await vi.waitFor(() => expect(saveForm).toHaveBeenCalled());
+    expect(saveForm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'form_dso_11',
+        name: 'Aanvraag — Submission requirements',
+        language: 'nl',
+        status: 'dso',
+      })
+    );
+  });
+});
+
+describe('DsoExplorer — Activities toolbar', () => {
+  async function openActivities() {
+    getActiviteiten.mockResolvedValue(emptyResult());
+    await openTab(/Activities/);
+    await screen.findByText('Valid on');
+  }
+
+  test('a date is converted to the DSO day-month-year format on Load', async () => {
+    await openActivities();
+
+    const dateField = document.querySelector('input[type="date"]') as HTMLInputElement;
+    await userEvent.type(dateField, '2026-03-14');
+    await userEvent.click(screen.getByRole('button', { name: 'Load' }));
+
+    await vi.waitFor(() =>
+      expect(getActiviteiten).toHaveBeenLastCalledWith('14-03-2026', 1, 'pre')
+    );
+  });
+
+  test('Load re-queries by OIN while a location preset is active', async () => {
+    getActiviteitenByOin.mockResolvedValue(emptyResult());
+    await openActivities();
+    await userEvent.click(screen.getByRole('button', { name: 'Flevoland' }));
+    getActiviteitenByOin.mockClear();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Load' }));
+
+    await vi.waitFor(() => expect(getActiviteitenByOin).toHaveBeenCalled());
+  });
+
+  test('clicking the active preset again returns to the unfiltered list', async () => {
+    getActiviteitenByOin.mockResolvedValue(emptyResult());
+    await openActivities();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Ede' }));
+    expect(await screen.findByPlaceholderText(/Filter Ede activities/)).toBeTruthy();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Ede' }));
+
+    await vi.waitFor(() =>
+      expect(screen.queryByPlaceholderText(/Filter Ede activities/)).toBeNull()
+    );
+  });
+
+  test('the name filter can be cleared with its own button', async () => {
+    getActiviteitenByOin.mockResolvedValue({
+      items: [{ urn: 'a1', omschrijving: 'Kapvergunning' }],
+      page: { number: 1, size: 10 },
+      hasNext: false,
+    });
+    await openActivities();
+    await userEvent.click(screen.getByRole('button', { name: 'Gelderland' }));
+    await screen.findByText('Kapvergunning');
+
+    await userEvent.type(screen.getByPlaceholderText(/Filter Gelderland/), 'zzz');
+    expect(screen.getByText(/No activities matching/)).toBeTruthy();
+
+    const clearFilter = screen
+      .getByPlaceholderText(/Filter Gelderland/)
+      .closest('div')!.parentElement!;
+    await userEvent.click(within(clearFilter).getByRole('button', { name: 'Clear' }));
+
+    expect(screen.getByText('Kapvergunning')).toBeTruthy();
+  });
+
+  test('an empty authority set gets its own message in OIN mode', async () => {
+    getActiviteitenByOin.mockResolvedValue(emptyResult());
+    await openActivities();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Lelystad' }));
+
+    expect(
+      await screen.findByText('No activities found for this authority on the selected date.')
+    ).toBeTruthy();
+  });
+
+  test('OIN mode reports a count instead of a page number and hides pagination', async () => {
+    getActiviteitenByOin.mockResolvedValue({
+      items: [{ urn: 'a1', omschrijving: 'Kapvergunning' }],
+      page: { number: 1, size: 10 },
+      hasNext: true,
+    });
+    await openActivities();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Lelystad' }));
+
+    expect(await screen.findByText('1 activities')).toBeTruthy();
+    await userEvent.type(screen.getByPlaceholderText(/Filter Lelystad/), 'Kap');
+    expect(screen.getByText('1 of 1 activities')).toBeTruthy();
+  });
+
+  test('the Inspect button opens the detail panel for a pasted URN', async () => {
+    getActiviteitDetail.mockResolvedValue({
+      urn: 'urn:manual',
+      omschrijving: 'Manual activity',
+      verfijnbaar: false,
+    });
+    await openActivities();
+
+    const field = screen.getByPlaceholderText('Paste URN to inspect directly…');
+    expect(screen.getByRole('button', { name: 'Inspect' })).toBeDisabled();
+
+    await userEvent.type(field, 'urn:manual');
+    await userEvent.click(screen.getByRole('button', { name: 'Inspect' }));
+
+    expect(await screen.findByText('Manual activity')).toBeTruthy();
+  });
+
+  test('pressing Enter on a blank URN field does nothing', async () => {
+    await openActivities();
+
+    await userEvent.type(screen.getByPlaceholderText('Paste URN to inspect directly…'), '{Enter}');
+
+    expect(screen.queryByText('Activity detail')).toBeNull();
+  });
+
+  test('a row shows its parent URN and can be deselected by clicking again', async () => {
+    getActiviteiten.mockResolvedValue({
+      items: [
+        {
+          urn: 'urn:a:kid',
+          omschrijving: 'Kind',
+          _links: {
+            bovenliggendeActiviteit: { href: 'https://dso.example/activiteiten/urn%3Aa%3Aouder' },
+          },
+        },
+      ],
+      page: { number: 1, size: 10 },
+      hasNext: false,
+    });
+    getActiviteitDetail.mockResolvedValue({
+      urn: 'urn:a:kid',
+      omschrijving: 'Kind',
+      verfijnbaar: false,
+    });
+    await openTab(/Activities/);
+
+    expect(await screen.findByText(/↳ urn:a:ouder/)).toBeTruthy();
+
+    await userEvent.click(screen.getByText('Kind'));
+    await screen.findByText('Activity detail');
+
+    await userEvent.click(screen.getAllByText('Kind')[0]);
+    await vi.waitFor(() => expect(screen.queryByText('Activity detail')).toBeNull());
+  });
+
+  test('the list error is surfaced when the activities query fails', async () => {
+    getActiviteiten.mockRejectedValue(new Error('activities down'));
+    await openTab(/Activities/);
+
+    expect(await screen.findByText('activities down')).toBeTruthy();
+  });
+
+  test('paging forward reloads the list and clears the selection', async () => {
+    getActiviteiten.mockResolvedValue({
+      items: [{ urn: 'a1', omschrijving: 'Kapvergunning' }],
+      page: { number: 1, size: 10 },
+      hasNext: true,
+    });
+    await openTab(/Activities/);
+    await screen.findByText('Kapvergunning');
+
+    const [prev, next] = screen.getAllByRole('button').slice(-2);
+    expect(prev).toBeDisabled();
+    await userEvent.click(next);
+
+    await vi.waitFor(() => expect(getActiviteiten).toHaveBeenLastCalledWith(undefined, 2, 'pre'));
+    expect(screen.getByText('Page 2 · 1 items')).toBeTruthy();
   });
 });

--- a/packages/frontend/src/components/FormEditor/FormCanvas.test.tsx
+++ b/packages/frontend/src/components/FormEditor/FormCanvas.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
@@ -31,6 +31,8 @@ vi.mock('@bpmn-io/form-js', () => ({
       instances.push(this as unknown as MockFormJsEditor);
     }
     importSchema(schema: Record<string, unknown>) {
+      // A schema carrying __fail stands in for one form-js cannot parse.
+      if (schema.__fail) return Promise.reject(new Error('bad schema'));
       this.schema = schema;
       return Promise.resolve();
     }
@@ -84,7 +86,7 @@ describe('FormCanvas', () => {
     const { editor } = await renderCanvas();
     expect(screen.getByRole('button', { name: /Save/ })).toBeDisabled();
 
-    editor.emit('changed');
+    act(() => editor.emit('changed'));
     expect(await screen.findByRole('button', { name: /Save/ })).not.toBeDisabled();
   });
 
@@ -95,7 +97,7 @@ describe('FormCanvas', () => {
 
   test('clicking Save calls onSave with the saved schema and resets the dirty state', async () => {
     const { editor, onSave, onDirtyChange } = await renderCanvas();
-    editor.emit('changed');
+    act(() => editor.emit('changed'));
     await screen.findByRole('button', { name: /Save/ }).then((b) => expect(b).not.toBeDisabled());
 
     await userEvent.click(screen.getByRole('button', { name: /Save/ }));
@@ -108,10 +110,10 @@ describe('FormCanvas', () => {
 
   test('a subsequent edit after saving re-triggers the dirty signal', async () => {
     const { editor, onDirtyChange } = await renderCanvas();
-    editor.emit('changed');
+    act(() => editor.emit('changed'));
     await userEvent.click(screen.getByRole('button', { name: /Save/ }));
 
-    editor.emit('changed');
+    act(() => editor.emit('changed'));
     expect(await screen.findByRole('button', { name: /Save/ })).not.toBeDisabled();
     expect(onDirtyChange).toHaveBeenLastCalledWith(true);
   });
@@ -137,6 +139,68 @@ describe('FormCanvas', () => {
     });
     expect(clickSpy).toHaveBeenCalled();
     expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+  });
+
+  test('a repeat change event before saving does not re-signal dirty', async () => {
+    const { editor, onDirtyChange } = await renderCanvas();
+
+    act(() => editor.emit('changed'));
+    act(() => editor.emit('changed'));
+    act(() => editor.emit('changed'));
+
+    expect(onDirtyChange).toHaveBeenCalledTimes(1);
+    expect(onDirtyChange).toHaveBeenCalledWith(true);
+  });
+
+  test('Export omits wrapper metadata when neither language nor organization is set', async () => {
+    const createObjectURL = vi.fn().mockReturnValue('blob:mock-url');
+    global.URL.createObjectURL = createObjectURL;
+    global.URL.revokeObjectURL = vi.fn();
+    let downloadName = '';
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+      this: HTMLAnchorElement
+    ) {
+      downloadName = this.download;
+    });
+
+    await renderCanvas();
+    await userEvent.click(screen.getByText('Export .form'));
+
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    expect(JSON.parse(await blob.text())).toEqual({ id: 'form-1', components: [] });
+    expect(downloadName).toBe('form-1.form');
+  });
+
+  test('Export falls back to "form" as the filename when the schema has no id', async () => {
+    global.URL.createObjectURL = vi.fn().mockReturnValue('blob:mock-url');
+    global.URL.revokeObjectURL = vi.fn();
+    let downloadName = '';
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+      this: HTMLAnchorElement
+    ) {
+      downloadName = this.download;
+    });
+
+    await renderCanvas({ schema: { components: [] } });
+    await userEvent.click(screen.getByText('Export .form'));
+
+    expect(downloadName).toBe('form.form');
+  });
+
+  test('logs and keeps the toolbar usable when the schema cannot be imported', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { editor } = await renderCanvas({ schema: { __fail: true } });
+
+    await vi.waitFor(() =>
+      expect(consoleError).toHaveBeenCalledWith(
+        'Failed to import form schema:',
+        expect.objectContaining({ message: 'bad schema' })
+      )
+    );
+    // No `changed` listener is wired up, so the canvas can never go dirty.
+    expect(editor.listeners.changed).toBeUndefined();
+    expect(screen.getByRole('button', { name: /Save/ })).toBeDisabled();
   });
 
   test('Close calls onClose', async () => {

--- a/packages/frontend/src/components/FormEditor/FormEditor.test.tsx
+++ b/packages/frontend/src/components/FormEditor/FormEditor.test.tsx
@@ -369,3 +369,158 @@ describe('FormEditor — close / discard-changes gate', () => {
     expect(screen.getByText('No form selected')).toBeTruthy();
   });
 });
+
+describe('FormEditor — guards and no-ops', () => {
+  function setup(forms = [form()], lookup = form()) {
+    getForms.mockReturnValue(forms);
+    getForm.mockReturnValue(lookup);
+    getStoredVersion.mockReturnValue(Infinity);
+    hydrateFromServer.mockResolvedValue(forms);
+  }
+
+  test('creating a new form while dirty is cancelled when the discard prompt is declined', async () => {
+    setup();
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    render(<FormEditor />);
+
+    await userEvent.click(screen.getByText('load-f1'));
+    await userEvent.click(screen.getByText('mark-dirty'));
+    saveForm.mockClear();
+
+    await userEvent.click(screen.getByText('create-form'));
+
+    expect(window.confirm).toHaveBeenCalled();
+    expect(saveForm).not.toHaveBeenCalled();
+    expect(screen.getByText('active:f1')).toBeTruthy();
+  });
+
+  test('re-loading the already-active form is a no-op, even while dirty', async () => {
+    setup();
+    const confirmSpy = vi.spyOn(window, 'confirm');
+    render(<FormEditor />);
+
+    await userEvent.click(screen.getByText('load-f1'));
+    await userEvent.click(screen.getByText('mark-dirty'));
+    await userEvent.click(screen.getByText('load-f1'));
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(screen.getByText('active:f1')).toBeTruthy();
+  });
+
+  test('loading a form that has disappeared leaves the selection untouched', async () => {
+    getForms.mockReturnValue([form(), form({ id: 'f2', name: 'Other' })]);
+    getForm.mockImplementation((id: string) => (id === 'f2' ? undefined : form()));
+    getStoredVersion.mockReturnValue(Infinity);
+    hydrateFromServer.mockResolvedValue(getForms());
+    render(<FormEditor />);
+
+    await userEvent.click(screen.getByText('load-f1'));
+    await userEvent.click(screen.getByText('load-f2'));
+
+    expect(screen.getByText('active:f1')).toBeTruthy();
+  });
+
+  test('saving keeps the committed language and organization when the footer was not touched', async () => {
+    setup(
+      [form({ language: 'de', organization: 'heusden' })],
+      form({
+        language: 'de',
+        organization: 'heusden',
+      })
+    );
+    render(<FormEditor />);
+
+    await userEvent.click(screen.getByText('load-f1'));
+    await userEvent.click(screen.getByText('save-canvas'));
+
+    expect(saveForm).toHaveBeenCalledWith(
+      expect.objectContaining({ language: 'de', organization: 'heusden' })
+    );
+  });
+
+  test('a footer organization edit is merged into the saved form', async () => {
+    setup();
+    render(<FormEditor />);
+
+    await userEvent.click(screen.getByText('load-f1'));
+    await userEvent.click(screen.getByText('set-org'));
+    await userEvent.click(screen.getByText('save-canvas'));
+
+    expect(saveForm).toHaveBeenCalledWith(expect.objectContaining({ organization: 'flevoland' }));
+  });
+
+  test('saving after the form disappeared from storage writes nothing', async () => {
+    getForms.mockReturnValue([form()]);
+    getStoredVersion.mockReturnValue(Infinity);
+    hydrateFromServer.mockResolvedValue([form()]);
+    getForm.mockReturnValue(form());
+    render(<FormEditor />);
+
+    await userEvent.click(screen.getByText('load-f1'));
+    saveForm.mockClear();
+    getForm.mockReturnValue(undefined);
+
+    await userEvent.click(screen.getByText('save-canvas'));
+
+    expect(saveForm).not.toHaveBeenCalled();
+  });
+
+  test('renaming a form that no longer exists writes nothing', async () => {
+    getForms.mockReturnValue([form()]);
+    getStoredVersion.mockReturnValue(Infinity);
+    hydrateFromServer.mockResolvedValue([form()]);
+    getForm.mockReturnValue(form());
+    render(<FormEditor />);
+
+    await userEvent.click(screen.getByText('load-f1'));
+    saveForm.mockClear();
+    getForm.mockReturnValue(undefined);
+
+    await userEvent.click(screen.getByText('rename-active'));
+
+    expect(saveForm).not.toHaveBeenCalled();
+  });
+
+  test('footer edits are ignored while no form is active', async () => {
+    setup([form()]);
+    render(<FormEditor />);
+
+    await userEvent.click(screen.getByText('set-language'));
+    await userEvent.click(screen.getByText('set-org'));
+    await userEvent.click(screen.getByText('load-f1'));
+    await userEvent.click(screen.getByText('save-canvas'));
+
+    expect(saveForm).toHaveBeenCalledWith(
+      expect.objectContaining({ language: undefined, organization: undefined })
+    );
+  });
+
+  test('declining the delete confirmation keeps the form', async () => {
+    setup();
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    render(<FormEditor />);
+
+    await userEvent.click(screen.getByText('load-f1'));
+    await userEvent.click(screen.getByText('delete-f1'));
+
+    expect(deleteForm).not.toHaveBeenCalled();
+    expect(screen.getByText('active:f1')).toBeTruthy();
+  });
+
+  test('deleting a form other than the active one keeps the selection', async () => {
+    getForms.mockReturnValue([form(), form({ id: 'f2', name: 'Other' })]);
+    getForm.mockImplementation((id: string) =>
+      id === 'f2' ? form({ id: 'f2', name: 'Other' }) : form()
+    );
+    getStoredVersion.mockReturnValue(Infinity);
+    hydrateFromServer.mockResolvedValue(getForms());
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    render(<FormEditor />);
+
+    await userEvent.click(screen.getByText('load-f1'));
+    await userEvent.click(screen.getByText('delete-f2'));
+
+    expect(deleteForm).toHaveBeenCalledWith('f2');
+    expect(screen.getByText('active:f1')).toBeTruthy();
+  });
+});

--- a/packages/frontend/src/components/GraphView.test.tsx
+++ b/packages/frontend/src/components/GraphView.test.tsx
@@ -1,0 +1,372 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { SparqlResponse } from '../types';
+import GraphView from './GraphView';
+
+type Cell = { value: string; type?: string };
+
+function response(bindings: Record<string, Cell>[]): SparqlResponse {
+  return {
+    head: { vars: Object.keys(bindings[0] ?? {}) },
+    results: { bindings },
+  } as SparqlResponse;
+}
+
+function spo(s: string, p: string, o: string, oType = 'uri'): Record<string, Cell> {
+  return {
+    s: { value: s, type: 'uri' },
+    p: { value: p, type: 'uri' },
+    o: { value: o, type: oType },
+  };
+}
+
+let resizeCallbacks: ResizeObserverCallback[] = [];
+const disconnect = vi.fn();
+
+class StubResizeObserver implements ResizeObserver {
+  constructor(private cb: ResizeObserverCallback) {
+    resizeCallbacks.push(cb);
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {
+    disconnect();
+  }
+}
+
+function fireResize(width: number, height: number) {
+  act(() => {
+    for (const cb of resizeCallbacks) {
+      cb(
+        [{ contentRect: { width, height } } as unknown as ResizeObserverEntry],
+        {} as ResizeObserver
+      );
+    }
+  });
+}
+
+beforeEach(() => {
+  resizeCallbacks = [];
+  disconnect.mockClear();
+  vi.stubGlobal('ResizeObserver', StubResizeObserver);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** Nodes and links are only appended once the force simulation has been built. */
+function svgOf(container: HTMLElement): SVGSVGElement {
+  return container.querySelector('svg') as SVGSVGElement;
+}
+
+/**
+ * jsdom implements neither SVGSVGElement.width/height animated values (which
+ * d3-zoom reads to derive its extent) nor SVGSVGElement.createSVGPoint. Supply
+ * the one d3 needs so zoom and drag gestures can run.
+ */
+function makeGesturesWork(svg: SVGSVGElement, width = 800, height = 600) {
+  Object.defineProperty(svg, 'width', { value: { baseVal: { value: width } } });
+  Object.defineProperty(svg, 'height', { value: { baseVal: { value: height } } });
+}
+
+/**
+ * d3-drag reads `event.view.document`, but this jsdom build refuses `view` in
+ * the MouseEvent constructor, so attach it to the instance after construction.
+ */
+function dispatchMouse(target: EventTarget, type: string, clientX: number, clientY: number) {
+  const event = new MouseEvent(type, { bubbles: true, cancelable: true, button: 0 });
+  Object.defineProperty(event, 'view', { value: window });
+  Object.defineProperty(event, 'clientX', { value: clientX });
+  Object.defineProperty(event, 'clientY', { value: clientY });
+  target.dispatchEvent(event);
+}
+
+describe('GraphView empty states', () => {
+  test('prompts for a query when there is no data', () => {
+    const { container } = render(<GraphView data={null} />);
+    expect(screen.getByText(/Run a query to visualize the knowledge graph/)).toBeTruthy();
+    expect(svgOf(container).querySelector('.zoom-container')).toBeNull();
+  });
+
+  test('keeps the prompt when the result set is empty', () => {
+    const { container } = render(<GraphView data={response([])} />);
+    expect(screen.getByText(/Run a query to visualize the knowledge graph/)).toBeTruthy();
+    expect(svgOf(container).querySelector('.zoom-container')).toBeNull();
+  });
+
+  test('renders the colour legend regardless of data', () => {
+    render(<GraphView data={null} />);
+    expect(screen.getByText(/Subject \/[\s\S]*Entity/)).toBeTruthy();
+    expect(screen.getByText(/Object[\s\S]*\(URI\/BNode\)/)).toBeTruthy();
+    expect(screen.getByText(/Literal Value/)).toBeTruthy();
+  });
+
+  test('disconnects the resize observer on unmount', () => {
+    const { unmount } = render(<GraphView data={null} />);
+    unmount();
+    expect(disconnect).toHaveBeenCalled();
+  });
+});
+
+describe('GraphView s-p-o bindings', () => {
+  test('builds one node per distinct term and one link per triple', () => {
+    const { container } = render(
+      <GraphView
+        data={response([
+          spo('https://example.org/a', 'https://example.org/p/knows', 'https://example.org/b'),
+          spo('https://example.org/a', 'https://example.org/p/knows', 'https://example.org/c'),
+        ])}
+      />
+    );
+
+    const svg = svgOf(container);
+    expect(svg.querySelectorAll('.nodes > g')).toHaveLength(3);
+    expect(svg.querySelectorAll('.links > g')).toHaveLength(2);
+    expect(svg.querySelector('marker#arrowhead')).not.toBeNull();
+  });
+
+  test('labels links with the last segment of the predicate', () => {
+    const { container } = render(
+      <GraphView data={response([spo('urn:a', 'https://example.org/p/knows', 'urn:b')])} />
+    );
+    const text = svgOf(container).querySelector('.links text');
+    expect(text?.textContent).toBe('knows');
+  });
+
+  test('prefers the fragment when the predicate uses a hash', () => {
+    const { container } = render(
+      <GraphView data={response([spo('urn:a', 'https://example.org/onto#label', 'urn:b')])} />
+    );
+    expect(svgOf(container).querySelector('.links text')?.textContent).toBe('label');
+  });
+
+  test('falls back to the raw predicate when it has no usable segment', () => {
+    const { container } = render(
+      <GraphView data={response([spo('urn:a', 'https://example.org/', 'urn:b')])} />
+    );
+    expect(svgOf(container).querySelector('.links text')?.textContent).toBe('https://example.org/');
+  });
+
+  test('styles semantic predicates differently from ordinary ones', () => {
+    const { container } = render(
+      <GraphView
+        data={response([
+          spo('urn:a', 'http://www.w3.org/2004/02/skos/core#exactMatch', 'urn:b'),
+          spo('urn:a', 'https://example.org/p/knows', 'urn:c'),
+        ])}
+      />
+    );
+
+    const lines = Array.from(svgOf(container).querySelectorAll('.links line'));
+    const semantic = lines.find((l) => l.getAttribute('stroke') === '#10b981');
+    const plain = lines.find((l) => l.getAttribute('stroke') === '#cbd5e1');
+
+    expect(semantic?.getAttribute('stroke-dasharray')).toBe('5,5');
+    expect(semantic?.getAttribute('stroke-width')).toBe('2.5');
+    expect(plain?.getAttribute('stroke-dasharray')).toBe('none');
+    expect(plain?.getAttribute('stroke-width')).toBe('1.5');
+  });
+
+  test('treats dcterms:subject as a semantic link', () => {
+    const { container } = render(
+      <GraphView data={response([spo('urn:a', 'http://purl.org/dc/terms/subject', 'urn:b')])} />
+    );
+    expect(svgOf(container).querySelector('.links line')?.getAttribute('stroke')).toBe('#10b981');
+  });
+
+  test('colours subjects blue, literal objects green and URI objects amber', () => {
+    const { container } = render(
+      <GraphView
+        data={response([
+          spo('urn:subject', 'urn:p', 'a literal', 'literal'),
+          spo('urn:subject', 'urn:p2', 'urn:object'),
+        ])}
+      />
+    );
+
+    const fills = Array.from(svgOf(container).querySelectorAll('.nodes circle')).map((c) =>
+      c.getAttribute('fill')
+    );
+    expect(fills).toContain('#3b82f6');
+    expect(fills).toContain('#10b981');
+    expect(fills).toContain('#f59e0b');
+  });
+
+  test('truncates node labels longer than 25 characters', () => {
+    const long = 'a'.repeat(40);
+    const { container } = render(
+      <GraphView data={response([spo(`urn:${long}`, 'urn:p', 'urn:b')])} />
+    );
+
+    const labels = Array.from(svgOf(container).querySelectorAll('.nodes text')).map(
+      (t) => t.textContent
+    );
+    expect(labels).toContain(`urn:${'a'.repeat(21)}...`);
+    expect(labels).toContain('urn:b');
+  });
+
+  test('falls back to the whole term when it has no trailing segment to label', () => {
+    const { container } = render(
+      <GraphView data={response([spo('https://example.org/', 'urn:p', 'urn:b')])} />
+    );
+    const labels = Array.from(svgOf(container).querySelectorAll('.nodes text')).map(
+      (t) => t.textContent
+    );
+    expect(labels).toContain('https://example.org/');
+  });
+
+  test('exposes the full term as the node tooltip', () => {
+    const { container } = render(
+      <GraphView data={response([spo('https://example.org/a', 'urn:p', 'urn:b')])} />
+    );
+    const titles = Array.from(svgOf(container).querySelectorAll('.nodes title')).map(
+      (t) => t.textContent
+    );
+    expect(titles).toContain('https://example.org/a');
+  });
+
+  test('positions links and nodes once the simulation ticks', async () => {
+    const { container } = render(<GraphView data={response([spo('urn:a', 'urn:p', 'urn:b')])} />);
+
+    await waitFor(() => {
+      const line = svgOf(container).querySelector('.links line');
+      expect(line?.getAttribute('x1')).not.toBeNull();
+    });
+
+    const node = svgOf(container).querySelector('.nodes > g');
+    expect(node?.getAttribute('transform')).toMatch(/^translate\(/);
+  });
+});
+
+describe('GraphView column-based bindings', () => {
+  test('links the first column to every other bound column', () => {
+    const { container } = render(
+      <GraphView
+        data={response([
+          {
+            org: { value: 'urn:svb', type: 'uri' },
+            name: { value: 'Sociale Verzekeringsbank', type: 'literal' },
+            city: { value: 'Amstelveen', type: 'literal' },
+          },
+        ])}
+      />
+    );
+
+    const svg = svgOf(container);
+    expect(svg.querySelectorAll('.nodes > g')).toHaveLength(3);
+    const predicates = Array.from(svg.querySelectorAll('.links text')).map((t) => t.textContent);
+    expect(predicates).toEqual(['name', 'city']);
+  });
+
+  test('ignores rows with fewer than two columns', () => {
+    const { container } = render(
+      <GraphView data={response([{ only: { value: 'urn:a', type: 'uri' } }])} />
+    );
+    expect(svgOf(container).querySelectorAll('.links > g')).toHaveLength(0);
+  });
+
+  test('skips columns that are unbound in a row', () => {
+    const data = {
+      head: { vars: ['org', 'name', 'city'] },
+      results: {
+        bindings: [
+          {
+            org: { value: 'urn:svb', type: 'uri' },
+            name: { value: 'SVB', type: 'literal' },
+            city: undefined,
+          },
+        ],
+      },
+    } as unknown as SparqlResponse;
+
+    const { container } = render(<GraphView data={data} />);
+    expect(svgOf(container).querySelectorAll('.links > g')).toHaveLength(1);
+  });
+
+  test('reuses a node shared by two rows instead of duplicating it', () => {
+    const { container } = render(
+      <GraphView
+        data={response([
+          { org: { value: 'urn:svb', type: 'uri' }, name: { value: 'SVB', type: 'literal' } },
+          { org: { value: 'urn:svb', type: 'uri' }, name: { value: 'S.V.B.', type: 'literal' } },
+        ])}
+      />
+    );
+    expect(svgOf(container).querySelectorAll('.nodes > g')).toHaveLength(3);
+  });
+});
+
+describe('GraphView interaction', () => {
+  test('resizing the wrapper resizes the svg', async () => {
+    const { container } = render(<GraphView data={response([spo('urn:a', 'urn:p', 'urn:b')])} />);
+    expect(svgOf(container).getAttribute('width')).toBe('800');
+
+    fireResize(1024, 512);
+
+    await waitFor(() => expect(svgOf(container).getAttribute('width')).toBe('1024'));
+    expect(svgOf(container).getAttribute('height')).toBe('512');
+  });
+
+  test('zooming transforms the container group rather than the svg', () => {
+    const { container } = render(<GraphView data={response([spo('urn:a', 'urn:p', 'urn:b')])} />);
+    const svg = svgOf(container);
+    makeGesturesWork(svg);
+
+    fireEvent.wheel(svg, { deltaY: -120, clientX: 100, clientY: 100 });
+
+    expect(svg.querySelector('.zoom-container')?.getAttribute('transform')).toMatch(/translate/);
+  });
+
+  test('dragging a node moves it by the pointer delta, and releasing unpins it', async () => {
+    const { container } = render(<GraphView data={response([spo('urn:a', 'urn:p', 'urn:b')])} />);
+    makeGesturesWork(svgOf(container));
+    const node = svgOf(container).querySelector('.nodes > g') as SVGGElement;
+
+    const position = () => {
+      const [x, y] = /translate\(([-\d.]+),([-\d.]+)\)/
+        .exec(node.getAttribute('transform') ?? '')!
+        .slice(1)
+        .map(Number);
+      return { x, y };
+    };
+
+    await waitFor(() => expect(node.getAttribute('transform')).toMatch(/^translate\(/));
+
+    dispatchMouse(node, 'mousedown', 10, 10);
+    const start = position();
+    dispatchMouse(window, 'mousemove', 640, 480);
+
+    // Pinned to the cursor: the node tracks the pointer delta exactly.
+    await waitFor(() => {
+      const moved = position();
+      expect(moved.x - start.x).toBeCloseTo(630, 5);
+      expect(moved.y - start.y).toBeCloseTo(470, 5);
+    });
+    const pinned = position();
+
+    dispatchMouse(window, 'mouseup', 640, 480);
+
+    // Unpinned, the simulation is free to move the node again.
+    await waitFor(() => expect(position()).not.toEqual(pinned));
+  });
+
+  test('re-rendering with new data replaces the previous graph', () => {
+    const { container, rerender } = render(
+      <GraphView data={response([spo('urn:a', 'urn:p', 'urn:b')])} />
+    );
+    expect(svgOf(container).querySelectorAll('.nodes > g')).toHaveLength(2);
+
+    rerender(
+      <GraphView
+        data={response([spo('urn:x', 'urn:p', 'urn:y'), spo('urn:x', 'urn:p', 'urn:z')])}
+      />
+    );
+
+    const svg = svgOf(container);
+    expect(svg.querySelectorAll('.zoom-container')).toHaveLength(1);
+    expect(svg.querySelectorAll('.nodes > g')).toHaveLength(3);
+  });
+});

--- a/packages/frontend/src/components/OrganizationCard.test.tsx
+++ b/packages/frontend/src/components/OrganizationCard.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const resolveLogo = vi.fn();
+vi.mock('../utils/logoResolver', () => ({
+  resolveLogo: (...args: unknown[]) => resolveLogo(...args),
+}));
+
+import OrganizationCard from './OrganizationCard';
+
+function org(overrides: Record<string, unknown> = {}) {
+  return {
+    uri: 'https://example.org/org/svb',
+    identifier: 'SVB',
+    name: 'Sociale Verzekeringsbank',
+    ...overrides,
+  };
+}
+
+describe('OrganizationCard', () => {
+  beforeEach(() => {
+    resolveLogo.mockReset();
+    resolveLogo.mockResolvedValue(null);
+  });
+
+  test('renders name and identifier, and falls back to the placeholder icon without a logo', () => {
+    const { container } = render(<OrganizationCard organization={org()} endpoint="e" />);
+
+    expect(screen.getByText('Sociale Verzekeringsbank')).toBeTruthy();
+    expect(screen.getByText('SVB')).toBeTruthy();
+    expect(container.querySelector('img')).toBeNull();
+    expect(resolveLogo).not.toHaveBeenCalled();
+  });
+
+  test('resolves and renders a logo when the organization has one', async () => {
+    resolveLogo.mockResolvedValue('https://cdn.example.org/svb.png');
+    render(<OrganizationCard organization={org({ logo: './assets/svb.png' })} endpoint="ep" />);
+
+    const img = await screen.findByAltText('Sociale Verzekeringsbank logo');
+    expect(img.getAttribute('src')).toBe('https://cdn.example.org/svb.png');
+    expect(resolveLogo).toHaveBeenCalledWith('./assets/svb.png', 'ep');
+  });
+
+  test('falls back to the placeholder icon when the resolved logo fails to load', async () => {
+    resolveLogo.mockResolvedValue('https://cdn.example.org/broken.png');
+    const { container } = render(
+      <OrganizationCard organization={org({ logo: 'broken.png' })} endpoint="e" />
+    );
+
+    const img = await screen.findByAltText('Sociale Verzekeringsbank logo');
+    fireEvent.error(img);
+
+    await waitFor(() => expect(container.querySelector('img')).toBeNull());
+  });
+
+  test('keeps the placeholder when logo resolution yields nothing', async () => {
+    resolveLogo.mockResolvedValue(null);
+    const { container } = render(
+      <OrganizationCard organization={org({ logo: 'missing.png' })} endpoint="e" />
+    );
+
+    await waitFor(() => expect(resolveLogo).toHaveBeenCalled());
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  test('renders a homepage link and the trailing segment of the spatial URI', async () => {
+    render(
+      <OrganizationCard
+        organization={org({
+          homepage: 'https://www.svb.nl',
+          spatial: 'http://publications.europa.eu/resource/authority/country/NLD',
+        })}
+        endpoint="e"
+      />
+    );
+
+    const link = screen.getByRole('link', { name: /Website/ });
+    expect(link.getAttribute('href')).toBe('https://www.svb.nl');
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(screen.getByText(/NLD/)).toBeTruthy();
+  });
+
+  test('omits the homepage link and spatial line when both are absent', () => {
+    render(<OrganizationCard organization={org()} endpoint="e" />);
+
+    expect(screen.queryByRole('link')).toBeNull();
+    expect(screen.queryByText(/📍/)).toBeNull();
+  });
+
+  test.each([
+    ['small', 'p-3', 'w-12'],
+    ['medium', 'p-4', 'w-16'],
+    ['large', 'p-6', 'w-24'],
+  ] as const)('applies the %s size classes', (size, containerClass, logoClass) => {
+    const { container } = render(
+      <OrganizationCard organization={org()} endpoint="e" size={size} />
+    );
+
+    expect(container.querySelector(`.${containerClass}`)).not.toBeNull();
+    expect(container.querySelector(`.${logoClass}`)).not.toBeNull();
+  });
+
+  test('defaults to the medium size when none is given', () => {
+    const { container } = render(<OrganizationCard organization={org()} endpoint="e" />);
+    expect(container.querySelector('.p-4')).not.toBeNull();
+  });
+
+  test('re-resolves the logo when the endpoint changes', async () => {
+    resolveLogo.mockResolvedValue('https://cdn.example.org/a.png');
+    const { rerender } = render(
+      <OrganizationCard organization={org({ logo: 'a.png' })} endpoint="first" />
+    );
+    await waitFor(() => expect(resolveLogo).toHaveBeenCalledTimes(1));
+
+    rerender(<OrganizationCard organization={org({ logo: 'a.png' })} endpoint="second" />);
+    await waitFor(() => expect(resolveLogo).toHaveBeenCalledTimes(2));
+    expect(resolveLogo).toHaveBeenLastCalledWith('a.png', 'second');
+  });
+});
+
+describe('OrganizationCard accessibility', () => {
+  test('the homepage link opens safely in a new tab', async () => {
+    resolveLogo.mockResolvedValue(null);
+    render(<OrganizationCard organization={org({ homepage: 'https://svb.nl' })} endpoint="e" />);
+    const link = screen.getByRole('link');
+    expect(link.getAttribute('rel')).toBe('noreferrer');
+    await userEvent.hover(link);
+  });
+});

--- a/packages/frontend/src/components/OrganizationsView.test.tsx
+++ b/packages/frontend/src/components/OrganizationsView.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const executeSparqlQuery = vi.fn();
+vi.mock('../services/sparqlService', () => ({
+  executeSparqlQuery: (...args: unknown[]) => executeSparqlQuery(...args),
+}));
+
+vi.mock('./OrganizationCard', () => ({
+  default: ({
+    organization,
+    endpoint,
+    size,
+  }: {
+    organization: { name: string; identifier: string };
+    endpoint: string;
+    size: string;
+  }) => (
+    <div data-testid="org-card">
+      {organization.name} | {organization.identifier} | {endpoint} | {size}
+    </div>
+  ),
+}));
+
+import OrganizationsView from './OrganizationsView';
+
+function binding(overrides: Record<string, { value: string }> = {}) {
+  return {
+    organization: { value: 'https://example.org/org/svb' },
+    identifier: { value: 'SVB' },
+    name: { value: 'Sociale Verzekeringsbank' },
+    ...overrides,
+  };
+}
+
+function response(bindings: unknown[]) {
+  return { head: { vars: [] }, results: { bindings } };
+}
+
+describe('OrganizationsView', () => {
+  beforeEach(() => {
+    executeSparqlQuery.mockReset();
+  });
+
+  test('shows a loading state until the query resolves', async () => {
+    let release: (value: unknown) => void = () => {};
+    executeSparqlQuery.mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve;
+      })
+    );
+
+    render(<OrganizationsView endpoint="e" />);
+    expect(screen.getByText('Loading organizations...')).toBeTruthy();
+
+    release(response([]));
+    await waitFor(() => expect(screen.queryByText('Loading organizations...')).toBeNull());
+  });
+
+  test('renders one card per organization and a pluralised count', async () => {
+    executeSparqlQuery.mockResolvedValue(
+      response([
+        binding(),
+        binding({
+          organization: { value: 'https://example.org/org/uwv' },
+          identifier: { value: 'UWV' },
+          name: { value: 'UWV' },
+        }),
+      ])
+    );
+
+    render(<OrganizationsView endpoint="my-endpoint" />);
+
+    await waitFor(() => expect(screen.getAllByTestId('org-card')).toHaveLength(2));
+    expect(screen.getByText('2 organizations found')).toBeTruthy();
+    expect(screen.getByText('Sociale Verzekeringsbank | SVB | my-endpoint | medium')).toBeTruthy();
+  });
+
+  test('uses the singular noun for exactly one organization', async () => {
+    executeSparqlQuery.mockResolvedValue(response([binding()]));
+    render(<OrganizationsView endpoint="e" />);
+    expect(await screen.findByText('1 organization found')).toBeTruthy();
+  });
+
+  test('maps optional bindings and defaults missing required ones to empty strings', async () => {
+    executeSparqlQuery.mockResolvedValue(
+      response([
+        {
+          homepage: { value: 'https://svb.nl' },
+          logo: { value: 'logo.png' },
+          spatial: { value: 'NLD' },
+        },
+      ])
+    );
+
+    render(<OrganizationsView endpoint="e" />);
+    const card = await screen.findByTestId('org-card');
+    expect(card.textContent).toBe(' |  | e | medium');
+  });
+
+  test('shows the empty state when the dataset has no organizations', async () => {
+    executeSparqlQuery.mockResolvedValue(response([]));
+    render(<OrganizationsView endpoint="e" />);
+    expect(await screen.findByText('No organizations found in this dataset')).toBeTruthy();
+  });
+
+  test('surfaces an Error message and retries on demand', async () => {
+    executeSparqlQuery.mockRejectedValueOnce(new Error('endpoint unreachable'));
+    render(<OrganizationsView endpoint="e" />);
+
+    expect(await screen.findByText('endpoint unreachable')).toBeTruthy();
+
+    executeSparqlQuery.mockResolvedValueOnce(response([binding()]));
+    await userEvent.click(screen.getByRole('button', { name: /Try Again/ }));
+
+    expect(await screen.findByTestId('org-card')).toBeTruthy();
+    expect(screen.queryByText('endpoint unreachable')).toBeNull();
+  });
+
+  test('falls back to a generic message when the rejection is not an Error', async () => {
+    executeSparqlQuery.mockRejectedValue('boom');
+    render(<OrganizationsView endpoint="e" />);
+    expect(await screen.findByText('Failed to load organizations')).toBeTruthy();
+  });
+
+  test('the Refresh button re-runs the query', async () => {
+    executeSparqlQuery.mockResolvedValue(response([binding()]));
+    render(<OrganizationsView endpoint="e" />);
+    await screen.findByTestId('org-card');
+    expect(executeSparqlQuery).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(screen.getByRole('button', { name: /Refresh/ }));
+    await waitFor(() => expect(executeSparqlQuery).toHaveBeenCalledTimes(2));
+  });
+
+  test('reloads when the endpoint prop changes', async () => {
+    executeSparqlQuery.mockResolvedValue(response([binding()]));
+    const { rerender } = render(<OrganizationsView endpoint="first" />);
+    await screen.findByTestId('org-card');
+
+    rerender(<OrganizationsView endpoint="second" />);
+    await waitFor(() => expect(executeSparqlQuery).toHaveBeenCalledTimes(2));
+    expect(executeSparqlQuery).toHaveBeenLastCalledWith(expect.any(String), 'second');
+  });
+
+  test('queries for public organisations ordered by name', async () => {
+    executeSparqlQuery.mockResolvedValue(response([]));
+    render(<OrganizationsView endpoint="e" />);
+    await waitFor(() => expect(executeSparqlQuery).toHaveBeenCalled());
+
+    const query = executeSparqlQuery.mock.calls[0][0] as string;
+    expect(query).toContain('cv:PublicOrganisation');
+    expect(query).toContain('ORDER BY ?name');
+  });
+});

--- a/packages/frontend/src/components/ResultsTable.test.tsx
+++ b/packages/frontend/src/components/ResultsTable.test.tsx
@@ -1,0 +1,294 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const resolveLogo = vi.fn();
+vi.mock('../utils/logoResolver', () => ({
+  resolveLogo: (...args: unknown[]) => resolveLogo(...args),
+}));
+
+import { SparqlResponse } from '../types';
+import ResultsTable from './ResultsTable';
+
+type Cell = { value: string; type?: string; 'xml:lang'?: string };
+
+function response(vars: string[], bindings: Record<string, Cell>[]): SparqlResponse {
+  return { head: { vars }, results: { bindings } } as SparqlResponse;
+}
+
+const COMPLETE_LOGO_URL =
+  'https://api.triplydb.triply.cc/datasets/acme/dataset/assets/asset-1/version-9';
+
+describe('ResultsTable empty and idle states', () => {
+  beforeEach(() => {
+    resolveLogo.mockReset();
+    resolveLogo.mockResolvedValue(null);
+  });
+
+  test('prompts for a query when there is no data at all', () => {
+    render(<ResultsTable data={null} />);
+    expect(screen.getByText('No results yet. Run a query.')).toBeTruthy();
+  });
+
+  test('reports an empty result set', () => {
+    render(<ResultsTable data={response(['s'], [])} />);
+    expect(screen.getByText('Query returned 0 results.')).toBeTruthy();
+  });
+});
+
+describe('ResultsTable regular cells', () => {
+  beforeEach(() => {
+    resolveLogo.mockReset();
+    resolveLogo.mockResolvedValue(null);
+  });
+
+  test('renders a header per variable and a 1-based row index', () => {
+    render(
+      <ResultsTable
+        data={response(
+          ['name', 'age'],
+          [
+            { name: { value: 'Ada' }, age: { value: '36' } },
+            { name: { value: 'Grace' }, age: { value: '45' } },
+          ]
+        )}
+      />
+    );
+
+    expect(screen.getByText('?name')).toBeTruthy();
+    expect(screen.getByText('?age')).toBeTruthy();
+    expect(screen.getByText('1')).toBeTruthy();
+    expect(screen.getByText('2')).toBeTruthy();
+    expect(screen.getByText('Grace')).toBeTruthy();
+  });
+
+  test('renders a dash for a variable unbound in a row', () => {
+    render(<ResultsTable data={response(['name', 'nick'], [{ name: { value: 'Ada' } }])} />);
+    expect(screen.getByText('-')).toBeTruthy();
+  });
+
+  test('renders a URI cell as a link showing its last path segment', () => {
+    render(
+      <ResultsTable
+        data={response(['s'], [{ s: { value: 'https://example.org/things/widget', type: 'uri' } }])}
+      />
+    );
+
+    const link = screen.getByRole('link', { name: 'widget' });
+    expect(link.getAttribute('href')).toBe('https://example.org/things/widget');
+    expect(link.getAttribute('target')).toBe('_blank');
+  });
+
+  test('prefers the fragment over the path segment for a hash URI', () => {
+    render(
+      <ResultsTable
+        data={response(['s'], [{ s: { value: 'https://example.org/onto#Person', type: 'uri' } }])}
+      />
+    );
+    expect(screen.getByRole('link', { name: 'Person' })).toBeTruthy();
+  });
+
+  test('shows a non-http URI verbatim', () => {
+    render(
+      <ResultsTable data={response(['s'], [{ s: { value: 'urn:nl:svb:123', type: 'uri' } }])} />
+    );
+    expect(screen.getByRole('link', { name: 'urn:nl:svb:123' })).toBeTruthy();
+  });
+
+  test('appends the language tag to a tagged literal', () => {
+    render(
+      <ResultsTable
+        data={response(
+          ['label'],
+          [{ label: { value: 'Kapvergunning', type: 'literal', 'xml:lang': 'nl' } }]
+        )}
+      />
+    );
+    expect(screen.getByText('Kapvergunning')).toBeTruthy();
+    expect(screen.getByText('@nl')).toBeTruthy();
+  });
+
+  test('omits the language tag for an untagged literal', () => {
+    render(
+      <ResultsTable data={response(['label'], [{ label: { value: 'plain', type: 'literal' } }])} />
+    );
+    expect(screen.queryByText(/^@/)).toBeNull();
+  });
+});
+
+describe('ResultsTable logo columns', () => {
+  beforeEach(() => {
+    resolveLogo.mockReset();
+    resolveLogo.mockResolvedValue(null);
+  });
+
+  test('does not resolve logos when no endpoint is supplied', async () => {
+    render(<ResultsTable data={response(['logo'], [{ logo: { value: 'a.png' } }])} />);
+    await waitFor(() => expect(screen.getByTitle('a.png')).toBeTruthy());
+    expect(resolveLogo).not.toHaveBeenCalled();
+  });
+
+  test('does not resolve when no column looks like a logo', async () => {
+    render(<ResultsTable data={response(['name'], [{ name: { value: 'x' } }])} endpoint="e" />);
+    await waitFor(() => expect(screen.getByText('x')).toBeTruthy());
+    expect(resolveLogo).not.toHaveBeenCalled();
+  });
+
+  test.each(['logo', 'orgLogo', 'image'])('marks %s as a logo column in the header', (varName) => {
+    render(<ResultsTable data={response([varName], [{ [varName]: { value: 'a.png' } }])} />);
+    const header = screen.getByRole('columnheader', { name: new RegExp(varName) });
+    expect(header.textContent).not.toContain('?');
+  });
+
+  test('resolves each distinct logo path once and renders the image', async () => {
+    resolveLogo.mockResolvedValue('https://cdn.example.org/a.png');
+    render(
+      <ResultsTable
+        data={response(
+          ['logo'],
+          [{ logo: { value: 'assets/a.png' } }, { logo: { value: 'assets/a.png' } }]
+        )}
+        endpoint="ep"
+      />
+    );
+
+    await waitFor(() => expect(screen.getAllByAltText('Organization logo')).toHaveLength(2));
+    expect(resolveLogo).toHaveBeenCalledTimes(1);
+    expect(resolveLogo).toHaveBeenCalledWith('assets/a.png', 'ep');
+    expect(screen.getAllByRole('link', { name: 'a.png' })).toHaveLength(2);
+  });
+
+  test('skips bindings with no value when collecting logo paths', async () => {
+    resolveLogo.mockResolvedValue('https://cdn.example.org/a.png');
+    render(
+      <ResultsTable
+        data={response(['logo'], [{ logo: { value: '' } }, { logo: { value: 'a.png' } }])}
+        endpoint="ep"
+      />
+    );
+
+    await waitFor(() => expect(resolveLogo).toHaveBeenCalledTimes(1));
+    expect(resolveLogo).toHaveBeenCalledWith('a.png', 'ep');
+  });
+
+  test('renders an already-complete TriplyDB asset URL without resolution', async () => {
+    resolveLogo.mockResolvedValue(null);
+    render(
+      <ResultsTable
+        data={response(['logo'], [{ logo: { value: COMPLETE_LOGO_URL } }])}
+        endpoint="e"
+      />
+    );
+
+    const img = await screen.findByAltText('Organization logo');
+    expect(img.getAttribute('src')).toBe(COMPLETE_LOGO_URL);
+  });
+
+  test('shows a pending marker while an incomplete path is unresolved', async () => {
+    resolveLogo.mockResolvedValue(null);
+    render(
+      <ResultsTable data={response(['logo'], [{ logo: { value: 'assets/a.png' } }])} endpoint="e" />
+    );
+    await waitFor(() => expect(resolveLogo).toHaveBeenCalled());
+    const pending = screen.getByTitle('assets/a.png');
+    expect(pending.textContent).toContain('a.png');
+    expect(screen.queryByAltText('Organization logo')).toBeNull();
+  });
+
+  test('switches to an error state when the image fails to load', async () => {
+    resolveLogo.mockResolvedValue('https://cdn.example.org/broken.png');
+    render(
+      <ResultsTable data={response(['logo'], [{ logo: { value: 'broken.png' } }])} endpoint="e" />
+    );
+
+    fireEvent.error(await screen.findByAltText('Organization logo'));
+
+    await waitFor(() => expect(screen.queryByAltText('Organization logo')).toBeNull());
+    const link = screen.getByRole('link', { name: 'broken.png' });
+    expect(link.getAttribute('title')).toContain('Failed to load');
+  });
+
+  test('clicking a logo opens a modal that closes on backdrop click', async () => {
+    resolveLogo.mockResolvedValue('https://cdn.example.org/a.png');
+    const { container } = render(
+      <ResultsTable data={response(['logo'], [{ logo: { value: 'dir/a.png' } }])} endpoint="e" />
+    );
+
+    await userEvent.click(await screen.findByAltText('Organization logo'));
+    expect(screen.getByAltText('a.png')).toBeTruthy();
+
+    await userEvent.click(container.querySelector('.fixed.inset-0') as HTMLElement);
+    await waitFor(() => expect(screen.queryByAltText('a.png')).toBeNull());
+  });
+
+  test('clicking the modal image itself does not close the modal', async () => {
+    resolveLogo.mockResolvedValue('https://cdn.example.org/a.png');
+    render(<ResultsTable data={response(['logo'], [{ logo: { value: 'a.png' } }])} endpoint="e" />);
+
+    await userEvent.click(await screen.findByAltText('Organization logo'));
+    await userEvent.click(screen.getByAltText('a.png'));
+    expect(screen.getByAltText('a.png')).toBeTruthy();
+  });
+
+  test('the close button dismisses the modal', async () => {
+    resolveLogo.mockResolvedValue('https://cdn.example.org/a.png');
+    render(<ResultsTable data={response(['logo'], [{ logo: { value: 'a.png' } }])} endpoint="e" />);
+
+    await userEvent.click(await screen.findByAltText('Organization logo'));
+    await userEvent.click(screen.getByTitle('Close (ESC)'));
+    await waitFor(() => expect(screen.queryByTitle('Close (ESC)')).toBeNull());
+  });
+
+  test('Escape closes the modal and other keys leave it open', async () => {
+    resolveLogo.mockResolvedValue('https://cdn.example.org/a.png');
+    render(<ResultsTable data={response(['logo'], [{ logo: { value: 'a.png' } }])} endpoint="e" />);
+
+    await userEvent.click(await screen.findByAltText('Organization logo'));
+
+    fireEvent.keyDown(document, { key: 'Enter' });
+    expect(screen.getByAltText('a.png')).toBeTruthy();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByAltText('a.png')).toBeNull());
+  });
+
+  test('falls back to "Logo" as the modal alt when the value has no path segment', async () => {
+    resolveLogo.mockResolvedValue('https://cdn.example.org/a.png');
+    render(<ResultsTable data={response(['logo'], [{ logo: { value: 'x/' } }])} endpoint="e" />);
+
+    await userEvent.click(await screen.findByAltText('Organization logo'));
+    expect(screen.getByAltText('Logo')).toBeTruthy();
+  });
+
+  test('clears stale image errors when new data arrives', async () => {
+    resolveLogo.mockResolvedValue('https://cdn.example.org/a.png');
+    const { rerender } = render(
+      <ResultsTable data={response(['logo'], [{ logo: { value: 'a.png' } }])} endpoint="e" />
+    );
+
+    fireEvent.error(await screen.findByAltText('Organization logo'));
+    await waitFor(() => expect(screen.queryByAltText('Organization logo')).toBeNull());
+
+    rerender(
+      <ResultsTable data={response(['logo'], [{ logo: { value: 'a.png' } }])} endpoint="e" />
+    );
+    expect(await screen.findByAltText('Organization logo')).toBeTruthy();
+  });
+
+  test('renders logo and non-logo columns side by side', async () => {
+    resolveLogo.mockResolvedValue('https://cdn.example.org/a.png');
+    render(
+      <ResultsTable
+        data={response(
+          ['name', 'orgLogo'],
+          [{ name: { value: 'SVB' }, orgLogo: { value: 'a.png' } }]
+        )}
+        endpoint="e"
+      />
+    );
+
+    const row = (await screen.findByText('SVB')).closest('tr') as HTMLElement;
+    expect(within(row).getByAltText('Organization logo')).toBeTruthy();
+  });
+});

--- a/packages/frontend/src/components/RopaEditor/RopaEditor.test.tsx
+++ b/packages/frontend/src/components/RopaEditor/RopaEditor.test.tsx
@@ -116,4 +116,35 @@ describe('RopaEditor', () => {
     expect(deleteRopa).toHaveBeenCalledWith('r1');
     expect(await screen.findByText('Select a record or create a new one')).toBeTruthy();
   });
+
+  test('deleting a record other than the active one keeps the selection', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    deleteRopa.mockResolvedValue(undefined);
+    const other = record({ id: 'r2', title: 'Kinderbijslag' });
+    listRopa.mockResolvedValueOnce([record(), other]).mockResolvedValue([record()]);
+    render(<RopaEditor />);
+
+    await userEvent.click(await screen.findByText('Zorgtoeslag'));
+
+    const card = screen.getByText('Kinderbijslag').closest('div')!.parentElement!;
+    await userEvent.click(within(card).getByRole('button'));
+
+    expect(deleteRopa).toHaveBeenCalledWith('r2');
+    expect(await screen.findByRole('heading', { name: 'Zorgtoeslag' })).toBeTruthy();
+  });
+
+  test('survives a failed load and still renders the empty list', async () => {
+    listRopa.mockRejectedValue(new Error('backend unreachable'));
+    render(<RopaEditor />);
+
+    expect(await screen.findByText('Select a record or create a new one')).toBeTruthy();
+    expect(screen.queryByText('Zorgtoeslag')).toBeNull();
+  });
+
+  test('survives a load rejection that is not an Error', async () => {
+    listRopa.mockRejectedValue('boom');
+    render(<RopaEditor />);
+
+    expect(await screen.findByText('Select a record or create a new one')).toBeTruthy();
+  });
 });

--- a/packages/frontend/src/components/ShaclValidator.test.tsx
+++ b/packages/frontend/src/components/ShaclValidator.test.tsx
@@ -1,0 +1,552 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import ShaclValidator from './ShaclValidator';
+
+const API = 'http://api.test';
+
+type Issue = {
+  severity: 'error' | 'warning' | 'info';
+  code: string;
+  message: string;
+  location?: string;
+  line?: number;
+  column?: number;
+};
+
+type LayerOverride = { loaded?: boolean; issues?: Issue[] };
+
+function layers(overrides: Record<string, LayerOverride> = {}) {
+  const build = (label: string, key: string) => ({
+    label,
+    loaded: overrides[key]?.loaded ?? true,
+    issues: overrides[key]?.issues ?? [],
+  });
+  return {
+    cprmv: build('CPRMV', 'cprmv'),
+    'cpsv-ap': build('CPSV-AP', 'cpsv-ap'),
+    'ronl-custom': build('RONL custom', 'ronl-custom'),
+  };
+}
+
+function result(overrides: Record<string, unknown> = {}) {
+  return {
+    valid: true,
+    parseError: null,
+    layers: layers(),
+    summary: { errors: 0, warnings: 0, infos: 0 },
+    ...overrides,
+  };
+}
+
+const TURTLE = '<urn:s> a <urn:C> .';
+
+function ttlFile(name = 'service.ttl', content = TURTLE) {
+  return new File([content], name, { type: 'text/turtle' });
+}
+
+function dropZone(container: HTMLElement): HTMLElement {
+  return container.querySelector('.border-dashed') as HTMLElement;
+}
+
+function dataTransfer(files: File[]) {
+  return { files, items: [], types: ['Files'] } as unknown as DataTransfer;
+}
+
+async function addFiles(container: HTMLElement, files: File[]) {
+  const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+  await userEvent.upload(input, files);
+  for (const file of files) {
+    await screen.findByTitle(file.name);
+  }
+}
+
+function ok(data: unknown) {
+  return { ok: true, status: 200, json: async () => ({ success: true, data }) };
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('ShaclValidator drop zone', () => {
+  test('shows the empty prompt before any file is added', () => {
+    render(<ShaclValidator apiBaseUrl={API} />);
+
+    expect(screen.getByText('Drop Turtle files here')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Clear all/ })).toBeNull();
+  });
+
+  test('switches to the compact prompt once a file is loaded', async () => {
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+    await addFiles(container, [ttlFile()]);
+
+    expect(screen.getByText(/Drop more files or click to browse/)).toBeTruthy();
+    expect(screen.queryByText('Drop Turtle files here')).toBeNull();
+    expect(screen.getByText(/E = error/)).toBeTruthy();
+  });
+
+  test('highlights while dragging and clears the highlight on leave', () => {
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+    const zone = dropZone(container);
+
+    fireEvent.dragOver(zone);
+    expect(zone.className).toContain('border-blue-400');
+
+    fireEvent.dragLeave(zone);
+    expect(zone.className).toContain('border-slate-300');
+  });
+
+  test('accepts .ttl files dropped on the zone', async () => {
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+
+    fireEvent.drop(dropZone(container), {
+      dataTransfer: dataTransfer([ttlFile('a.ttl'), ttlFile('b.ttl')]),
+    });
+
+    expect(await screen.findByTitle('a.ttl')).toBeTruthy();
+    expect(await screen.findByTitle('b.ttl')).toBeTruthy();
+  });
+
+  test('rejects non-Turtle files with a transient warning', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+
+    fireEvent.drop(dropZone(container), {
+      dataTransfer: dataTransfer([ttlFile('notes.txt'), ttlFile('graph.rdf')]),
+    });
+
+    expect(await screen.findByText('Skipped 2 file(s) — only .ttl is accepted.')).toBeTruthy();
+    expect(screen.queryByTitle('notes.txt')).toBeNull();
+
+    await act(() => vi.advanceTimersByTimeAsync(4000));
+    await waitFor(() => expect(screen.queryByText(/Skipped 2 file/)).toBeNull());
+  });
+
+  test('keeps the accepted files from a mixed drop', async () => {
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+
+    fireEvent.drop(dropZone(container), {
+      dataTransfer: dataTransfer([ttlFile('good.ttl'), ttlFile('bad.jsonld')]),
+    });
+
+    expect(await screen.findByTitle('good.ttl')).toBeTruthy();
+    expect(await screen.findByText(/Skipped 1 file/)).toBeTruthy();
+  });
+
+  test('clicking the zone opens the hidden file picker', async () => {
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const click = vi.spyOn(input, 'click');
+
+    await userEvent.click(dropZone(container));
+
+    expect(click).toHaveBeenCalled();
+  });
+
+  test('renders the file size in kilobytes', async () => {
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+    await addFiles(container, [ttlFile('big.ttl', 'x'.repeat(1536))]);
+
+    expect(screen.getByText('1.5 KB')).toBeTruthy();
+  });
+});
+
+describe('ShaclValidator validation modes', () => {
+  test('defaults to file-local validation', async () => {
+    fetchMock.mockResolvedValue(ok(result()));
+
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+    await addFiles(container, [ttlFile()]);
+    await userEvent.click(screen.getByRole('button', { name: 'Validate' }));
+
+    await screen.findByText('Valid');
+    expect(fetchMock).toHaveBeenCalledWith(`${API}/v1/shacl/validate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: TURTLE }),
+    });
+    expect(screen.queryByPlaceholderText(/SPARQL endpoint/)).toBeNull();
+  });
+
+  test('merge-simulated mode reveals the endpoint field and its explanation', async () => {
+    render(<ShaclValidator apiBaseUrl={API} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /Merge-simulated/ }));
+
+    expect(screen.getByPlaceholderText('SPARQL endpoint (blank = server default)')).toBeTruthy();
+    expect(screen.getByText(/unions each file with the already-published triples/)).toBeTruthy();
+  });
+
+  test('merge-simulated mode posts to the merged endpoint without an endpoint override', async () => {
+    fetchMock.mockResolvedValue(ok(result()));
+
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+    await addFiles(container, [ttlFile()]);
+    await userEvent.click(screen.getByRole('button', { name: /Merge-simulated/ }));
+    await userEvent.click(screen.getByRole('button', { name: 'Validate' }));
+
+    await screen.findByText('Valid');
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${API}/v1/shacl/validate-merged`,
+      expect.objectContaining({ body: JSON.stringify({ content: TURTLE }) })
+    );
+  });
+
+  test('a typed endpoint is sent with the merged request', async () => {
+    fetchMock.mockResolvedValue(ok(result()));
+
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+    await addFiles(container, [ttlFile()]);
+    await userEvent.click(screen.getByRole('button', { name: /Merge-simulated/ }));
+    await userEvent.type(
+      screen.getByPlaceholderText(/SPARQL endpoint/),
+      '  https://sparql.example.org  '
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Validate' }));
+
+    await screen.findByText('Valid');
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${API}/v1/shacl/validate-merged`,
+      expect.objectContaining({
+        body: JSON.stringify({ content: TURTLE, endpoint: 'https://sparql.example.org' }),
+      })
+    );
+  });
+
+  test('a whitespace-only endpoint is treated as blank', async () => {
+    fetchMock.mockResolvedValue(ok(result()));
+
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+    await addFiles(container, [ttlFile()]);
+    await userEvent.click(screen.getByRole('button', { name: /Merge-simulated/ }));
+    await userEvent.type(screen.getByPlaceholderText(/SPARQL endpoint/), '   ');
+    await userEvent.click(screen.getByRole('button', { name: 'Validate' }));
+
+    await screen.findByText('Valid');
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${API}/v1/shacl/validate-merged`,
+      expect.objectContaining({ body: JSON.stringify({ content: TURTLE }) })
+    );
+  });
+
+  test('switching back to file-local hides the endpoint field again', async () => {
+    render(<ShaclValidator apiBaseUrl={API} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /Merge-simulated/ }));
+    expect(screen.getByPlaceholderText(/SPARQL endpoint/)).toBeTruthy();
+
+    await userEvent.click(screen.getByRole('button', { name: /File-local/ }));
+    expect(screen.queryByPlaceholderText(/SPARQL endpoint/)).toBeNull();
+  });
+});
+
+describe('ShaclValidator results', () => {
+  test('reports a valid file with an all-clear badge', async () => {
+    fetchMock.mockResolvedValue(ok(result()));
+
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+    await addFiles(container, [ttlFile()]);
+    await userEvent.click(screen.getByRole('button', { name: 'Validate' }));
+
+    expect(await screen.findByText('Valid')).toBeTruthy();
+    expect(screen.getByText('All checks passed')).toBeTruthy();
+  });
+
+  test('shows per-severity counts for an invalid file', async () => {
+    fetchMock.mockResolvedValue(
+      ok(result({ valid: false, summary: { errors: 4, warnings: 2, infos: 6 } }))
+    );
+
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+    await addFiles(container, [ttlFile()]);
+    await userEvent.click(screen.getByRole('button', { name: 'Validate' }));
+
+    expect(await screen.findByText('Invalid')).toBeTruthy();
+    expect(screen.getByText('4E')).toBeTruthy();
+    expect(screen.getByText('2W')).toBeTruthy();
+    expect(screen.getByText('6I')).toBeTruthy();
+    expect(screen.queryByText('All checks passed')).toBeNull();
+  });
+
+  test('omits the all-clear badge when a valid file still has warnings', async () => {
+    fetchMock.mockResolvedValue(ok(result({ summary: { errors: 0, warnings: 1, infos: 0 } })));
+
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+    await addFiles(container, [ttlFile()]);
+    await userEvent.click(screen.getByRole('button', { name: 'Validate' }));
+
+    expect(await screen.findByText('Valid')).toBeTruthy();
+    expect(screen.queryByText('All checks passed')).toBeNull();
+  });
+
+  test('surfaces a parse error alongside the summary', async () => {
+    fetchMock.mockResolvedValue(
+      ok(result({ valid: false, parseError: 'Unexpected "." on line 3' }))
+    );
+
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+    await addFiles(container, [ttlFile()]);
+    await userEvent.click(screen.getByRole('button', { name: 'Validate' }));
+
+    expect(await screen.findByText('Unexpected "." on line 3')).toBeTruthy();
+  });
+
+  test('shows the spinner while the request is in flight', async () => {
+    let release: (value: unknown) => void = () => {};
+    fetchMock.mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve;
+      })
+    );
+
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+    await addFiles(container, [ttlFile()]);
+    await userEvent.click(screen.getByRole('button', { name: 'Validate' }));
+
+    expect(await screen.findByText('Running validation…')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Validating/ })).toHaveProperty('disabled', true);
+
+    release(ok(result()));
+    await screen.findByText('Valid');
+  });
+
+  test('reports the server error message when validation fails', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ success: false, error: { message: 'Turtle could not be parsed' } }),
+    });
+
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+    await addFiles(container, [ttlFile()]);
+    await userEvent.click(screen.getByRole('button', { name: 'Validate' }));
+
+    expect(await screen.findByText('Turtle could not be parsed')).toBeTruthy();
+  });
+
+  test('falls back to the status code when the server sends no message', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 502, json: async () => ({ success: false }) });
+
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+    await addFiles(container, [ttlFile()]);
+    await userEvent.click(screen.getByRole('button', { name: 'Validate' }));
+
+    expect(await screen.findByText('Server error: 502')).toBeTruthy();
+  });
+
+  test('treats an unsuccessful 200 body as an error', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: false, error: { message: 'Shapes unavailable' } }),
+    });
+
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+    await addFiles(container, [ttlFile()]);
+    await userEvent.click(screen.getByRole('button', { name: 'Validate' }));
+
+    expect(await screen.findByText('Shapes unavailable')).toBeTruthy();
+  });
+
+  test('falls back to a generic message when the rejection is not an Error', async () => {
+    fetchMock.mockRejectedValue('offline');
+
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+    await addFiles(container, [ttlFile()]);
+    await userEvent.click(screen.getByRole('button', { name: 'Validate' }));
+
+    expect(await screen.findByText('Validation request failed.')).toBeTruthy();
+  });
+});
+
+describe('ShaclValidator layer sections', () => {
+  async function renderWithLayers(overrides: Record<string, LayerOverride>) {
+    fetchMock.mockResolvedValue(ok(result({ valid: false, layers: layers(overrides) })));
+
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+    await addFiles(container, [ttlFile()]);
+    await userEvent.click(screen.getByRole('button', { name: 'Validate' }));
+    await screen.findByText('Invalid');
+    return container;
+  }
+
+  test('starts collapsed and expands on click', async () => {
+    await renderWithLayers({
+      cprmv: { issues: [{ severity: 'error', code: 'SH-001', message: 'Missing sh:targetClass' }] },
+    });
+
+    expect(screen.queryByText('Missing sh:targetClass')).toBeNull();
+
+    await userEvent.click(screen.getByRole('button', { name: /CPRMV/ }));
+    expect(screen.getByText('Missing sh:targetClass')).toBeTruthy();
+    expect(screen.getByText('SH-001')).toBeTruthy();
+
+    await userEvent.click(screen.getByRole('button', { name: /CPRMV/ }));
+    expect(screen.queryByText('Missing sh:targetClass')).toBeNull();
+  });
+
+  test('marks a loaded, issue-free layer OK', async () => {
+    await renderWithLayers({});
+
+    const clean = screen.getByRole('button', { name: /CPSV-AP/ });
+    expect(within(clean).getByText('OK')).toBeTruthy();
+
+    await userEvent.click(clean);
+    expect(screen.getByText('No issues found.')).toBeTruthy();
+  });
+
+  test('marks a layer with no shapes as not loaded and explains why on expand', async () => {
+    await renderWithLayers({ 'ronl-custom': { loaded: false } });
+
+    const header = screen.getByRole('button', { name: /RONL custom/ });
+    expect(within(header).getByText('Not loaded')).toBeTruthy();
+    expect(within(header).queryByText('OK')).toBeNull();
+
+    await userEvent.click(header);
+    expect(
+      screen.getByText('No shapes are loaded for this layer, so nothing was validated against it.')
+    ).toBeTruthy();
+  });
+
+  test('counts each severity in the layer header', async () => {
+    await renderWithLayers({
+      cprmv: {
+        issues: [
+          { severity: 'error', code: 'E1', message: 'e' },
+          { severity: 'warning', code: 'W1', message: 'w' },
+          { severity: 'warning', code: 'W2', message: 'w2' },
+          { severity: 'info', code: 'I1', message: 'i' },
+        ],
+      },
+    });
+
+    const header = screen.getByRole('button', { name: /CPRMV/ });
+    expect(within(header).getByText('1E')).toBeTruthy();
+    expect(within(header).getByText('2W')).toBeTruthy();
+    expect(within(header).getByText('1I')).toBeTruthy();
+  });
+
+  test('leads a warning-only layer without an error count', async () => {
+    await renderWithLayers({
+      cprmv: { issues: [{ severity: 'warning', code: 'W1', message: 'w' }] },
+    });
+
+    const header = screen.getByRole('button', { name: /CPRMV/ });
+    expect(within(header).queryByText(/^\d+E$/)).toBeNull();
+    expect(within(header).getByText('1W')).toBeTruthy();
+  });
+
+  test('renders an info-only layer without error or warning counts', async () => {
+    await renderWithLayers({
+      cprmv: { issues: [{ severity: 'info', code: 'I1', message: 'fyi' }] },
+    });
+
+    const header = screen.getByRole('button', { name: /CPRMV/ });
+    expect(within(header).getByText('1I')).toBeTruthy();
+    expect(within(header).queryByText('OK')).toBeNull();
+  });
+
+  test('shows an issue location and its line and column', async () => {
+    await renderWithLayers({
+      cprmv: {
+        issues: [
+          {
+            severity: 'error',
+            code: 'E1',
+            message: 'bad node',
+            location: 'urn:service:1',
+            line: 12,
+            column: 4,
+          },
+        ],
+      },
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /CPRMV/ }));
+    expect(screen.getByText('urn:service:1')).toBeTruthy();
+    expect(screen.getByText('Line 12, col 4')).toBeTruthy();
+  });
+
+  test('omits the column when the issue has none', async () => {
+    await renderWithLayers({
+      cprmv: { issues: [{ severity: 'error', code: 'E1', message: 'bad', line: 7 }] },
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /CPRMV/ }));
+    expect(screen.getByText('Line 7')).toBeTruthy();
+  });
+
+  test('omits location and line when the issue carries neither', async () => {
+    await renderWithLayers({
+      cprmv: { issues: [{ severity: 'error', code: 'E1', message: 'bad' }] },
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /CPRMV/ }));
+    expect(screen.queryByText(/^Line /)).toBeNull();
+  });
+});
+
+describe('ShaclValidator multi-file actions', () => {
+  test('validates every pending entry at once, then hides the bulk button', async () => {
+    fetchMock.mockResolvedValue(ok(result()));
+
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+    await addFiles(container, [ttlFile('a.ttl'), ttlFile('b.ttl')]);
+
+    await userEvent.click(screen.getByRole('button', { name: /Validate all/ }));
+
+    await waitFor(() => expect(screen.getAllByText('Valid')).toHaveLength(2));
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(screen.queryByRole('button', { name: /Validate all/ })).toBeNull();
+  });
+
+  test('keeps the bulk button visible while one entry is still pending', async () => {
+    fetchMock.mockResolvedValue(ok(result()));
+
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+    await addFiles(container, [ttlFile('a.ttl'), ttlFile('b.ttl')]);
+
+    await userEvent.click(screen.getAllByRole('button', { name: 'Validate' })[0]);
+    await screen.findByText('Valid');
+
+    expect(screen.getByRole('button', { name: /Validate all/ })).toBeTruthy();
+  });
+
+  test('removes a single entry', async () => {
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+    await addFiles(container, [ttlFile('a.ttl'), ttlFile('b.ttl')]);
+
+    const card = screen.getByTitle('a.ttl').closest('.flex-col') as HTMLElement;
+    await userEvent.click(within(card).getByTitle('Remove'));
+
+    await waitFor(() => expect(screen.queryByTitle('a.ttl')).toBeNull());
+    expect(screen.getByTitle('b.ttl')).toBeTruthy();
+  });
+
+  test('clears every entry at once', async () => {
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+    await addFiles(container, [ttlFile('a.ttl'), ttlFile('b.ttl')]);
+
+    await userEvent.click(screen.getByRole('button', { name: /Clear all/ }));
+
+    await waitFor(() => expect(screen.getByText('Drop Turtle files here')).toBeTruthy());
+  });
+
+  test('prompts for validation on a freshly added entry', async () => {
+    const { container } = render(<ShaclValidator apiBaseUrl={API} />);
+    await addFiles(container, [ttlFile()]);
+
+    expect(screen.getByText('Press Validate to run checks.')).toBeTruthy();
+  });
+});

--- a/packages/frontend/src/services/dsoService.test.ts
+++ b/packages/frontend/src/services/dsoService.test.ts
@@ -137,6 +137,83 @@ describe('activiteiten-shaped endpoints', () => {
     expect(result.items).toHaveLength(1);
   });
 
+  test('getActiviteitenByOin throws when the envelope reports success: false', async () => {
+    server.use(
+      http.post('*/v1/dso/activiteiten/oin', () => HttpResponse.json({ success: false, data: {} }))
+    );
+    await expect(getActiviteitenByOin('oin-123')).rejects.toThrow('DSO OIN request failed');
+  });
+
+  test('zoekActiviteiten throws on a non-ok response', async () => {
+    server.use(
+      http.post('*/v1/dso/activiteiten/zoek', () => new HttpResponse(null, { status: 500 }))
+    );
+    await expect(zoekActiviteiten({})).rejects.toThrow('HTTP 500');
+  });
+
+  test('zoekActiviteiten throws when the envelope reports success: false', async () => {
+    server.use(
+      http.post('*/v1/dso/activiteiten/zoek', () => HttpResponse.json({ success: false, data: {} }))
+    );
+    await expect(zoekActiviteiten({})).rejects.toThrow('DSO search failed');
+  });
+
+  test('zoekActiviteiten falls back to the requested page and an empty list', async () => {
+    server.use(
+      http.post('*/v1/dso/activiteiten/zoek', () => HttpResponse.json({ success: true, data: {} }))
+    );
+
+    const result = await zoekActiviteiten({ page: 3, pageSize: 50 });
+
+    expect(result).toEqual({ items: [], page: { number: 3, size: 50 }, hasNext: false });
+  });
+
+  test('zoekActiviteiten defaults the page when the caller supplies none', async () => {
+    server.use(
+      http.post('*/v1/dso/activiteiten/zoek', () => HttpResponse.json({ success: true, data: {} }))
+    );
+
+    expect((await zoekActiviteiten({})).page).toEqual({ number: 1, size: 20 });
+  });
+
+  test('zoekActiviteiten reports hasNext when the envelope carries a next link', async () => {
+    server.use(
+      http.post('*/v1/dso/activiteiten/zoek', () =>
+        HttpResponse.json({
+          success: true,
+          data: { _links: { next: { href: 'https://example.com/next' } } },
+        })
+      )
+    );
+
+    expect((await zoekActiviteiten({})).hasNext).toBe(true);
+  });
+
+  test('getActiviteiten falls back to an empty list and a default page', async () => {
+    server.use(
+      http.get('*/v1/dso/activiteiten', () => HttpResponse.json({ success: true, data: {} }))
+    );
+
+    expect(await getActiviteiten()).toEqual({
+      items: [],
+      page: { number: 1, size: 20 },
+      hasNext: false,
+    });
+  });
+
+  test('getActiviteiten reports hasNext when the envelope carries a next link', async () => {
+    server.use(
+      http.get('*/v1/dso/activiteiten', () =>
+        HttpResponse.json({
+          success: true,
+          data: { _links: { next: { href: 'https://example.com/next' } } },
+        })
+      )
+    );
+
+    expect((await getActiviteiten()).hasNext).toBe(true);
+  });
+
   test('getActiviteiten fetches with page/pageSize params', async () => {
     let url = '';
     server.use(
@@ -211,6 +288,87 @@ describe('werkzaamheden endpoints', () => {
   });
 });
 
+describe('werkzaamheden edge cases', () => {
+  test('zoekWerkzaamheden sends no zoekterm when the search box is blank', async () => {
+    let body: unknown;
+    server.use(
+      http.post('*/v1/dso/werkzaamheden/zoek', async ({ request }) => {
+        body = await request.json();
+        return HttpResponse.json({ success: true, data: {} });
+      })
+    );
+
+    await zoekWerkzaamheden('   ');
+
+    expect(body).toEqual({ page: 1, pageSize: 20 });
+  });
+
+  test('zoekWerkzaamheden throws on a non-ok response', async () => {
+    server.use(
+      http.post('*/v1/dso/werkzaamheden/zoek', () => new HttpResponse(null, { status: 503 }))
+    );
+    await expect(zoekWerkzaamheden('kappen')).rejects.toThrow('HTTP 503');
+  });
+
+  test('zoekWerkzaamheden throws when the envelope reports success: false', async () => {
+    server.use(
+      http.post('*/v1/dso/werkzaamheden/zoek', () =>
+        HttpResponse.json({ success: false, data: {} })
+      )
+    );
+    await expect(zoekWerkzaamheden('kappen')).rejects.toThrow('DSO search failed');
+  });
+
+  test('zoekWerkzaamheden falls back to the requested page and reports hasNext', async () => {
+    server.use(
+      http.post('*/v1/dso/werkzaamheden/zoek', () =>
+        HttpResponse.json({
+          success: true,
+          data: { _links: { next: { href: 'https://example.com/next' } } },
+        })
+      )
+    );
+
+    expect(await zoekWerkzaamheden('kappen', 4)).toEqual({
+      items: [],
+      page: { number: 4, size: 20 },
+      hasNext: true,
+    });
+  });
+
+  test('suggereerWerkzaamheden returns [] when the envelope reports success: false', async () => {
+    server.use(
+      http.post('*/v1/dso/werkzaamheden/suggereer', () =>
+        HttpResponse.json({ success: false, data: null })
+      )
+    );
+    expect(await suggereerWerkzaamheden('kap')).toEqual([]);
+  });
+
+  test('suggereerWerkzaamheden returns [] when the payload is not an array', async () => {
+    server.use(
+      http.post('*/v1/dso/werkzaamheden/suggereer', () =>
+        HttpResponse.json({ success: true, data: { unexpected: true } })
+      )
+    );
+    expect(await suggereerWerkzaamheden('kap')).toEqual([]);
+  });
+
+  test('getWerkzaamheidDetail throws on a non-ok response', async () => {
+    server.use(
+      http.get('*/v1/dso/werkzaamheden/:urn', () => new HttpResponse(null, { status: 404 }))
+    );
+    await expect(getWerkzaamheidDetail('urn:1')).rejects.toThrow('HTTP 404');
+  });
+
+  test('getWerkzaamheidDetail throws when the envelope reports success: false', async () => {
+    server.use(
+      http.get('*/v1/dso/werkzaamheden/:urn', () => HttpResponse.json({ success: false, data: {} }))
+    );
+    await expect(getWerkzaamheidDetail('urn:1')).rejects.toThrow('DSO request failed');
+  });
+});
+
 describe('getActiviteitDetail', () => {
   test('fetches the activiteit detail with an optional datum param', async () => {
     let url = '';
@@ -237,6 +395,30 @@ describe('fetchToepasbareRegels', () => {
       )
     );
     expect(await fetchToepasbareRegels('fs-ref')).toEqual({ items: [{ identifier: 1 }] });
+  });
+
+  test('accepts the alternative _embedded.toepasbareRegels key', async () => {
+    server.use(
+      http.get('*/v1/dso/toepasbare-regels', () =>
+        HttpResponse.json({
+          success: true,
+          data: { _embedded: { toepasbareRegels: [{ identifier: 7 }] } },
+        })
+      )
+    );
+    expect(await fetchToepasbareRegels('fs-ref')).toEqual({ items: [{ identifier: 7 }] });
+  });
+
+  test('falls back to [] when the embedded value is not a list', async () => {
+    server.use(
+      http.get('*/v1/dso/toepasbare-regels', () =>
+        HttpResponse.json({
+          success: true,
+          data: { _embedded: { toepasbareRegelsList: { not: 'a list' } } },
+        })
+      )
+    );
+    expect(await fetchToepasbareRegels('fs-ref')).toEqual({ items: [] });
   });
 
   test('falls back to [] when neither known key is present', async () => {

--- a/packages/frontend/src/services/templateService.test.ts
+++ b/packages/frontend/src/services/templateService.test.ts
@@ -84,6 +84,33 @@ describe('templateService.getTemplatesByCategory', () => {
     expect(result[0].category).toBe('financial');
   });
 
+  test('passes the endpoint alongside the category when provided', async () => {
+    let url = '';
+    server.use(
+      http.get('*/api/chains/templates', ({ request }) => {
+        url = request.url;
+        return HttpResponse.json({
+          success: true,
+          data: { templates: [], total: 0, categories: [] },
+        });
+      })
+    );
+
+    await templateService.getTemplatesByCategory('financial', 'https://example.com/sparql');
+
+    expect(url).toContain('category=financial');
+    expect(url).toContain(`endpoint=${encodeURIComponent('https://example.com/sparql')}`);
+  });
+
+  test('returns [] when the backend reports success: false', async () => {
+    server.use(
+      http.get('*/api/chains/templates', () =>
+        HttpResponse.json({ success: false, error: 'unknown category' })
+      )
+    );
+    expect(await templateService.getTemplatesByCategory('nope')).toEqual([]);
+  });
+
   test('returns [] (not a throw) when the request fails outright', async () => {
     server.use(http.get('*/api/chains/templates', () => HttpResponse.error()));
     expect(await templateService.getTemplatesByCategory('financial')).toEqual([]);
@@ -107,6 +134,20 @@ describe('templateService.getTemplateById', () => {
       )
     );
     expect(await templateService.getTemplateById('missing')).toBeNull();
+  });
+
+  test('passes the endpoint as a query param when provided', async () => {
+    let url = '';
+    server.use(
+      http.get('*/api/chains/templates/:id', ({ request }) => {
+        url = request.url;
+        return HttpResponse.json({ success: true, data: chainTemplate() });
+      })
+    );
+
+    await templateService.getTemplateById('t1', 'https://example.com/sparql');
+
+    expect(url).toContain(`endpoint=${encodeURIComponent('https://example.com/sparql')}`);
   });
 
   test('returns null (not a throw) when the request fails outright', async () => {

--- a/packages/frontend/src/utils/exportService.test.ts
+++ b/packages/frontend/src/utils/exportService.test.ts
@@ -1,0 +1,441 @@
+// @vitest-environment jsdom
+import JSZip from 'jszip';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { DmnModel } from '../types';
+import { ExportFormat, ExportOptions } from '../types/export.types';
+
+const getFormatById = vi.hoisted(() => vi.fn());
+
+vi.mock('./exportFormats', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./exportFormats')>();
+  return {
+    ...actual,
+    getFormatById: (id: ExportFormat) => getFormatById(id),
+  };
+});
+
+import * as exportFormats from './exportFormats';
+import { exportChain, validateChainForExport } from './exportService';
+
+// ─── Test doubles for the browser download path ──────────────────────────────
+//
+// downloadBlob() calls URL.createObjectURL(blob) and then clicks a temporary
+// <a>. jsdom implements neither, so record both halves and pair them up.
+
+let downloads: { blob: Blob | null; filename: string }[] = [];
+let clickSpy: ReturnType<typeof vi.spyOn>;
+let lastBlob: Blob | null = null;
+let createObjectURL: (blob: Blob) => string;
+
+function dmn(overrides: Partial<DmnModel> = {}): DmnModel {
+  return {
+    id: 'd1',
+    identifier: 'age-check',
+    title: 'Age check',
+    inputs: [{ identifier: 'age', title: 'Age', type: 'Integer' }],
+    outputs: [{ identifier: 'eligible', title: 'Eligible', type: 'Boolean' }],
+    ...overrides,
+  } as DmnModel;
+}
+
+function options(overrides: Partial<ExportOptions> = {}): ExportOptions {
+  return { format: 'json', filename: 'my-chain', ...overrides };
+}
+
+async function textOf(content: string | Blob): Promise<string> {
+  return content instanceof Blob ? await content.text() : content;
+}
+
+beforeEach(() => {
+  downloads = [];
+  lastBlob = null;
+
+  getFormatById.mockImplementation((id: ExportFormat) => exportFormats.EXPORT_FORMATS[id] ?? null);
+
+  createObjectURL = (blob: Blob) => {
+    lastBlob = blob;
+    return 'blob:mock';
+  };
+  vi.stubGlobal('URL', {
+    createObjectURL: (blob: Blob) => createObjectURL(blob),
+    revokeObjectURL: vi.fn(),
+  });
+
+  clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+    this: HTMLAnchorElement
+  ) {
+    downloads.push({ blob: lastBlob, filename: this.download });
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe('validateChainForExport', () => {
+  test('rejects an empty chain', () => {
+    expect(validateChainForExport([])).toEqual({
+      valid: false,
+      errors: ['Chain is empty - add at least one DMN'],
+    });
+  });
+
+  test('accepts a chain with at least one DMN', () => {
+    expect(validateChainForExport(['age-check'])).toEqual({ valid: true, errors: [] });
+  });
+});
+
+describe('exportChain format selection', () => {
+  test('rejects a format with no definition', async () => {
+    getFormatById.mockReturnValue(null);
+
+    const result = await exportChain([], {}, [], options({ format: 'nope' as ExportFormat }));
+
+    expect(result).toEqual({
+      success: false,
+      filename: '',
+      content: '',
+      error: 'Unknown export format: nope',
+    });
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+
+  test('rejects a known-but-unhandled format', async () => {
+    // Defensive branch: a format the registry knows but the switch does not render.
+    getFormatById.mockReturnValue({
+      id: 'yaml' as ExportFormat,
+      name: 'YAML',
+      description: '',
+      extension: 'yaml',
+      mimeType: 'text/yaml',
+      icon: '📄',
+    });
+
+    const result = await exportChain(['a'], {}, [], options({ format: 'yaml' as ExportFormat }));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Unsupported export format: yaml');
+  });
+
+  test('reports a thrown error as a failed export', async () => {
+    getFormatById.mockImplementation(() => {
+      throw new Error('registry offline');
+    });
+
+    const result = await exportChain(['a'], {}, [], options());
+
+    expect(result).toEqual({
+      success: false,
+      filename: '',
+      content: '',
+      error: 'registry offline',
+    });
+  });
+
+  test('falls back to a generic message when a non-Error is thrown', async () => {
+    getFormatById.mockImplementation(() => {
+      throw 'kaboom';
+    });
+
+    const result = await exportChain(['a'], {}, [], options());
+    expect(result.error).toBe('Unknown error during export');
+  });
+});
+
+describe('exportChain — JSON', () => {
+  test('pretty-prints by default and downloads the blob', async () => {
+    const result = await exportChain(
+      ['age-check', 'income-check'],
+      { age: 42 },
+      [dmn()],
+      options({ filename: 'my-chain.json' })
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.filename).toBe('my-chain.json');
+    expect(downloads).toHaveLength(1);
+    expect(downloads[0].filename).toBe('my-chain.json');
+
+    const json = JSON.parse(await textOf(result.content));
+    expect(json.version).toBe('1.0');
+    expect(json.chain).toEqual({ dmnIds: ['age-check', 'income-check'], inputs: { age: 42 } });
+    expect(await textOf(result.content)).toContain('\n  ');
+  });
+
+  test('emits compact JSON when prettyPrint is false', async () => {
+    const result = await exportChain(['a'], {}, [], options({ prettyPrint: false }));
+    expect(await textOf(result.content)).not.toContain('\n  ');
+  });
+
+  test('pluralises the generated description', async () => {
+    const one = await exportChain(['a'], {}, [], options());
+    const two = await exportChain(['a', 'b'], {}, [], options());
+
+    expect(JSON.parse(await textOf(one.content)).description).toBe('Chain with 1 DMN');
+    expect(JSON.parse(await textOf(two.content)).description).toBe('Chain with 2 DMNs');
+  });
+
+  test.each([
+    [['a'], 'simple'],
+    [['a', 'b'], 'simple'],
+    [['a', 'b', 'c'], 'medium'],
+    [['a', 'b', 'c', 'd'], 'medium'],
+    [['a', 'b', 'c', 'd', 'e'], 'complex'],
+  ])('grades a %s-DMN chain as %s', async (ids, complexity) => {
+    const result = await exportChain(ids as string[], {}, [], options());
+    const meta = JSON.parse(await textOf(result.content)).metadata;
+
+    expect(meta.complexity).toBe(complexity);
+    expect(meta.estimatedTime).toBe((ids as string[]).length * 150 + 50);
+    expect(meta.tags).toEqual(['exported', 'chain']);
+  });
+
+  test('omits metadata when includeMetadata is false', async () => {
+    const result = await exportChain(['a'], {}, [], options({ includeMetadata: false }));
+    expect(JSON.parse(await textOf(result.content)).metadata).toBeUndefined();
+  });
+
+  test('derives a filename when none is given', async () => {
+    const result = await exportChain(['a'], {}, [], { format: 'json' });
+
+    expect(JSON.parse(await textOf(result.content)).name).toBe('Unnamed Chain');
+    expect(result.filename).toMatch(/^chain-unnamed-chain-\d{4}-\d{2}-\d{2}-\d{6}\.json$/);
+  });
+});
+
+describe('exportChain — BPMN', () => {
+  async function bpmnFor(dmnIds: string[], dmns: DmnModel[], name = 'My Chain') {
+    const result = await exportChain(dmnIds, {}, dmns, options({ format: 'bpmn', filename: name }));
+    return { result, xml: await textOf(result.content) };
+  }
+
+  test('emits one business rule task per DMN wired start → tasks → end', async () => {
+    const { xml } = await bpmnFor(
+      ['age-check', 'income-check'],
+      [dmn(), dmn({ identifier: 'income-check', title: 'Income check' })]
+    );
+
+    expect(xml).toContain('<process id="chain-my-chain"');
+    expect(xml).toContain('operaton:decisionRef="age-check"');
+    expect(xml).toContain('operaton:decisionRef="income-check"');
+    expect(xml).toContain('<incoming>flow-start-dmn-0</incoming>');
+    expect(xml).toContain('<outgoing>flow-dmn-0-dmn-1</outgoing>');
+    expect(xml).toContain('<incoming>flow-dmn-1-end</incoming>');
+    expect(xml).toContain('sourceRef="dmn-0" targetRef="dmn-1"');
+  });
+
+  test('falls back to the DMN id when the model is not in the chain list', async () => {
+    const { xml } = await bpmnFor(['unknown-dmn'], []);
+    expect(xml).toContain('<businessRuleTask id="dmn-0" name="unknown-dmn"');
+    expect(xml).not.toContain('<documentation>');
+  });
+
+  test('includes the DMN description as task documentation when present', async () => {
+    const { xml } = await bpmnFor(['age-check'], [dmn({ description: 'Checks age' })]);
+    expect(xml).toContain('<documentation>Checks age</documentation>');
+  });
+
+  test('escapes XML-significant characters in names and ids', async () => {
+    const { xml } = await bpmnFor(
+      ['a&b'],
+      [dmn({ identifier: 'a&b', title: '<Age> & "Income" \'check\'' })]
+    );
+
+    expect(xml).toContain('&lt;Age&gt; &amp; &quot;Income&quot; &apos;check&apos;');
+    expect(xml).toContain('operaton:decisionRef="a&amp;b"');
+  });
+
+  test('lays out one diagram shape per task plus start and end events', async () => {
+    const { xml } = await bpmnFor(['a', 'b'], []);
+
+    expect(xml).toContain('bpmnElement="dmn-0"');
+    expect(xml).toContain('bpmnElement="dmn-1"');
+    expect(xml).toContain('<bpmndi:BPMNShape id="end_di" bpmnElement="end">');
+    expect(xml).toContain('x="650" y="102"');
+    expect(xml).toContain('<bpmndi:BPMNEdge id="flow-dmn-0-dmn-1_di"');
+  });
+
+  test('downloads with the XML mime type', async () => {
+    const { result } = await bpmnFor(['a'], []);
+    expect(result.success).toBe(true);
+    expect((result.content as Blob).type).toBe('application/xml');
+    expect(downloads).toHaveLength(1);
+  });
+});
+
+describe('exportChain — package (ZIP)', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => ({
+        ok: true,
+        statusText: 'OK',
+        text: async () => `<definitions id="${String(url).split('/').slice(-2)[0]}" />`,
+      }))
+    );
+  });
+
+  async function entriesOf(content: string | Blob) {
+    const zip = await JSZip.loadAsync(content as Blob);
+    return Object.keys(zip.files).sort();
+  }
+
+  test('bundles the BPMN, every DMN and a README', async () => {
+    const result = await exportChain(
+      ['age-check', 'income-check'],
+      { age: 42 },
+      [dmn(), dmn({ identifier: 'income-check', title: 'Income check' })],
+      options({ format: 'package', filename: 'my-chain' })
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.filename).toMatch(/^chain-my-chain-\d{4}-\d{2}-\d{2}-\d{6}\.zip$/);
+    expect(await entriesOf(result.content)).toEqual([
+      'README.md',
+      'age-check.dmn',
+      'chain.bpmn',
+      'income-check.dmn',
+    ]);
+    expect(downloads).toHaveLength(1);
+  });
+
+  test('skips a DMN whose XML cannot be fetched but still produces a package', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) =>
+        String(url).includes('missing')
+          ? { ok: false, statusText: 'Not Found', text: async () => '' }
+          : { ok: true, statusText: 'OK', text: async () => '<definitions />' }
+      )
+    );
+
+    const result = await exportChain(
+      ['age-check', 'missing'],
+      {},
+      [dmn()],
+      options({ format: 'package' })
+    );
+
+    expect(result.success).toBe(true);
+    expect(await entriesOf(result.content)).toEqual(['README.md', 'age-check.dmn', 'chain.bpmn']);
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to fetch DMN missing:',
+      expect.objectContaining({ message: 'Failed to fetch DMN missing: Not Found' })
+    );
+  });
+
+  test('reports a failure when the package cannot be built', async () => {
+    createObjectURL = () => {
+      throw new Error('no object URLs here');
+    };
+
+    const result = await exportChain(['age-check'], {}, [dmn()], options({ format: 'package' }));
+
+    expect(result).toEqual({
+      success: false,
+      filename: '',
+      content: '',
+      error: 'no object URLs here',
+    });
+  });
+
+  async function readmeFor(
+    dmnIds: string[],
+    inputs: Record<string, unknown>,
+    dmns: DmnModel[]
+  ): Promise<string> {
+    const result = await exportChain(
+      dmnIds,
+      inputs,
+      dmns,
+      options({ format: 'package', filename: 'My Chain' })
+    );
+    const zip = await JSZip.loadAsync(result.content as Blob);
+    return zip.file('README.md')!.async('string');
+  }
+
+  test('documents deploy commands against the configured Operaton instance', async () => {
+    vi.stubEnv('VITE_OPERATON_BASE_URL', 'https://operaton.example.org/engine-rest');
+
+    const readme = await readmeFor(['age-check'], { age: 42 }, [dmn()]);
+
+    expect(readme).toContain('https://operaton.example.org/engine-rest/deployment/create');
+    expect(readme).toContain('https://operaton.example.org/operaton/app/cockpit/');
+    expect(readme).toContain('curl -X POST');
+    expect(readme).toContain('-F "data=@age-check.dmn"');
+  });
+
+  test('uses a placeholder URL when Operaton is not configured', async () => {
+    vi.stubEnv('VITE_OPERATON_BASE_URL', '');
+    const readme = await readmeFor(['age-check'], {}, [dmn()]);
+    expect(readme).toContain('<YOUR_OPERATON_URL>/engine-rest');
+  });
+
+  test('renders the chain test data and per-DMN input/output counts', async () => {
+    const readme = await readmeFor(['age-check'], { age: 42, region: 'NL' }, [dmn()]);
+
+    expect(readme).toContain('- **age**: `42`');
+    expect(readme).toContain('- **region**: `"NL"`');
+    expect(readme).toContain('"age": {"value": 42, "type": "Integer"}');
+    expect(readme).toContain('- Inputs: 1 variables');
+    expect(readme).toContain('- Outputs: 1 variables');
+    expect(readme).toContain('- eligible (Boolean)');
+  });
+
+  test('degrades gracefully when the DMN declares no inputs or outputs', async () => {
+    const readme = await readmeFor(['bare'], { x: 1 }, [
+      dmn({ identifier: 'bare', inputs: undefined, outputs: undefined }),
+    ]);
+
+    expect(readme).toContain('"example": {"value": "value", "type": "String"}');
+    expect(readme).toContain('(See DMN definition for output variables)');
+    expect(readme).toContain('- Inputs: 0 variables');
+  });
+
+  test('defaults the input type when a DMN input omits one', async () => {
+    const readme = await readmeFor(['age-check'], { age: 42 }, [
+      dmn({ inputs: [{ identifier: 'age', title: 'Age' }] as DmnModel['inputs'] }),
+    ]);
+    expect(readme).toContain('"age": {"value": 42, "type": "String"}');
+  });
+
+  test('defaults the output type when a DMN output omits one', async () => {
+    const readme = await readmeFor(['age-check'], {}, [
+      dmn({ outputs: [{ identifier: 'eligible', title: 'Eligible' }] as DmnModel['outputs'] }),
+    ]);
+    expect(readme).toContain('- eligible (unknown)');
+  });
+
+  test('lists a fallback DMN key when the chain has no models at all', async () => {
+    const readme = await readmeFor(['ghost'], {}, []);
+
+    expect(readme).toContain('/decision-definition/key/DMN_KEY/evaluate');
+    expect(readme).toContain('**DMN Count:** 0');
+    expect(readme).toContain('final DMN');
+  });
+
+  test('reports metadata complexity and estimated time', async () => {
+    const readme = await readmeFor(['a', 'b', 'c'], {}, [dmn()]);
+
+    expect(readme).toContain('**Complexity:** medium');
+    expect(readme).toContain('**Estimated Execution Time:** ~500ms');
+  });
+
+  test('omits complexity and timing when metadata is excluded', async () => {
+    const result = await exportChain(
+      ['a'],
+      {},
+      [dmn()],
+      options({ format: 'package', includeMetadata: false })
+    );
+    const zip = await JSZip.loadAsync(result.content as Blob);
+    const readme = await zip.file('README.md')!.async('string');
+
+    expect(readme).toContain('**Complexity:** N/A');
+    expect(readme).not.toContain('Estimated Execution Time');
+  });
+});


### PR DESCRIPTION
Branched from `origin/acc`. Every source file in `packages/frontend` and `packages/backend` now reports more than 80% branch coverage.

## Result

| | Before | After |
|---|---|---|
| **Frontend** branch total | 65.89% | **90.62%** |
| Frontend files below 80% | 26 of 77 | **0** |
| Frontend tests | 578 | **1014** |
| **Backend** branch total | 91.49% | **92.22%** |
| Backend files below 80% | 1 of 43 | **0** |
| Backend tests | 1134 | **1140** |

## Files that had no test at all

| File | Before | After |
|---|---|---|
| `ShaclValidator.tsx` | 0% | 95.10% |
| `DmnValidator.tsx` | 0% | 94.30% |
| `utils/exportService.ts` | 0% | 94.66% |
| `GraphView.tsx` | 0% | 82.25% |
| `ResultsTable.tsx` | 0% | 100% |
| `OrganizationsView.tsx` | 0% | 100% |
| `OrganizationCard.tsx` | 0% | 100% |
| `DocumentComposer/defaultTemplates.ts` | 0% | 100% |

## Largest gains in existing suites

| File | Before | After |
|---|---|---|
| `DsoExplorer.tsx` | 68.02% | 90.59% |
| `BpmnCanvas.tsx` | 67.04% | 86.93% |
| `ChainBuilder.tsx` | 57.29% | 90.62% |
| `DocumentCanvas.tsx` | 61.53% | 92.30% |
| `BpmnModeler.tsx` | 77.11% | 94.91% |
| `services/dsoService.ts` | 71.76% | 96.47% |
| `services/triplydb.service.ts` (backend) | 77.77% | 100% |

`DocumentComposer.tsx`, `FormEditor.tsx`, `ChainComposer.tsx`, `DmnList.tsx`, `DocumentList.tsx`, `FormCanvas.tsx`, `InputForm.tsx`, `Changelog.tsx`, `ZonePanel.tsx`, `ContentLibrary.tsx`, `RopaEditor.tsx` and `templateService.ts` all cleared the bar too.

## One non-test change

`defaultTemplates.ts` exports its three TipTap builders (`emptyDoc`, `heading`, `paragraphs`). Their default-parameter and empty-string branches are unreachable through the module's own template data, so the file could not clear 80% without exercising them directly. No behaviour change.

## Notes for reviewers

Two jsdom limitations are worked around, each commented at the call site:

- This jsdom build rejects `view` in the `MouseEvent` constructor, so the d3-drag gestures in `GraphView.test.tsx` attach it to the event instance after construction.
- dnd-kit reports `transform` / `isOver` / `isDragging` only during a live gesture, so the tests covering those styling branches mock `useDraggable` / `useDroppable` / `useSortable` and drive the state directly.

Defensive branches that no valid input can reach are deliberately left uncovered rather than contorted into tests: ref guards React always satisfies, and a handful of `?? fallback` arms sitting behind an earlier type check.

## Verification

- `npm run test --workspaces` — 1014 frontend + 1140 backend tests pass
- `npm run lint` — clean
- `npm run check-format` — clean
