### PR TITLE
feat(rip): add R2.3 VO-raming phase bundle for Flevoland

### DIFF
--- a/examples/organizations/flevoland/rip-phase-23/RipR23Process.bpmn
+++ b/examples/organizations/flevoland/rip-phase-23/RipR23Process.bpmn
@@ -1,0 +1,470 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:ronl="http://ronl.nl/schema/1.0" id="Definitions_RipR23" targetNamespace="http://example.com/rip-phase-23" exporter="Camunda Modeler" exporterVersion="5.45.0">
+  <bpmn:collaboration id="Collaboration_RipR23">
+    <bpmn:participant id="Participant_RipR23" name="R2.3 - VO-raming" processRef="RipR23Process" />
+  </bpmn:collaboration>
+  <bpmn:process id="RipR23Process" name="R2.3 - VO-raming" isExecutable="true" camunda:historyTimeToLive="180">
+    <bpmn:laneSet id="LaneSet_RipR23">
+      <bpmn:lane id="Lane_Kostenadviseur" name="Kostenadviseur">
+        <bpmn:flowNodeRef>Task_LatenOpstellenVoRaming</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_KostenContractdeskundige" name="Kosten- en contractdeskundige">
+        <bpmn:flowNodeRef>Task_OpstellenVoRaming</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_RIPteam" name="RIP-team">
+        <bpmn:flowNodeRef>Task_ControlerenProjectramingVO</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_BepalenInkoopstrategie</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndEvent_InkoopstrategieBepaald</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_Projectleider" name="Projectleider">
+        <bpmn:flowNodeRef>StartEvent_R23</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_BepalenRamingsroute</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_MbviMoment</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_RamingJoin</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_VervolgSplit</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_Projectkrediet</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_OpstellenMemoProjectkrediet</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_KredietJoin</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_AccorderenProjectplan</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndEvent_R24</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_InfraOverleg" name="Infra-overleg">
+        <bpmn:flowNodeRef>Task_BesluitenOverProjectkrediet</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_PKT" name="PKT + Aandrager, Manager Financi&#235;n">
+        <bpmn:flowNodeRef>Task_VerwerkenProjectraming</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_Projectbeheersing" name="Projectbeheersing">
+        <bpmn:flowNodeRef>Task_UpdatenProjectplanning</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndEvent_PlanningGeactualiseerd</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_Adviseur" name="Adviseur">
+        <bpmn:flowNodeRef>Task_EvaluerenPlanvoorbereiding</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_Kwaliteit" name="Kwaliteit">
+        <bpmn:flowNodeRef>Task_AnalyserenVerbeterpunten</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndEvent_EvaluatieVerwerkt</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+
+    <!-- No start-event form: the Faseladder board starts this process through
+         POST /v1/process/RipR23Process/start with variables (municipality,
+         projectNumber, projectName, businessKey inherited from the project's
+         R2.1 run). The MBVI routing question is therefore asked in the first
+         user task instead, so the gateway below always has a value to read. -->
+    <bpmn:startEvent id="StartEvent_R23" name="Start R2.3 - VO-raming&#10;(vanuit R2.2)">
+      <bpmn:outgoing>Flow_StartEvent_R23_Task_BepalenRamingsroute</bpmn:outgoing>
+    </bpmn:startEvent>
+
+    <bpmn:userTask id="Task_BepalenRamingsroute" name="Bepalen ramingsroute&#10;VO-raming" camunda:formRef="rip-bepalen-ramingsroute" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
+      <bpmn:incoming>Flow_StartEvent_R23_Task_BepalenRamingsroute</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_BepalenRamingsroute_Gateway_MbviMoment</bpmn:outgoing>
+    </bpmn:userTask>
+
+    <bpmn:exclusiveGateway id="Gateway_MbviMoment" name="tijdens / voorafgaand aan&#10;MBVI-proces?">
+      <bpmn:incoming>Flow_Task_BepalenRamingsroute_Gateway_MbviMoment</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_MbviMoment_Task_LatenOpstellenVoRaming</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_MbviMoment_Task_OpstellenVoRaming</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+
+    <bpmn:userTask id="Task_LatenOpstellenVoRaming" name="Laten opstellen&#10;VO-raming" camunda:formRef="rip-laten-opstellen-vo-raming" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-kostenadviseur" ronl:documentRef="rip-projectraming">
+      <bpmn:incoming>Flow_Gateway_MbviMoment_Task_LatenOpstellenVoRaming</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_LatenOpstellenVoRaming_Gateway_RamingJoin</bpmn:outgoing>
+    </bpmn:userTask>
+
+    <bpmn:userTask id="Task_OpstellenVoRaming" name="Opstellen&#10;VO-raming" camunda:formRef="rip-opstellen-vo-raming" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-kosten-contractdeskundige" ronl:documentRef="rip-projectraming">
+      <bpmn:incoming>Flow_Gateway_MbviMoment_Task_OpstellenVoRaming</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_OpstellenVoRaming_Gateway_RamingJoin</bpmn:outgoing>
+    </bpmn:userTask>
+
+    <bpmn:exclusiveGateway id="Gateway_RamingJoin">
+      <bpmn:incoming>Flow_Task_LatenOpstellenVoRaming_Gateway_RamingJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_OpstellenVoRaming_Gateway_RamingJoin</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_RamingJoin_Task_ControlerenProjectramingVO</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+
+    <bpmn:userTask id="Task_ControlerenProjectramingVO" name="Controleren&#10;Projectraming VO" camunda:formRef="rip-controleren-projectraming-vo" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-team">
+      <bpmn:incoming>Flow_Gateway_RamingJoin_Task_ControlerenProjectramingVO</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_ControlerenProjectramingVO_Gateway_VervolgSplit</bpmn:outgoing>
+    </bpmn:userTask>
+
+    <bpmn:parallelGateway id="Gateway_VervolgSplit">
+      <bpmn:incoming>Flow_Task_ControlerenProjectramingVO_Gateway_VervolgSplit</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_VervolgSplit_Task_BepalenInkoopstrategie</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_VervolgSplit_Gateway_Projectkrediet</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_VervolgSplit_Task_UpdatenProjectplanning</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_VervolgSplit_Task_EvaluerenPlanvoorbereiding</bpmn:outgoing>
+    </bpmn:parallelGateway>
+
+    <bpmn:userTask id="Task_BepalenInkoopstrategie" name="Bepalen&#10;inkoopstrategie" camunda:formRef="rip-bepalen-inkoopstrategie" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-team" ronl:documentRef="rip-inkoopplan">
+      <bpmn:incoming>Flow_Gateway_VervolgSplit_Task_BepalenInkoopstrategie</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_BepalenInkoopstrategie_EndEvent_InkoopstrategieBepaald</bpmn:outgoing>
+    </bpmn:userTask>
+
+    <bpmn:endEvent id="EndEvent_InkoopstrategieBepaald" name="Inkoopstrategie bepaald">
+      <bpmn:incoming>Flow_Task_BepalenInkoopstrategie_EndEvent_InkoopstrategieBepaald</bpmn:incoming>
+    </bpmn:endEvent>
+
+    <bpmn:exclusiveGateway id="Gateway_Projectkrediet" name="Raming VO binnen /&#10;buiten projectkrediet?">
+      <bpmn:incoming>Flow_Gateway_VervolgSplit_Gateway_Projectkrediet</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_Projectkrediet_Task_OpstellenMemoProjectkrediet</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_Projectkrediet_Gateway_KredietJoin</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+
+    <bpmn:userTask id="Task_OpstellenMemoProjectkrediet" name="Opstellen memo projectkrediet&#10;(zachte claim)" camunda:formRef="rip-opstellen-memo-projectkrediet" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-memo-projectkrediet">
+      <bpmn:incoming>Flow_Gateway_Projectkrediet_Task_OpstellenMemoProjectkrediet</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_OpstellenMemoProjectkrediet_Task_BesluitenOverProjectkrediet</bpmn:outgoing>
+    </bpmn:userTask>
+
+    <bpmn:userTask id="Task_BesluitenOverProjectkrediet" name="Besluiten over&#10;projectkrediet" camunda:formRef="rip-besluiten-projectkrediet" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-infra-overleg" ronl:documentRef="rip-besluit-projectkrediet">
+      <bpmn:incoming>Flow_Task_OpstellenMemoProjectkrediet_Task_BesluitenOverProjectkrediet</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_BesluitenOverProjectkrediet_Task_VerwerkenProjectraming</bpmn:outgoing>
+    </bpmn:userTask>
+
+    <bpmn:userTask id="Task_VerwerkenProjectraming" name="Verwerken projectraming&#10;en raamkrediet Infra" camunda:formRef="rip-verwerken-projectraming" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-pkt,rip-aandrager,rip-manager-financien">
+      <bpmn:incoming>Flow_Task_BesluitenOverProjectkrediet_Task_VerwerkenProjectraming</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_VerwerkenProjectraming_Gateway_KredietJoin</bpmn:outgoing>
+    </bpmn:userTask>
+
+    <bpmn:exclusiveGateway id="Gateway_KredietJoin">
+      <bpmn:incoming>Flow_Gateway_Projectkrediet_Gateway_KredietJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_VerwerkenProjectraming_Gateway_KredietJoin</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_KredietJoin_Task_AccorderenProjectplan</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+
+    <bpmn:userTask id="Task_AccorderenProjectplan" name="Accorderen Projectplan&#10;5. Afronding VO-fase" camunda:formRef="rip-accorderen-projectplan-vo" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-projectplan-vo">
+      <bpmn:incoming>Flow_Gateway_KredietJoin_Task_AccorderenProjectplan</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_AccorderenProjectplan_EndEvent_R24</bpmn:outgoing>
+    </bpmn:userTask>
+
+    <bpmn:endEvent id="EndEvent_R24" name="Projectplan vastgesteld (VO)&#10;&#8594; R2.4 Opdracht extern ingenieursbureau">
+      <bpmn:incoming>Flow_Task_AccorderenProjectplan_EndEvent_R24</bpmn:incoming>
+    </bpmn:endEvent>
+
+    <bpmn:userTask id="Task_UpdatenProjectplanning" name="Updaten projectplanning en&#10;informeren PL en ondersteuner" camunda:formRef="rip-updaten-projectplanning" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectbeheersing">
+      <bpmn:incoming>Flow_Gateway_VervolgSplit_Task_UpdatenProjectplanning</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_UpdatenProjectplanning_EndEvent_PlanningGeactualiseerd</bpmn:outgoing>
+    </bpmn:userTask>
+
+    <bpmn:endEvent id="EndEvent_PlanningGeactualiseerd" name="Projectplanning&#10;geactualiseerd">
+      <bpmn:incoming>Flow_Task_UpdatenProjectplanning_EndEvent_PlanningGeactualiseerd</bpmn:incoming>
+    </bpmn:endEvent>
+
+    <bpmn:userTask id="Task_EvaluerenPlanvoorbereiding" name="Evalueren planvoorbereiding&#10;(intern)" camunda:formRef="rip-evalueren-planvoorbereiding" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-adviseur" ronl:documentRef="rip-evaluatie-vo">
+      <bpmn:incoming>Flow_Gateway_VervolgSplit_Task_EvaluerenPlanvoorbereiding</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_EvaluerenPlanvoorbereiding_Task_AnalyserenVerbeterpunten</bpmn:outgoing>
+    </bpmn:userTask>
+
+    <bpmn:userTask id="Task_AnalyserenVerbeterpunten" name="Analyseren en verwerken&#10;verbeterpunten" camunda:formRef="rip-analyseren-verbeterpunten" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-kwaliteit">
+      <bpmn:incoming>Flow_Task_EvaluerenPlanvoorbereiding_Task_AnalyserenVerbeterpunten</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_AnalyserenVerbeterpunten_EndEvent_EvaluatieVerwerkt</bpmn:outgoing>
+    </bpmn:userTask>
+
+    <bpmn:endEvent id="EndEvent_EvaluatieVerwerkt" name="Verbeterpunten verwerkt">
+      <bpmn:incoming>Flow_Task_AnalyserenVerbeterpunten_EndEvent_EvaluatieVerwerkt</bpmn:incoming>
+    </bpmn:endEvent>
+
+    <bpmn:sequenceFlow id="Flow_StartEvent_R23_Task_BepalenRamingsroute" sourceRef="StartEvent_R23" targetRef="Task_BepalenRamingsroute" />
+    <bpmn:sequenceFlow id="Flow_Task_BepalenRamingsroute_Gateway_MbviMoment" sourceRef="Task_BepalenRamingsroute" targetRef="Gateway_MbviMoment" />
+    <bpmn:sequenceFlow id="Flow_Gateway_MbviMoment_Task_LatenOpstellenVoRaming" name="tijdens" sourceRef="Gateway_MbviMoment" targetRef="Task_LatenOpstellenVoRaming">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${mbviMoment == "tijdens"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_MbviMoment_Task_OpstellenVoRaming" name="voorafgaand aan" sourceRef="Gateway_MbviMoment" targetRef="Task_OpstellenVoRaming">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${mbviMoment == "voorafgaandAan"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Task_LatenOpstellenVoRaming_Gateway_RamingJoin" sourceRef="Task_LatenOpstellenVoRaming" targetRef="Gateway_RamingJoin" />
+    <bpmn:sequenceFlow id="Flow_Task_OpstellenVoRaming_Gateway_RamingJoin" sourceRef="Task_OpstellenVoRaming" targetRef="Gateway_RamingJoin" />
+    <bpmn:sequenceFlow id="Flow_Gateway_RamingJoin_Task_ControlerenProjectramingVO" sourceRef="Gateway_RamingJoin" targetRef="Task_ControlerenProjectramingVO" />
+    <bpmn:sequenceFlow id="Flow_Task_ControlerenProjectramingVO_Gateway_VervolgSplit" sourceRef="Task_ControlerenProjectramingVO" targetRef="Gateway_VervolgSplit" />
+    <bpmn:sequenceFlow id="Flow_Gateway_VervolgSplit_Task_BepalenInkoopstrategie" sourceRef="Gateway_VervolgSplit" targetRef="Task_BepalenInkoopstrategie" />
+    <bpmn:sequenceFlow id="Flow_Gateway_VervolgSplit_Gateway_Projectkrediet" sourceRef="Gateway_VervolgSplit" targetRef="Gateway_Projectkrediet" />
+    <bpmn:sequenceFlow id="Flow_Gateway_VervolgSplit_Task_UpdatenProjectplanning" sourceRef="Gateway_VervolgSplit" targetRef="Task_UpdatenProjectplanning" />
+    <bpmn:sequenceFlow id="Flow_Gateway_VervolgSplit_Task_EvaluerenPlanvoorbereiding" sourceRef="Gateway_VervolgSplit" targetRef="Task_EvaluerenPlanvoorbereiding" />
+    <bpmn:sequenceFlow id="Flow_Task_BepalenInkoopstrategie_EndEvent_InkoopstrategieBepaald" sourceRef="Task_BepalenInkoopstrategie" targetRef="EndEvent_InkoopstrategieBepaald" />
+    <bpmn:sequenceFlow id="Flow_Gateway_Projectkrediet_Task_OpstellenMemoProjectkrediet" name="buiten" sourceRef="Gateway_Projectkrediet" targetRef="Task_OpstellenMemoProjectkrediet">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${projectkredietDekking == "buiten"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_Projectkrediet_Gateway_KredietJoin" name="binnen" sourceRef="Gateway_Projectkrediet" targetRef="Gateway_KredietJoin">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${projectkredietDekking == "binnen"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Task_OpstellenMemoProjectkrediet_Task_BesluitenOverProjectkrediet" sourceRef="Task_OpstellenMemoProjectkrediet" targetRef="Task_BesluitenOverProjectkrediet" />
+    <bpmn:sequenceFlow id="Flow_Task_BesluitenOverProjectkrediet_Task_VerwerkenProjectraming" sourceRef="Task_BesluitenOverProjectkrediet" targetRef="Task_VerwerkenProjectraming" />
+    <bpmn:sequenceFlow id="Flow_Task_VerwerkenProjectraming_Gateway_KredietJoin" sourceRef="Task_VerwerkenProjectraming" targetRef="Gateway_KredietJoin" />
+    <bpmn:sequenceFlow id="Flow_Gateway_KredietJoin_Task_AccorderenProjectplan" sourceRef="Gateway_KredietJoin" targetRef="Task_AccorderenProjectplan" />
+    <bpmn:sequenceFlow id="Flow_Task_AccorderenProjectplan_EndEvent_R24" sourceRef="Task_AccorderenProjectplan" targetRef="EndEvent_R24" />
+    <bpmn:sequenceFlow id="Flow_Task_UpdatenProjectplanning_EndEvent_PlanningGeactualiseerd" sourceRef="Task_UpdatenProjectplanning" targetRef="EndEvent_PlanningGeactualiseerd" />
+    <bpmn:sequenceFlow id="Flow_Task_EvaluerenPlanvoorbereiding_Task_AnalyserenVerbeterpunten" sourceRef="Task_EvaluerenPlanvoorbereiding" targetRef="Task_AnalyserenVerbeterpunten" />
+    <bpmn:sequenceFlow id="Flow_Task_AnalyserenVerbeterpunten_EndEvent_EvaluatieVerwerkt" sourceRef="Task_AnalyserenVerbeterpunten" targetRef="EndEvent_EvaluatieVerwerkt" />
+
+    <bpmn:textAnnotation id="Annotation_BP4">
+      <bpmn:text>BP4 Controleren VO-raming door Kostenadviseur of Kosten- en contractdeskundige</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_BP4" sourceRef="Gateway_RamingJoin" targetRef="Annotation_BP4" />
+    <bpmn:textAnnotation id="Annotation_IN11">
+      <bpmn:text>IN1.1 Behoefte tot inkoop</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_IN11" sourceRef="Task_BepalenInkoopstrategie" targetRef="Annotation_IN11" />
+  </bpmn:process>
+
+  <bpmndi:BPMNDiagram id="BPMNDiagram_RipR23">
+    <bpmndi:BPMNPlane id="BPMNPlane_RipR23" bpmnElement="Collaboration_RipR23">
+      <bpmndi:BPMNShape id="Participant_RipR23_di" bpmnElement="Participant_RipR23" isHorizontal="true">
+        <dc:Bounds x="160" y="80" width="1900" height="1120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Kostenadviseur_di" bpmnElement="Lane_Kostenadviseur" isHorizontal="true">
+        <dc:Bounds x="190" y="80" width="1870" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_KostenContractdeskundige_di" bpmnElement="Lane_KostenContractdeskundige" isHorizontal="true">
+        <dc:Bounds x="190" y="200" width="1870" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_RIPteam_di" bpmnElement="Lane_RIPteam" isHorizontal="true">
+        <dc:Bounds x="190" y="320" width="1870" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Projectleider_di" bpmnElement="Lane_Projectleider" isHorizontal="true">
+        <dc:Bounds x="190" y="440" width="1870" height="160" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_InfraOverleg_di" bpmnElement="Lane_InfraOverleg" isHorizontal="true">
+        <dc:Bounds x="190" y="600" width="1870" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_PKT_di" bpmnElement="Lane_PKT" isHorizontal="true">
+        <dc:Bounds x="190" y="720" width="1870" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Projectbeheersing_di" bpmnElement="Lane_Projectbeheersing" isHorizontal="true">
+        <dc:Bounds x="190" y="840" width="1870" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Adviseur_di" bpmnElement="Lane_Adviseur" isHorizontal="true">
+        <dc:Bounds x="190" y="960" width="1870" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Kwaliteit_di" bpmnElement="Lane_Kwaliteit" isHorizontal="true">
+        <dc:Bounds x="190" y="1080" width="1870" height="120" />
+      </bpmndi:BPMNShape>
+
+      <bpmndi:BPMNShape id="StartEvent_R23_di" bpmnElement="StartEvent_R23">
+        <dc:Bounds x="232" y="502" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="210" y="545" width="82" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_BepalenRamingsroute_di" bpmnElement="Task_BepalenRamingsroute">
+        <dc:Bounds x="330" y="480" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_MbviMoment_di" bpmnElement="Gateway_MbviMoment" isMarkerVisible="true">
+        <dc:Bounds x="480" y="495" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="458" y="552" width="95" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_LatenOpstellenVoRaming_di" bpmnElement="Task_LatenOpstellenVoRaming">
+        <dc:Bounds x="580" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_OpstellenVoRaming_di" bpmnElement="Task_OpstellenVoRaming">
+        <dc:Bounds x="580" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_RamingJoin_di" bpmnElement="Gateway_RamingJoin" isMarkerVisible="true">
+        <dc:Bounds x="740" y="495" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Annotation_BP4_di" bpmnElement="Annotation_BP4">
+        <dc:Bounds x="760" y="95" width="250" height="70" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_ControlerenProjectramingVO_di" bpmnElement="Task_ControlerenProjectramingVO">
+        <dc:Bounds x="840" y="340" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_VervolgSplit_di" bpmnElement="Gateway_VervolgSplit">
+        <dc:Bounds x="1000" y="495" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_BepalenInkoopstrategie_di" bpmnElement="Task_BepalenInkoopstrategie">
+        <dc:Bounds x="1100" y="340" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_InkoopstrategieBepaald_di" bpmnElement="EndEvent_InkoopstrategieBepaald">
+        <dc:Bounds x="1260" y="362" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1238" y="402" width="82" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Annotation_IN11_di" bpmnElement="Annotation_IN11">
+        <dc:Bounds x="1350" y="300" width="200" height="45" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_Projectkrediet_di" bpmnElement="Gateway_Projectkrediet" isMarkerVisible="true">
+        <dc:Bounds x="1100" y="495" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1080" y="452" width="92" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_OpstellenMemoProjectkrediet_di" bpmnElement="Task_OpstellenMemoProjectkrediet">
+        <dc:Bounds x="1200" y="480" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_BesluitenOverProjectkrediet_di" bpmnElement="Task_BesluitenOverProjectkrediet">
+        <dc:Bounds x="1360" y="620" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_VerwerkenProjectraming_di" bpmnElement="Task_VerwerkenProjectraming">
+        <dc:Bounds x="1520" y="740" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_KredietJoin_di" bpmnElement="Gateway_KredietJoin" isMarkerVisible="true">
+        <dc:Bounds x="1680" y="495" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_AccorderenProjectplan_di" bpmnElement="Task_AccorderenProjectplan">
+        <dc:Bounds x="1760" y="480" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_R24_di" bpmnElement="EndEvent_R24">
+        <dc:Bounds x="1920" y="502" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1890" y="545" width="98" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_UpdatenProjectplanning_di" bpmnElement="Task_UpdatenProjectplanning">
+        <dc:Bounds x="1100" y="860" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_PlanningGeactualiseerd_di" bpmnElement="EndEvent_PlanningGeactualiseerd">
+        <dc:Bounds x="1260" y="882" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1240" y="922" width="78" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_EvaluerenPlanvoorbereiding_di" bpmnElement="Task_EvaluerenPlanvoorbereiding">
+        <dc:Bounds x="1100" y="980" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_AnalyserenVerbeterpunten_di" bpmnElement="Task_AnalyserenVerbeterpunten">
+        <dc:Bounds x="1260" y="1100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_EvaluatieVerwerkt_di" bpmnElement="EndEvent_EvaluatieVerwerkt">
+        <dc:Bounds x="1420" y="1122" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1398" y="1162" width="82" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+
+      <bpmndi:BPMNEdge id="Flow_StartEvent_R23_Task_BepalenRamingsroute_di" bpmnElement="Flow_StartEvent_R23_Task_BepalenRamingsroute">
+        <di:waypoint x="268" y="520" />
+        <di:waypoint x="330" y="520" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_BepalenRamingsroute_Gateway_MbviMoment_di" bpmnElement="Flow_Task_BepalenRamingsroute_Gateway_MbviMoment">
+        <di:waypoint x="430" y="520" />
+        <di:waypoint x="480" y="520" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_MbviMoment_Task_LatenOpstellenVoRaming_di" bpmnElement="Flow_Gateway_MbviMoment_Task_LatenOpstellenVoRaming">
+        <di:waypoint x="505" y="495" />
+        <di:waypoint x="505" y="140" />
+        <di:waypoint x="580" y="140" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="512" y="120" width="40" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_MbviMoment_Task_OpstellenVoRaming_di" bpmnElement="Flow_Gateway_MbviMoment_Task_OpstellenVoRaming">
+        <di:waypoint x="505" y="495" />
+        <di:waypoint x="505" y="260" />
+        <di:waypoint x="580" y="260" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="512" y="240" width="88" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_LatenOpstellenVoRaming_Gateway_RamingJoin_di" bpmnElement="Flow_Task_LatenOpstellenVoRaming_Gateway_RamingJoin">
+        <di:waypoint x="680" y="140" />
+        <di:waypoint x="765" y="140" />
+        <di:waypoint x="765" y="495" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_OpstellenVoRaming_Gateway_RamingJoin_di" bpmnElement="Flow_Task_OpstellenVoRaming_Gateway_RamingJoin">
+        <di:waypoint x="680" y="260" />
+        <di:waypoint x="765" y="260" />
+        <di:waypoint x="765" y="495" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_BP4_di" bpmnElement="Association_BP4">
+        <di:waypoint x="778" y="497" />
+        <di:waypoint x="830" y="165" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_RamingJoin_Task_ControlerenProjectramingVO_di" bpmnElement="Flow_Gateway_RamingJoin_Task_ControlerenProjectramingVO">
+        <di:waypoint x="790" y="520" />
+        <di:waypoint x="815" y="520" />
+        <di:waypoint x="815" y="380" />
+        <di:waypoint x="840" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_ControlerenProjectramingVO_Gateway_VervolgSplit_di" bpmnElement="Flow_Task_ControlerenProjectramingVO_Gateway_VervolgSplit">
+        <di:waypoint x="940" y="380" />
+        <di:waypoint x="970" y="380" />
+        <di:waypoint x="970" y="520" />
+        <di:waypoint x="1000" y="520" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_VervolgSplit_Task_BepalenInkoopstrategie_di" bpmnElement="Flow_Gateway_VervolgSplit_Task_BepalenInkoopstrategie">
+        <di:waypoint x="1025" y="495" />
+        <di:waypoint x="1025" y="380" />
+        <di:waypoint x="1100" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_VervolgSplit_Gateway_Projectkrediet_di" bpmnElement="Flow_Gateway_VervolgSplit_Gateway_Projectkrediet">
+        <di:waypoint x="1050" y="520" />
+        <di:waypoint x="1100" y="520" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_VervolgSplit_Task_UpdatenProjectplanning_di" bpmnElement="Flow_Gateway_VervolgSplit_Task_UpdatenProjectplanning">
+        <di:waypoint x="1025" y="545" />
+        <di:waypoint x="1025" y="900" />
+        <di:waypoint x="1100" y="900" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_VervolgSplit_Task_EvaluerenPlanvoorbereiding_di" bpmnElement="Flow_Gateway_VervolgSplit_Task_EvaluerenPlanvoorbereiding">
+        <di:waypoint x="1025" y="545" />
+        <di:waypoint x="1025" y="1020" />
+        <di:waypoint x="1100" y="1020" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_BepalenInkoopstrategie_EndEvent_InkoopstrategieBepaald_di" bpmnElement="Flow_Task_BepalenInkoopstrategie_EndEvent_InkoopstrategieBepaald">
+        <di:waypoint x="1200" y="380" />
+        <di:waypoint x="1260" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_IN11_di" bpmnElement="Association_IN11">
+        <di:waypoint x="1198" y="358" />
+        <di:waypoint x="1350" y="330" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_Projectkrediet_Task_OpstellenMemoProjectkrediet_di" bpmnElement="Flow_Gateway_Projectkrediet_Task_OpstellenMemoProjectkrediet">
+        <di:waypoint x="1150" y="520" />
+        <di:waypoint x="1200" y="520" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1159" y="498" width="33" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_Projectkrediet_Gateway_KredietJoin_di" bpmnElement="Flow_Gateway_Projectkrediet_Gateway_KredietJoin">
+        <di:waypoint x="1125" y="545" />
+        <di:waypoint x="1125" y="578" />
+        <di:waypoint x="1705" y="578" />
+        <di:waypoint x="1705" y="545" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1132" y="556" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_OpstellenMemoProjectkrediet_Task_BesluitenOverProjectkrediet_di" bpmnElement="Flow_Task_OpstellenMemoProjectkrediet_Task_BesluitenOverProjectkrediet">
+        <di:waypoint x="1300" y="520" />
+        <di:waypoint x="1330" y="520" />
+        <di:waypoint x="1330" y="660" />
+        <di:waypoint x="1360" y="660" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_BesluitenOverProjectkrediet_Task_VerwerkenProjectraming_di" bpmnElement="Flow_Task_BesluitenOverProjectkrediet_Task_VerwerkenProjectraming">
+        <di:waypoint x="1460" y="660" />
+        <di:waypoint x="1490" y="660" />
+        <di:waypoint x="1490" y="780" />
+        <di:waypoint x="1520" y="780" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_VerwerkenProjectraming_Gateway_KredietJoin_di" bpmnElement="Flow_Task_VerwerkenProjectraming_Gateway_KredietJoin">
+        <di:waypoint x="1620" y="780" />
+        <di:waypoint x="1705" y="780" />
+        <di:waypoint x="1705" y="545" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_KredietJoin_Task_AccorderenProjectplan_di" bpmnElement="Flow_Gateway_KredietJoin_Task_AccorderenProjectplan">
+        <di:waypoint x="1730" y="520" />
+        <di:waypoint x="1760" y="520" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_AccorderenProjectplan_EndEvent_R24_di" bpmnElement="Flow_Task_AccorderenProjectplan_EndEvent_R24">
+        <di:waypoint x="1860" y="520" />
+        <di:waypoint x="1920" y="520" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_UpdatenProjectplanning_EndEvent_PlanningGeactualiseerd_di" bpmnElement="Flow_Task_UpdatenProjectplanning_EndEvent_PlanningGeactualiseerd">
+        <di:waypoint x="1200" y="900" />
+        <di:waypoint x="1260" y="900" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_EvaluerenPlanvoorbereiding_Task_AnalyserenVerbeterpunten_di" bpmnElement="Flow_Task_EvaluerenPlanvoorbereiding_Task_AnalyserenVerbeterpunten">
+        <di:waypoint x="1200" y="1020" />
+        <di:waypoint x="1230" y="1020" />
+        <di:waypoint x="1230" y="1140" />
+        <di:waypoint x="1260" y="1140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_AnalyserenVerbeterpunten_EndEvent_EvaluatieVerwerkt_di" bpmnElement="Flow_Task_AnalyserenVerbeterpunten_EndEvent_EvaluatieVerwerkt">
+        <di:waypoint x="1360" y="1140" />
+        <di:waypoint x="1420" y="1140" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/examples/organizations/flevoland/rip-phase-23/rip-accorderen-projectplan-vo.form
+++ b/examples/organizations/flevoland/rip-phase-23/rip-accorderen-projectplan-vo.form
@@ -1,0 +1,71 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-accorderen-projectplan-vo",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Approve the project plan — 5. Closing the VO phase"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Approve the project plan so the VO phase can be closed and R2.4 (commissioning the external engineering firm) can start."
+    },
+    {
+      "id": "Field_ProjectplanReferentie",
+      "type": "textfield",
+      "label": "Project plan reference",
+      "key": "projectplanReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_AkkoordProjectplan",
+      "type": "select",
+      "label": "Project plan approved",
+      "key": "akkoordProjectplan",
+      "values": [
+        {
+          "label": "Yes",
+          "value": "ja"
+        },
+        {
+          "label": "No",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_ProjectplanVastgesteldOp",
+      "type": "datetime",
+      "label": "Adopted on",
+      "key": "projectplanVastgesteldOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_AccordeerOpmerkingen",
+      "type": "textarea",
+      "label": "Comments",
+      "key": "accordeerOpmerkingen"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-23/rip-analyseren-verbeterpunten.form
+++ b/examples/organizations/flevoland/rip-phase-23/rip-analyseren-verbeterpunten.form
@@ -1,0 +1,52 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-analyseren-verbeterpunten",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Analyse and process the improvement points"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Analyse the evaluation outcome and record which improvement points were carried through."
+    },
+    {
+      "id": "Field_Verbeterpunten",
+      "type": "textarea",
+      "label": "Improvement points identified",
+      "key": "verbeterpunten",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_DoorgevoerdeAanpassingen",
+      "type": "textarea",
+      "label": "Changes carried through",
+      "key": "doorgevoerdeAanpassingen"
+    },
+    {
+      "id": "Field_VerbeterpuntenVerwerktOp",
+      "type": "datetime",
+      "label": "Processed on",
+      "key": "verbeterpuntenVerwerktOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-23/rip-bepalen-inkoopstrategie.form
+++ b/examples/organizations/flevoland/rip-phase-23/rip-bepalen-inkoopstrategie.form
@@ -1,0 +1,77 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-bepalen-inkoopstrategie",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Determine the procurement strategy"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Set the procurement strategy for the project against the procurement plan format, the adopted project plan and the Infra procurement strategy. The result feeds IN1.1."
+    },
+    {
+      "id": "Field_InkoopplanReferentie",
+      "type": "textfield",
+      "label": "Procurement plan reference",
+      "key": "inkoopplanReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_Inkoopstrategie",
+      "type": "select",
+      "label": "Procurement strategy",
+      "key": "inkoopstrategie",
+      "values": [
+        {
+          "label": "Open tender",
+          "value": "openbaar"
+        },
+        {
+          "label": "Restricted tender",
+          "value": "nietOpenbaar"
+        },
+        {
+          "label": "Private tender",
+          "value": "onderhands"
+        },
+        {
+          "label": "Framework agreement",
+          "value": "raamovereenkomst"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_VastgesteldProjectplanReferentie",
+      "type": "textfield",
+      "label": "Adopted project plan reference (VO assumptions)",
+      "key": "vastgesteldProjectplanReferentie"
+    },
+    {
+      "id": "Field_InkoopMotivering",
+      "type": "textarea",
+      "label": "Rationale for the chosen strategy",
+      "key": "inkoopMotivering",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-23/rip-bepalen-ramingsroute.form
+++ b/examples/organizations/flevoland/rip-phase-23/rip-bepalen-ramingsroute.form
@@ -1,0 +1,69 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-bepalen-ramingsroute",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Determine the VO-raming route"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Confirm the artefacts carried over from R2.2 and choose who draws up the VO cost estimate. During the MBVI process the cost advisor is commissioned; ahead of it the cost and contract specialist prepares it against the MBVI estimate."
+    },
+    {
+      "id": "Field_VoReferentie",
+      "type": "textfield",
+      "label": "Adopted VO reference (from R2.2)",
+      "key": "voReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_HoeveelheidsbepalingReferentie",
+      "type": "textfield",
+      "label": "Quantity determination reference (from R2.2)",
+      "key": "hoeveelheidsbepalingReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_MbviMoment",
+      "type": "select",
+      "label": "Estimate drawn up in relation to the MBVI process",
+      "key": "mbviMoment",
+      "values": [
+        {
+          "label": "During the MBVI process — cost advisor",
+          "value": "tijdens"
+        },
+        {
+          "label": "Ahead of the MBVI process — cost and contract specialist",
+          "value": "voorafgaandAan"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_RamingsrouteToelichting",
+      "type": "textarea",
+      "label": "Notes on the chosen route",
+      "key": "ramingsrouteToelichting"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-23/rip-besluit-projectkrediet.document
+++ b/examples/organizations/flevoland/rip-phase-23/rip-besluit-projectkrediet.document
@@ -1,0 +1,227 @@
+{
+  "id": "rip-besluit-projectkrediet",
+  "name": "RIP — Project Credit Decision (Besluit projectkrediet)",
+  "description": "Records the Infra consultation decision on the project credit requested in the memo.",
+  "processKey": "RipR23Process",
+  "serviceId": "RipR23",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{memoReferentie}}",
+      "variableKey": "memoReferentie",
+      "source": "process",
+      "label": "Memo reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{besluitProjectkrediet}}",
+      "variableKey": "besluitProjectkrediet",
+      "source": "process",
+      "label": "Decision"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{toegekendBedrag}}",
+      "variableKey": "toegekendBedrag",
+      "source": "process",
+      "label": "Granted amount"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{besluitDatum}}",
+      "variableKey": "besluitDatum",
+      "source": "process",
+      "label": "Decision date"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{besluitToelichting}}",
+      "variableKey": "besluitToelichting",
+      "source": "process",
+      "label": "Explanation"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Decision on memo {{memoReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Decision on the project credit",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Decision on the project credit"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "On {{besluitDatum}} the Infra consultation decided on the project credit requested in memo {{memoReferentie}} for project {{projectNumber}} — {{projectName}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Decision: {{besluitProjectkrediet}}. Granted amount: EUR {{toegekendBedrag}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Explanation: {{besluitToelichting}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The decision is processed into the Infra framework credit administration."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Decided by the Infra consultation"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-23/rip-besluiten-projectkrediet.form
+++ b/examples/organizations/flevoland/rip-phase-23/rip-besluiten-projectkrediet.form
@@ -1,0 +1,72 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-besluiten-projectkrediet",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Decide on the project credit"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Record the Infra consultation decision on the requested project credit."
+    },
+    {
+      "id": "Field_BesluitProjectkrediet",
+      "type": "select",
+      "label": "Decision",
+      "key": "besluitProjectkrediet",
+      "values": [
+        {
+          "label": "Granted",
+          "value": "toegekend"
+        },
+        {
+          "label": "Refused",
+          "value": "afgewezen"
+        },
+        {
+          "label": "Deferred",
+          "value": "aangehouden"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_ToegekendBedrag",
+      "type": "number",
+      "label": "Granted amount (EUR)",
+      "key": "toegekendBedrag"
+    },
+    {
+      "id": "Field_BesluitDatum",
+      "type": "datetime",
+      "label": "Decision date",
+      "key": "besluitDatum",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_BesluitToelichting",
+      "type": "textarea",
+      "label": "Explanation",
+      "key": "besluitToelichting"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-23/rip-controleren-projectraming-vo.form
+++ b/examples/organizations/flevoland/rip-phase-23/rip-controleren-projectraming-vo.form
@@ -1,0 +1,80 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-controleren-projectraming-vo",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Check the VO project estimate"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Review the project estimate and record whether it falls within or outside the available project credit. That answer routes the remainder of the phase."
+    },
+    {
+      "id": "Field_GecontroleerdDoor",
+      "type": "textfield",
+      "label": "Checked by",
+      "key": "gecontroleerdDoor",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_GecontroleerdOp",
+      "type": "datetime",
+      "label": "Checked on",
+      "key": "gecontroleerdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_BeschikbaarProjectkrediet",
+      "type": "number",
+      "label": "Available project credit (EUR)",
+      "key": "beschikbaarProjectkrediet",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_ProjectkredietDekking",
+      "type": "select",
+      "label": "Estimate falls within or outside the project credit",
+      "key": "projectkredietDekking",
+      "values": [
+        {
+          "label": "Within the project credit",
+          "value": "binnen"
+        },
+        {
+          "label": "Outside the project credit",
+          "value": "buiten"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_ControleOpmerkingen",
+      "type": "textarea",
+      "label": "Review comments",
+      "key": "controleOpmerkingen"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-23/rip-evaluatie-vo.document
+++ b/examples/organizations/flevoland/rip-phase-23/rip-evaluatie-vo.document
@@ -1,0 +1,204 @@
+{
+  "id": "rip-evaluatie-vo",
+  "name": "RIP — VO Phase Evaluation (Evaluatie VO)",
+  "description": "Internal evaluation of the plan preparation, carried out in Qualtrics and analysed by Quality.",
+  "processKey": "RipR23Process",
+  "serviceId": "RipR23",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{qualtricsReferentie}}",
+      "variableKey": "qualtricsReferentie",
+      "source": "process",
+      "label": "Qualtrics reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{evaluatieUitgevoerdOp}}",
+      "variableKey": "evaluatieUitgevoerdOp",
+      "source": "process",
+      "label": "Evaluation date"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{belangrijksteBevindingen}}",
+      "variableKey": "belangrijksteBevindingen",
+      "source": "process",
+      "label": "Main findings"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Evaluation {{qualtricsReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Evaluation of the plan preparation",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Evaluation of the plan preparation"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The internal evaluation of the plan preparation for project {{projectNumber}} — {{projectName}} was carried out on {{evaluatieUitgevoerdOp}} and is recorded in Qualtrics under {{qualtricsReferentie}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Main findings: {{belangrijksteBevindingen}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Quality analyses the outcome and carries the improvement points through into the RIP process descriptions."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Evaluated by the adviser"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-23/rip-evalueren-planvoorbereiding.form
+++ b/examples/organizations/flevoland/rip-phase-23/rip-evalueren-planvoorbereiding.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-evalueren-planvoorbereiding",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Evaluate the plan preparation (internal)"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Run the internal evaluation of the plan preparation and record the Qualtrics reference."
+    },
+    {
+      "id": "Field_QualtricsReferentie",
+      "type": "textfield",
+      "label": "Qualtrics evaluation reference",
+      "key": "qualtricsReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_EvaluatieUitgevoerdOp",
+      "type": "datetime",
+      "label": "Evaluation carried out on",
+      "key": "evaluatieUitgevoerdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_BelangrijksteBevindingen",
+      "type": "textarea",
+      "label": "Main findings",
+      "key": "belangrijksteBevindingen",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-23/rip-inkoopplan.document
+++ b/examples/organizations/flevoland/rip-phase-23/rip-inkoopplan.document
@@ -1,0 +1,211 @@
+{
+  "id": "rip-inkoopplan",
+  "name": "RIP — Procurement Plan (Inkoopplan)",
+  "description": "Format Inkoopplan. Sets the procurement strategy for the project and hands over to IN1.1 Behoefte tot inkoop.",
+  "processKey": "RipR23Process",
+  "serviceId": "RipR23",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{inkoopplanReferentie}}",
+      "variableKey": "inkoopplanReferentie",
+      "source": "process",
+      "label": "Procurement plan reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{inkoopstrategie}}",
+      "variableKey": "inkoopstrategie",
+      "source": "process",
+      "label": "Procurement strategy"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{inkoopMotivering}}",
+      "variableKey": "inkoopMotivering",
+      "source": "process",
+      "label": "Rationale"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{vastgesteldProjectplanReferentie}}",
+      "variableKey": "vastgesteldProjectplanReferentie",
+      "source": "process",
+      "label": "Adopted project plan reference"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Procurement plan {{inkoopplanReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Procurement strategy",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Procurement strategy"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The procurement strategy for project {{projectNumber}} — {{projectName}} is {{inkoopstrategie}}, recorded in procurement plan {{inkoopplanReferentie}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Rationale: {{inkoopMotivering}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The strategy follows the adopted project plan ({{vastgesteldProjectplanReferentie}}) and the Infra procurement strategy. It is handed over to IN1.1 Behoefte tot inkoop."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Determined by the RIP team"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-23/rip-laten-opstellen-vo-raming.form
+++ b/examples/organizations/flevoland/rip-phase-23/rip-laten-opstellen-vo-raming.form
@@ -1,0 +1,83 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-laten-opstellen-vo-raming",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Commission the VO cost estimate"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Have the VO cost estimate drawn up against the project estimate format and the Province of Flevoland SSK calculation model, using the quantity determination from R2.2."
+    },
+    {
+      "id": "Field_FormatProjectramingVersie",
+      "type": "textfield",
+      "label": "Project estimate format version",
+      "key": "formatProjectramingVersie"
+    },
+    {
+      "id": "Field_SskRekenmodelVersie",
+      "type": "textfield",
+      "label": "SSK calculation model version (Province of Flevoland)",
+      "key": "sskRekenmodelVersie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_ProjectramingReferentie",
+      "type": "textfield",
+      "label": "Project estimate reference",
+      "key": "projectramingReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_SskRamingReferentie",
+      "type": "textfield",
+      "label": "SSK estimate reference",
+      "key": "sskRamingReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_RamingBedrag",
+      "type": "number",
+      "label": "Estimated project cost (EUR)",
+      "key": "ramingBedrag",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_OpgesteldDoor",
+      "type": "textfield",
+      "label": "Drawn up by (cost advisor)",
+      "key": "opgesteldDoor",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_RamingToelichting",
+      "type": "textarea",
+      "label": "Notes and assumptions",
+      "key": "ramingToelichting"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-23/rip-memo-projectkrediet.document
+++ b/examples/organizations/flevoland/rip-phase-23/rip-memo-projectkrediet.document
@@ -1,0 +1,227 @@
+{
+  "id": "rip-memo-projectkrediet",
+  "name": "RIP — Project Credit Memo (Memo projectkrediet)",
+  "description": "Format Memo projectkrediet. The soft claim raised when the VO estimate exceeds the available project credit.",
+  "processKey": "RipR23Process",
+  "serviceId": "RipR23",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{memoReferentie}}",
+      "variableKey": "memoReferentie",
+      "source": "process",
+      "label": "Memo reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{gevraagdKrediet}}",
+      "variableKey": "gevraagdKrediet",
+      "source": "process",
+      "label": "Requested project credit"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{dekkingstekort}}",
+      "variableKey": "dekkingstekort",
+      "source": "process",
+      "label": "Shortfall"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{beschikbaarProjectkrediet}}",
+      "variableKey": "beschikbaarProjectkrediet",
+      "source": "process",
+      "label": "Available project credit"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{memoOnderbouwing}}",
+      "variableKey": "memoOnderbouwing",
+      "source": "process",
+      "label": "Substantiation"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Memo {{memoReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Request for additional project credit",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Request for additional project credit"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The VO cost estimate for project {{projectNumber}} — {{projectName}} falls outside the available project credit of EUR {{beschikbaarProjectkrediet}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "This memo ({{memoReferentie}}) requests a project credit of EUR {{gevraagdKrediet}}, a shortfall of EUR {{dekkingstekort}} against the current credit."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Substantiation: {{memoOnderbouwing}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The request is submitted to the Infra consultation as a soft claim."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up by the project leader"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-23/rip-opstellen-memo-projectkrediet.form
+++ b/examples/organizations/flevoland/rip-phase-23/rip-opstellen-memo-projectkrediet.form
@@ -1,0 +1,59 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-opstellen-memo-projectkrediet",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Draw up the project credit memo (soft claim)"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The estimate falls outside the current project credit. Draw up the project credit memo so the Infra consultation can decide on the additional credit."
+    },
+    {
+      "id": "Field_MemoReferentie",
+      "type": "textfield",
+      "label": "Memo reference",
+      "key": "memoReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_GevraagdKrediet",
+      "type": "number",
+      "label": "Requested project credit (EUR)",
+      "key": "gevraagdKrediet",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_Dekkingstekort",
+      "type": "number",
+      "label": "Shortfall against the current credit (EUR)",
+      "key": "dekkingstekort"
+    },
+    {
+      "id": "Field_MemoOnderbouwing",
+      "type": "textarea",
+      "label": "Substantiation of the soft claim",
+      "key": "memoOnderbouwing",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-23/rip-opstellen-vo-raming.form
+++ b/examples/organizations/flevoland/rip-phase-23/rip-opstellen-vo-raming.form
@@ -1,0 +1,92 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-opstellen-vo-raming",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Draw up the VO cost estimate"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Prepare the VO cost estimate from the project estimate format, the risk file, the quantity determination and the MBVI estimate."
+    },
+    {
+      "id": "Field_FormatProjectramingVersie",
+      "type": "textfield",
+      "label": "Project estimate format version",
+      "key": "formatProjectramingVersie"
+    },
+    {
+      "id": "Field_RisicodossierReferentie",
+      "type": "textfield",
+      "label": "Risk file reference",
+      "key": "risicodossierReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_MbviRamingReferentie",
+      "type": "textfield",
+      "label": "MBVI estimate reference",
+      "key": "mbviRamingReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_ProjectramingReferentie",
+      "type": "textfield",
+      "label": "Project estimate reference",
+      "key": "projectramingReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_SskRamingReferentie",
+      "type": "textfield",
+      "label": "SSK estimate reference",
+      "key": "sskRamingReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_RamingBedrag",
+      "type": "number",
+      "label": "Estimated project cost (EUR)",
+      "key": "ramingBedrag",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_OpgesteldDoor",
+      "type": "textfield",
+      "label": "Drawn up by (cost and contract specialist)",
+      "key": "opgesteldDoor",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_RamingToelichting",
+      "type": "textarea",
+      "label": "Notes and assumptions",
+      "key": "ramingToelichting"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-23/rip-projectplan-vo.document
+++ b/examples/organizations/flevoland/rip-phase-23/rip-projectplan-vo.document
@@ -1,0 +1,227 @@
+{
+  "id": "rip-projectplan-vo",
+  "name": "RIP — Adopted Project Plan, VO phase (Vastgesteld Projectplan VO)",
+  "description": "The project plan as adopted at the close of the VO phase. Hands over to R2.4 Opdracht extern ingenieursbureau.",
+  "processKey": "RipR23Process",
+  "serviceId": "RipR23",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{projectplanReferentie}}",
+      "variableKey": "projectplanReferentie",
+      "source": "process",
+      "label": "Project plan reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{projectplanVastgesteldOp}}",
+      "variableKey": "projectplanVastgesteldOp",
+      "source": "process",
+      "label": "Adopted on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{projectramingReferentie}}",
+      "variableKey": "projectramingReferentie",
+      "source": "process",
+      "label": "Project estimate reference"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{inkoopplanReferentie}}",
+      "variableKey": "inkoopplanReferentie",
+      "source": "process",
+      "label": "Procurement plan reference"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{accordeerOpmerkingen}}",
+      "variableKey": "accordeerOpmerkingen",
+      "source": "process",
+      "label": "Comments"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project plan {{projectplanReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Adopted project plan — closing the VO phase",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Adopted project plan — closing the VO phase"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project plan {{projectplanReferentie}} for project {{projectNumber}} — {{projectName}} was adopted on {{projectplanVastgesteldOp}}, closing the VO phase."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The plan incorporates the VO cost estimate {{projectramingReferentie}} and the procurement strategy recorded in {{inkoopplanReferentie}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Comments: {{accordeerOpmerkingen}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "With this adoption the project moves to R2.4, commissioning the external engineering firm."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Approved by the project leader"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-23/rip-projectraming.document
+++ b/examples/organizations/flevoland/rip-phase-23/rip-projectraming.document
@@ -1,0 +1,225 @@
+{
+  "id": "rip-projectraming",
+  "name": "RIP — Project Estimate (Projectraming / SSK-raming)",
+  "description": "Format Projectraming. Records the VO cost estimate and the matching SSK estimate for the preliminary design, drawn up in R2.3.",
+  "processKey": "RipR23Process",
+  "serviceId": "RipR23",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{projectramingReferentie}}",
+      "variableKey": "projectramingReferentie",
+      "source": "process",
+      "label": "Project estimate reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{sskRamingReferentie}}",
+      "variableKey": "sskRamingReferentie",
+      "source": "process",
+      "label": "SSK estimate reference"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{ramingBedrag}}",
+      "variableKey": "ramingBedrag",
+      "source": "process",
+      "label": "Estimated project cost"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{voReferentie}}",
+      "variableKey": "voReferentie",
+      "source": "process",
+      "label": "VO reference"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{hoeveelheidsbepalingReferentie}}",
+      "variableKey": "hoeveelheidsbepalingReferentie",
+      "source": "process",
+      "label": "Quantity determination reference"
+    },
+    {
+      "id": "b8",
+      "placeholder": "{{opgesteldDoor}}",
+      "variableKey": "opgesteldDoor",
+      "source": "process",
+      "label": "Drawn up by"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project estimate {{projectramingReferentie}} · SSK estimate {{sskRamingReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "VO cost estimate",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "VO cost estimate"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "This project estimate ({{projectramingReferentie}}) and the accompanying SSK estimate ({{sskRamingReferentie}}) cover the adopted preliminary design {{voReferentie}} for project {{projectNumber}} — {{projectName}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The estimated project cost is EUR {{ramingBedrag}}. The quantities are taken from the quantity determination {{hoeveelheidsbepalingReferentie}} produced in R2.2."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The estimate is submitted for verification under BP4 by the cost advisor or the cost and contract specialist before the RIP team checks it."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up by: {{opgesteldDoor}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-23/rip-updaten-projectplanning.form
+++ b/examples/organizations/flevoland/rip-phase-23/rip-updaten-projectplanning.form
@@ -1,0 +1,49 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-updaten-projectplanning",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Update the project planning"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Update the project planning after the VO estimate and inform the project leader and the support officer."
+    },
+    {
+      "id": "Field_PlanningReferentie",
+      "type": "textfield",
+      "label": "Planning reference",
+      "key": "planningReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_NieuweMijlpaaldatum",
+      "type": "datetime",
+      "label": "Next milestone date",
+      "key": "nieuweMijlpaaldatum",
+      "subtype": "date",
+      "dateLabel": "Date"
+    },
+    {
+      "id": "Field_GeinformeerdePersonen",
+      "type": "textarea",
+      "label": "People informed",
+      "key": "geinformeerdePersonen"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-23/rip-verwerken-projectraming.form
+++ b/examples/organizations/flevoland/rip-phase-23/rip-verwerken-projectraming.form
@@ -1,0 +1,58 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-verwerken-projectraming",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Process the project estimate and Infra framework credit"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Record the project estimate and the credit decision in the Infra framework credit administration."
+    },
+    {
+      "id": "Field_VerwerktBedrag",
+      "type": "number",
+      "label": "Amount processed (EUR)",
+      "key": "verwerktBedrag",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_AdministratieReferentie",
+      "type": "textfield",
+      "label": "Administration reference",
+      "key": "administratieReferentie"
+    },
+    {
+      "id": "Field_VerwerktOp",
+      "type": "datetime",
+      "label": "Processed on",
+      "key": "verwerktOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Field_VerwerkingsOpmerkingen",
+      "type": "textarea",
+      "label": "Comments",
+      "key": "verwerkingsOpmerkingen"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}


### PR DESCRIPTION
Models **R2.3 (VO-raming)** from `rip-phases-left/R2 Planvoorbereiding/R2_3 - VO-raming.pdf`, following the conventions R2.1 and R2.2 established. Third rung of the Flevoland RIP ladder.

`RipR23Process` — 22 flow nodes, 23 sequence flows, 9 lanes, 12 forms, 6 document templates. All nine lanes on the overzichtsplaat are modelled.

## Flow

```
Start (from R2.2)
 └─ Bepalen ramingsroute VO-raming            (Projectleider)
 └─ XOR  tijdens / voorafgaand aan MBVI-proces?
      ├─ tijdens          → Laten opstellen VO-raming   (Kostenadviseur)
      └─ voorafgaand aan  → Opstellen VO-raming         (Kosten- en contractdeskundige)
 └─ join ──▷ annotation: BP4 Controleren VO-raming
 └─ Controleren Projectraming VO              (RIP-team)   ← sets binnen/buiten
 └─ AND split
      ├─ Bepalen inkoopstrategie              (RIP-team) ──▷ annotation: IN1.1
      ├─ XOR  Raming VO binnen / buiten projectkrediet?
      │    ├─ buiten → Opstellen memo projectkrediet     (Projectleider)
      │    │            └─ Besluiten over projectkrediet (Infra-overleg)
      │    │                 └─ Verwerken projectraming  (PKT + Aandrager, Manager Financiën)
      │    └─ binnen ─────────────────────────┐
      │                                       └─ join → Accorderen Projectplan
      │                                                  5. Afronding VO-fase → R2.4
      ├─ Updaten projectplanning              (Projectbeheersing)
      └─ Evalueren planvoorbereiding          (Adviseur)
           └─ Analyseren en verwerken verbeterpunten (Kwaliteit)
```

## Two conventions carried over, not invented

**Cross-sheet references are annotations.** `BP4` and `IN1.1` are `textAnnotation`s, matching how R2.2 renders `CO1.` and `JU3.5`. Only the phase handover to R2.4 is an end event, mirroring R2.2's `→ R2.3`. R2.2's `Association_JoinTerugkeer` already attaches an annotation to a gateway, so `Association_BP4` on `Gateway_RamingJoin` follows an existing shape.

**The start event carries no form.** The Faseladder board starts this process via `POST /v1/process/RipR23Process/start` with variables. A start form would leave `mbviMoment` unset and the instance would stop at the first gateway with no outgoing flow selectable — a live instance parked where no human can action it. The routing question is asked in the first user task instead, which also keeps `projectNumber`/`projectName` arriving from the board rather than being re-collected. A comment at the start event records why.

## Faseladder contract conformance

Cross-checked with the `ronl-business-api` session that owns the board:

| | Item | State |
|---|---|---|
| 1 | Process-definition key | `RipR23Process` |
| 2 | Tenant `flevoland` | at deploy |
| 3 | `municipality` never read, set, renamed or cleared | verified |
| 4 | `businessKey` not set or overwritten | 0 occurrences |
| 5 | External-task topics | **none** — no serviceTasks, so no new worker subscription needed |
| 6 | `formRefBinding="deployment"` | all 12, zero `latest` |

The process closes on *Accorderen Projectplan 5. Afronding VO-fase*, which is R2.4's entry criterion, so the ladder narrative stays coherent.

`boardOwner` and `ronl:organization` are **deliberately absent**. Both are injected at deploy time (`injectBoardOwner` in the LDE backend; the deploy modal's organization field) and neither is authored in R2.1 or R2.2 source either. R2.3's candidate groups are all `rip-*`, so board derivation resolves to `infra-board`, matching the other two phases.

## Verification

Two checkers were run against R2.1 and R2.2 first to calibrate them against known-good files:

- **Structural BPMN** — ids, reference resolution, incoming/outgoing agreement, reachability, one-lane-per-node, deterministic exclusive gateways, DI integrity. R2.3: **OK**.
- **Bundle cross-check** — every `formRef`/`documentRef` resolves to a file whose internal id agrees, every `{{placeholder}}` has a binding, every gateway condition names a variable some form sets. R2.3: **OK**, with the two expected notes that `projectNumber`/`projectName` come from the board (same as R2.2).

## Not deployed

The engine still carries only `RipR21Process` and `RipR22Process`. Deployment is planned for tomorrow via the LDE deploy modal, which is also what stamps `ronl:organization` and `boardOwner`. The RBA side is holding its one-line phase-catalogue addition until `RipR23Process` is confirmed on `/engine-rest`.
