### PR TITLE
feat(rip): add R2.4 DO en -raming phase bundle for Flevoland

### DIFF
--- a/examples/organizations/flevoland/rip-phase-24/RipR24Process.bpmn
+++ b/examples/organizations/flevoland/rip-phase-24/RipR24Process.bpmn
@@ -1,0 +1,569 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:ronl="http://ronl.nl/schema/1.0" id="Definitions_RipR24Process" targetNamespace="http://example.com/rip-phase-24" exporter="Camunda Modeler" exporterVersion="5.45.0">
+  <bpmn:collaboration id="Collaboration_RipR24Process">
+    <bpmn:participant id="Participant_RipR24Process" name="R2.4 - DO en -raming" processRef="RipR24Process" />
+  </bpmn:collaboration>
+  <bpmn:process id="RipR24Process" name="R2.4 - DO en -raming" isExecutable="true" camunda:historyTimeToLive="180">
+    <bpmn:laneSet id="LaneSet_RipR24Process">
+      <bpmn:lane id="Lane_Adviseurs" name="Adviseurs, Beheerder Assetmanagement">
+        <bpmn:flowNodeRef>Task_BeoordelenRetournerenILS</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_RIPteam" name="RIP-team + Aandrager + Adviseurs + Vestigingsmanager">
+        <bpmn:flowNodeRef>Task_BesprekenConceptDO</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_ConceptDOAkkoord</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_ToetsenAanpassingen</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_AanpassingenAkkoord</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_Projectleider" name="Projectleider">
+        <bpmn:flowNodeRef>StartEvent_R24</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_OpdrachtExternIB</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_OnderzoekenSplit</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_LatenUitvoerenAanvullendeOnderzoeken</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_LatenInventariserenVergunningen</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_OnderzoekenJoin</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_LatenOpstellenConceptDO</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_LatenAanpassenDO</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_DOAkkoordJoin</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_DOSplit</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_LatenOpstellenDefinitiefDO</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_LatenOpstellenDefinitieveDORaming</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_DOJoin</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_OpstellenMemoProjectkredietDO</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_KredietJoin</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_InvullenILS</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_OntvangenBeoordeeldeILS</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_AccorderenProjectplanDO</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndEvent_R31</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_KostenContractdeskundige" name="Kosten- en contractdeskundige">
+        <bpmn:flowNodeRef>Task_OpstellenProjectramingDO</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_RamingBinnenKrediet</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_InfraOverleg" name="Infra-overleg">
+        <bpmn:flowNodeRef>Task_BesluitenOverProjectkredietDO</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_Financien" name="Financiën">
+        <bpmn:flowNodeRef>Task_AccorderenBeschikbaarKrediet</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_VerwerkenProjectramingDO</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+
+    <bpmn:startEvent id="StartEvent_R24" name="Start R2.4 - DO en -raming&#10;(vanuit R2.3)">
+      <bpmn:outgoing>Flow_StartEvent_R24_Task_OpdrachtExternIB</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:userTask id="Task_OpdrachtExternIB" name="Opdracht extern&#10;ingenieursbureau" camunda:formRef="rip-opdracht-extern-ib" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
+      <bpmn:incoming>Flow_StartEvent_R24_Task_OpdrachtExternIB</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_OpdrachtExternIB_Gateway_OnderzoekenSplit</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:parallelGateway id="Gateway_OnderzoekenSplit">
+      <bpmn:incoming>Flow_Task_OpdrachtExternIB_Gateway_OnderzoekenSplit</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_OnderzoekenSplit_Task_LatenUitvoerenAanvullendeOnderzoeken</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_OnderzoekenSplit_Task_LatenInventariserenVergunningen</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:userTask id="Task_LatenUitvoerenAanvullendeOnderzoeken" name="Laten uitvoeren aanvullende&#10;conditionerende onderzoeken" camunda:formRef="rip-aanvullende-conditionerende-onderzoeken" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
+      <bpmn:incoming>Flow_Gateway_OnderzoekenSplit_Task_LatenUitvoerenAanvullendeOnderzoeken</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_LatenUitvoerenAanvullendeOnderzoeken_Gateway_OnderzoekenJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_LatenInventariserenVergunningen" name="Laten inventariseren vergunningen&#10;door extern IB" camunda:formRef="rip-inventariseren-vergunningen" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-vergunningenscan">
+      <bpmn:incoming>Flow_Gateway_OnderzoekenSplit_Task_LatenInventariserenVergunningen</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_LatenInventariserenVergunningen_Gateway_OnderzoekenJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:parallelGateway id="Gateway_OnderzoekenJoin">
+      <bpmn:incoming>Flow_Task_LatenUitvoerenAanvullendeOnderzoeken_Gateway_OnderzoekenJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_LatenInventariserenVergunningen_Gateway_OnderzoekenJoin</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_OnderzoekenJoin_Task_LatenOpstellenConceptDO</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:userTask id="Task_LatenOpstellenConceptDO" name="Laten opstellen concept DO&#10;en concept DO-raming door extern IB" camunda:formRef="rip-concept-do" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-concept-do-dossier">
+      <bpmn:incoming>Flow_Gateway_OnderzoekenJoin_Task_LatenOpstellenConceptDO</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_LatenOpstellenConceptDO_Task_BesprekenConceptDO</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_BesprekenConceptDO" name="Bespreken concept DO&#10;en concept DO-raming" camunda:formRef="rip-bespreken-concept-do" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-team,rip-aandrager,rip-adviseur,rip-vestigingsmanager" ronl:documentRef="rip-bevindingenformulier-do">
+      <bpmn:incoming>Flow_Task_LatenOpstellenConceptDO_Task_BesprekenConceptDO</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_BesprekenConceptDO_Gateway_ConceptDOAkkoord</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_ConceptDOAkkoord" name="Akkoord?">
+      <bpmn:incoming>Flow_Task_BesprekenConceptDO_Gateway_ConceptDOAkkoord</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_ConceptDOAkkoord_Task_LatenAanpassenDO</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_ConceptDOAkkoord_Gateway_DOAkkoordJoin</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_LatenAanpassenDO" name="Laten aanpassen DO&#10;door extern IB" camunda:formRef="rip-aanpassen-do" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
+      <bpmn:incoming>Flow_Gateway_ConceptDOAkkoord_Task_LatenAanpassenDO</bpmn:incoming>
+      <bpmn:incoming>Flow_Gateway_AanpassingenAkkoord_Task_LatenAanpassenDO</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_LatenAanpassenDO_Task_ToetsenAanpassingen</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_ToetsenAanpassingen" name="Toetsen aanpassingen&#10;door PKT" camunda:formRef="rip-toetsen-aanpassingen" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-team,rip-aandrager,rip-adviseur,rip-vestigingsmanager">
+      <bpmn:incoming>Flow_Task_LatenAanpassenDO_Task_ToetsenAanpassingen</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_ToetsenAanpassingen_Gateway_AanpassingenAkkoord</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_AanpassingenAkkoord" name="Akkoord?">
+      <bpmn:incoming>Flow_Task_ToetsenAanpassingen_Gateway_AanpassingenAkkoord</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_AanpassingenAkkoord_Task_LatenAanpassenDO</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_AanpassingenAkkoord_Gateway_DOAkkoordJoin</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:exclusiveGateway id="Gateway_DOAkkoordJoin">
+      <bpmn:incoming>Flow_Gateway_ConceptDOAkkoord_Gateway_DOAkkoordJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Gateway_AanpassingenAkkoord_Gateway_DOAkkoordJoin</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_DOAkkoordJoin_Gateway_DOSplit</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:parallelGateway id="Gateway_DOSplit">
+      <bpmn:incoming>Flow_Gateway_DOAkkoordJoin_Gateway_DOSplit</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_DOSplit_Task_LatenOpstellenDefinitiefDO</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_DOSplit_Task_LatenOpstellenDefinitieveDORaming</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:userTask id="Task_LatenOpstellenDefinitiefDO" name="Laten opstellen definitief DO&#10;door extern IB" camunda:formRef="rip-definitief-do" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
+      <bpmn:incoming>Flow_Gateway_DOSplit_Task_LatenOpstellenDefinitiefDO</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_LatenOpstellenDefinitiefDO_Gateway_DOJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_LatenOpstellenDefinitieveDORaming" name="Laten opstellen definitieve&#10;DO-raming door extern IB" camunda:formRef="rip-definitieve-do-raming" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-do-raming">
+      <bpmn:incoming>Flow_Gateway_DOSplit_Task_LatenOpstellenDefinitieveDORaming</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_LatenOpstellenDefinitieveDORaming_Gateway_DOJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:parallelGateway id="Gateway_DOJoin">
+      <bpmn:incoming>Flow_Task_LatenOpstellenDefinitiefDO_Gateway_DOJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_LatenOpstellenDefinitieveDORaming_Gateway_DOJoin</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_DOJoin_Task_OpstellenProjectramingDO</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:userTask id="Task_OpstellenProjectramingDO" name="Opstellen&#10;Projectraming DO" camunda:formRef="rip-opstellen-projectraming-do" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-kosten-contractdeskundige" ronl:documentRef="rip-projectraming-do">
+      <bpmn:incoming>Flow_Gateway_DOJoin_Task_OpstellenProjectramingDO</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_OpstellenProjectramingDO_Gateway_RamingBinnenKrediet</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_RamingBinnenKrediet" name="Raming binnen&#10;projectkrediet?">
+      <bpmn:incoming>Flow_Task_OpstellenProjectramingDO_Gateway_RamingBinnenKrediet</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_RamingBinnenKrediet_Task_AccorderenBeschikbaarKrediet</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_RamingBinnenKrediet_Task_OpstellenMemoProjectkredietDO</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_AccorderenBeschikbaarKrediet" name="Accorderen&#10;beschikbaar krediet" camunda:formRef="rip-accorderen-beschikbaar-krediet" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-financien">
+      <bpmn:incoming>Flow_Gateway_RamingBinnenKrediet_Task_AccorderenBeschikbaarKrediet</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_AccorderenBeschikbaarKrediet_Gateway_KredietJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_OpstellenMemoProjectkredietDO" name="Opstellen memo projectkrediet&#10;(zachte claim)" camunda:formRef="rip-memo-projectkrediet-do" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-memo-projectkrediet-do">
+      <bpmn:incoming>Flow_Gateway_RamingBinnenKrediet_Task_OpstellenMemoProjectkredietDO</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_OpstellenMemoProjectkredietDO_Task_BesluitenOverProjectkredietDO</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_BesluitenOverProjectkredietDO" name="Besluiten over&#10;projectkrediet" camunda:formRef="rip-besluiten-projectkrediet-do" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-infra-overleg" ronl:documentRef="rip-besluit-projectkrediet-do">
+      <bpmn:incoming>Flow_Task_OpstellenMemoProjectkredietDO_Task_BesluitenOverProjectkredietDO</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_BesluitenOverProjectkredietDO_Task_VerwerkenProjectramingDO</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_VerwerkenProjectramingDO" name="Verwerken projectraming&#10;en raamkrediet Infra" camunda:formRef="rip-verwerken-projectraming-do" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-financien">
+      <bpmn:incoming>Flow_Task_BesluitenOverProjectkredietDO_Task_VerwerkenProjectramingDO</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_VerwerkenProjectramingDO_Gateway_KredietJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_KredietJoin">
+      <bpmn:incoming>Flow_Task_AccorderenBeschikbaarKrediet_Gateway_KredietJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_VerwerkenProjectramingDO_Gateway_KredietJoin</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_KredietJoin_Task_InvullenILS</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_InvullenILS" name="Invullen ILS" camunda:formRef="rip-invullen-ils" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-ils-flevoland">
+      <bpmn:incoming>Flow_Gateway_KredietJoin_Task_InvullenILS</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_InvullenILS_Task_BeoordelenRetournerenILS</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_BeoordelenRetournerenILS" name="Beoordelen en&#10;retourneren ILS" camunda:formRef="rip-beoordelen-ils" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-adviseur,rip-beheerder-assetmanagement">
+      <bpmn:incoming>Flow_Task_InvullenILS_Task_BeoordelenRetournerenILS</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_BeoordelenRetournerenILS_Task_OntvangenBeoordeeldeILS</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_OntvangenBeoordeeldeILS" name="Ontvangen&#10;beoordeelde ILS" camunda:formRef="rip-ontvangen-beoordeelde-ils" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
+      <bpmn:incoming>Flow_Task_BeoordelenRetournerenILS_Task_OntvangenBeoordeeldeILS</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_OntvangenBeoordeeldeILS_Task_AccorderenProjectplanDO</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_AccorderenProjectplanDO" name="Accorderen Projectplan&#10;6. Afronding DO-fase" camunda:formRef="rip-accorderen-projectplan-do" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-projectplan-do">
+      <bpmn:incoming>Flow_Task_OntvangenBeoordeeldeILS_Task_AccorderenProjectplanDO</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_AccorderenProjectplanDO_EndEvent_R31</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_R31" name="Vastgesteld Projectplan (DO)&#10;→ R3.1 Laten opstellen concept bestektekeningen">
+      <bpmn:incoming>Flow_Task_AccorderenProjectplanDO_EndEvent_R31</bpmn:incoming>
+    </bpmn:endEvent>
+
+    <bpmn:sequenceFlow id="Flow_StartEvent_R24_Task_OpdrachtExternIB" sourceRef="StartEvent_R24" targetRef="Task_OpdrachtExternIB" />
+    <bpmn:sequenceFlow id="Flow_Task_OpdrachtExternIB_Gateway_OnderzoekenSplit" sourceRef="Task_OpdrachtExternIB" targetRef="Gateway_OnderzoekenSplit" />
+    <bpmn:sequenceFlow id="Flow_Gateway_OnderzoekenSplit_Task_LatenUitvoerenAanvullendeOnderzoeken" sourceRef="Gateway_OnderzoekenSplit" targetRef="Task_LatenUitvoerenAanvullendeOnderzoeken" />
+    <bpmn:sequenceFlow id="Flow_Gateway_OnderzoekenSplit_Task_LatenInventariserenVergunningen" sourceRef="Gateway_OnderzoekenSplit" targetRef="Task_LatenInventariserenVergunningen" />
+    <bpmn:sequenceFlow id="Flow_Task_LatenUitvoerenAanvullendeOnderzoeken_Gateway_OnderzoekenJoin" sourceRef="Task_LatenUitvoerenAanvullendeOnderzoeken" targetRef="Gateway_OnderzoekenJoin" />
+    <bpmn:sequenceFlow id="Flow_Task_LatenInventariserenVergunningen_Gateway_OnderzoekenJoin" sourceRef="Task_LatenInventariserenVergunningen" targetRef="Gateway_OnderzoekenJoin" />
+    <bpmn:sequenceFlow id="Flow_Gateway_OnderzoekenJoin_Task_LatenOpstellenConceptDO" sourceRef="Gateway_OnderzoekenJoin" targetRef="Task_LatenOpstellenConceptDO" />
+    <bpmn:sequenceFlow id="Flow_Task_LatenOpstellenConceptDO_Task_BesprekenConceptDO" sourceRef="Task_LatenOpstellenConceptDO" targetRef="Task_BesprekenConceptDO" />
+    <bpmn:sequenceFlow id="Flow_Task_BesprekenConceptDO_Gateway_ConceptDOAkkoord" sourceRef="Task_BesprekenConceptDO" targetRef="Gateway_ConceptDOAkkoord" />
+    <bpmn:sequenceFlow id="Flow_Gateway_ConceptDOAkkoord_Task_LatenAanpassenDO" name="nee" sourceRef="Gateway_ConceptDOAkkoord" targetRef="Task_LatenAanpassenDO">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${conceptDoAkkoord == "nee"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_ConceptDOAkkoord_Gateway_DOAkkoordJoin" name="ja" sourceRef="Gateway_ConceptDOAkkoord" targetRef="Gateway_DOAkkoordJoin">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${conceptDoAkkoord == "ja"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Task_LatenAanpassenDO_Task_ToetsenAanpassingen" sourceRef="Task_LatenAanpassenDO" targetRef="Task_ToetsenAanpassingen" />
+    <bpmn:sequenceFlow id="Flow_Task_ToetsenAanpassingen_Gateway_AanpassingenAkkoord" sourceRef="Task_ToetsenAanpassingen" targetRef="Gateway_AanpassingenAkkoord" />
+    <bpmn:sequenceFlow id="Flow_Gateway_AanpassingenAkkoord_Task_LatenAanpassenDO" name="nee" sourceRef="Gateway_AanpassingenAkkoord" targetRef="Task_LatenAanpassenDO">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${aanpassingenAkkoord == "nee"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_AanpassingenAkkoord_Gateway_DOAkkoordJoin" name="ja" sourceRef="Gateway_AanpassingenAkkoord" targetRef="Gateway_DOAkkoordJoin">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${aanpassingenAkkoord == "ja"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_DOAkkoordJoin_Gateway_DOSplit" sourceRef="Gateway_DOAkkoordJoin" targetRef="Gateway_DOSplit" />
+    <bpmn:sequenceFlow id="Flow_Gateway_DOSplit_Task_LatenOpstellenDefinitiefDO" sourceRef="Gateway_DOSplit" targetRef="Task_LatenOpstellenDefinitiefDO" />
+    <bpmn:sequenceFlow id="Flow_Gateway_DOSplit_Task_LatenOpstellenDefinitieveDORaming" sourceRef="Gateway_DOSplit" targetRef="Task_LatenOpstellenDefinitieveDORaming" />
+    <bpmn:sequenceFlow id="Flow_Task_LatenOpstellenDefinitiefDO_Gateway_DOJoin" sourceRef="Task_LatenOpstellenDefinitiefDO" targetRef="Gateway_DOJoin" />
+    <bpmn:sequenceFlow id="Flow_Task_LatenOpstellenDefinitieveDORaming_Gateway_DOJoin" sourceRef="Task_LatenOpstellenDefinitieveDORaming" targetRef="Gateway_DOJoin" />
+    <bpmn:sequenceFlow id="Flow_Gateway_DOJoin_Task_OpstellenProjectramingDO" sourceRef="Gateway_DOJoin" targetRef="Task_OpstellenProjectramingDO" />
+    <bpmn:sequenceFlow id="Flow_Task_OpstellenProjectramingDO_Gateway_RamingBinnenKrediet" sourceRef="Task_OpstellenProjectramingDO" targetRef="Gateway_RamingBinnenKrediet" />
+    <bpmn:sequenceFlow id="Flow_Gateway_RamingBinnenKrediet_Task_AccorderenBeschikbaarKrediet" name="ja" sourceRef="Gateway_RamingBinnenKrediet" targetRef="Task_AccorderenBeschikbaarKrediet">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ramingBinnenKrediet == "ja"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_RamingBinnenKrediet_Task_OpstellenMemoProjectkredietDO" name="nee" sourceRef="Gateway_RamingBinnenKrediet" targetRef="Task_OpstellenMemoProjectkredietDO">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ramingBinnenKrediet == "nee"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Task_AccorderenBeschikbaarKrediet_Gateway_KredietJoin" sourceRef="Task_AccorderenBeschikbaarKrediet" targetRef="Gateway_KredietJoin" />
+    <bpmn:sequenceFlow id="Flow_Task_OpstellenMemoProjectkredietDO_Task_BesluitenOverProjectkredietDO" sourceRef="Task_OpstellenMemoProjectkredietDO" targetRef="Task_BesluitenOverProjectkredietDO" />
+    <bpmn:sequenceFlow id="Flow_Task_BesluitenOverProjectkredietDO_Task_VerwerkenProjectramingDO" sourceRef="Task_BesluitenOverProjectkredietDO" targetRef="Task_VerwerkenProjectramingDO" />
+    <bpmn:sequenceFlow id="Flow_Task_VerwerkenProjectramingDO_Gateway_KredietJoin" sourceRef="Task_VerwerkenProjectramingDO" targetRef="Gateway_KredietJoin" />
+    <bpmn:sequenceFlow id="Flow_Gateway_KredietJoin_Task_InvullenILS" sourceRef="Gateway_KredietJoin" targetRef="Task_InvullenILS" />
+    <bpmn:sequenceFlow id="Flow_Task_InvullenILS_Task_BeoordelenRetournerenILS" sourceRef="Task_InvullenILS" targetRef="Task_BeoordelenRetournerenILS" />
+    <bpmn:sequenceFlow id="Flow_Task_BeoordelenRetournerenILS_Task_OntvangenBeoordeeldeILS" sourceRef="Task_BeoordelenRetournerenILS" targetRef="Task_OntvangenBeoordeeldeILS" />
+    <bpmn:sequenceFlow id="Flow_Task_OntvangenBeoordeeldeILS_Task_AccorderenProjectplanDO" sourceRef="Task_OntvangenBeoordeeldeILS" targetRef="Task_AccorderenProjectplanDO" />
+    <bpmn:sequenceFlow id="Flow_Task_AccorderenProjectplanDO_EndEvent_R31" sourceRef="Task_AccorderenProjectplanDO" targetRef="EndEvent_R31" />
+
+    <bpmn:textAnnotation id="Annotation_IN11">
+      <bpmn:text>IN1.1 Behoefte tot inkoop</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Assoc_Annotation_IN11" sourceRef="Task_OpdrachtExternIB" targetRef="Annotation_IN11" />
+    <bpmn:textAnnotation id="Annotation_KV4">
+      <bpmn:text>KV4. Versturen documenten</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Assoc_Annotation_KV4" sourceRef="Task_OpdrachtExternIB" targetRef="Annotation_KV4" />
+  </bpmn:process>
+
+  <bpmndi:BPMNDiagram id="BPMNDiagram_RipR24Process">
+    <bpmndi:BPMNPlane id="BPMNPlane_RipR24Process" bpmnElement="Collaboration_RipR24Process">
+      <bpmndi:BPMNShape id="Participant_RipR24Process_di" bpmnElement="Participant_RipR24Process" isHorizontal="true">
+        <dc:Bounds x="160" y="80" width="3366" height="880" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Adviseurs_di" bpmnElement="Lane_Adviseurs" isHorizontal="true">
+        <dc:Bounds x="190" y="80" width="3336" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_RIPteam_di" bpmnElement="Lane_RIPteam" isHorizontal="true">
+        <dc:Bounds x="190" y="200" width="3336" height="160" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Projectleider_di" bpmnElement="Lane_Projectleider" isHorizontal="true">
+        <dc:Bounds x="190" y="360" width="3336" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_KostenContractdeskundige_di" bpmnElement="Lane_KostenContractdeskundige" isHorizontal="true">
+        <dc:Bounds x="190" y="560" width="3336" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_InfraOverleg_di" bpmnElement="Lane_InfraOverleg" isHorizontal="true">
+        <dc:Bounds x="190" y="680" width="3336" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Financien_di" bpmnElement="Lane_Financien" isHorizontal="true">
+        <dc:Bounds x="190" y="800" width="3336" height="160" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_R24_di" bpmnElement="StartEvent_R24">
+        <dc:Bounds x="232" y="442" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="146" y="483" width="208" height="28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_OpdrachtExternIB_di" bpmnElement="Task_OpdrachtExternIB">
+        <dc:Bounds x="300" y="420" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_OnderzoekenSplit_di" bpmnElement="Gateway_OnderzoekenSplit">
+        <dc:Bounds x="450" y="435" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_LatenUitvoerenAanvullendeOnderzoeken_di" bpmnElement="Task_LatenUitvoerenAanvullendeOnderzoeken">
+        <dc:Bounds x="530" y="375" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_LatenInventariserenVergunningen_di" bpmnElement="Task_LatenInventariserenVergunningen">
+        <dc:Bounds x="530" y="465" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_OnderzoekenJoin_di" bpmnElement="Gateway_OnderzoekenJoin">
+        <dc:Bounds x="690" y="435" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_LatenOpstellenConceptDO_di" bpmnElement="Task_LatenOpstellenConceptDO">
+        <dc:Bounds x="770" y="420" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_BesprekenConceptDO_di" bpmnElement="Task_BesprekenConceptDO">
+        <dc:Bounds x="930" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_ConceptDOAkkoord_di" bpmnElement="Gateway_ConceptDOAkkoord" isMarkerVisible="true">
+        <dc:Bounds x="1090" y="255" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1070" y="310" width="90" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_LatenAanpassenDO_di" bpmnElement="Task_LatenAanpassenDO">
+        <dc:Bounds x="1170" y="420" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_ToetsenAanpassingen_di" bpmnElement="Task_ToetsenAanpassingen">
+        <dc:Bounds x="1330" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_AanpassingenAkkoord_di" bpmnElement="Gateway_AanpassingenAkkoord" isMarkerVisible="true">
+        <dc:Bounds x="1490" y="255" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1470" y="310" width="90" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_DOAkkoordJoin_di" bpmnElement="Gateway_DOAkkoordJoin" isMarkerVisible="true">
+        <dc:Bounds x="1580" y="435" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_DOSplit_di" bpmnElement="Gateway_DOSplit">
+        <dc:Bounds x="1660" y="435" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_LatenOpstellenDefinitiefDO_di" bpmnElement="Task_LatenOpstellenDefinitiefDO">
+        <dc:Bounds x="1740" y="375" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_LatenOpstellenDefinitieveDORaming_di" bpmnElement="Task_LatenOpstellenDefinitieveDORaming">
+        <dc:Bounds x="1740" y="465" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_DOJoin_di" bpmnElement="Gateway_DOJoin">
+        <dc:Bounds x="1900" y="435" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_OpstellenProjectramingDO_di" bpmnElement="Task_OpstellenProjectramingDO">
+        <dc:Bounds x="1980" y="580" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_RamingBinnenKrediet_di" bpmnElement="Gateway_RamingBinnenKrediet" isMarkerVisible="true">
+        <dc:Bounds x="2140" y="595" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2105" y="650" width="120" height="28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_AccorderenBeschikbaarKrediet_di" bpmnElement="Task_AccorderenBeschikbaarKrediet">
+        <dc:Bounds x="2220" y="840" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_OpstellenMemoProjectkredietDO_di" bpmnElement="Task_OpstellenMemoProjectkredietDO">
+        <dc:Bounds x="2220" y="420" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_BesluitenOverProjectkredietDO_di" bpmnElement="Task_BesluitenOverProjectkredietDO">
+        <dc:Bounds x="2380" y="700" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_VerwerkenProjectramingDO_di" bpmnElement="Task_VerwerkenProjectramingDO">
+        <dc:Bounds x="2540" y="840" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_KredietJoin_di" bpmnElement="Gateway_KredietJoin" isMarkerVisible="true">
+        <dc:Bounds x="2700" y="435" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_InvullenILS_di" bpmnElement="Task_InvullenILS">
+        <dc:Bounds x="2780" y="420" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_BeoordelenRetournerenILS_di" bpmnElement="Task_BeoordelenRetournerenILS">
+        <dc:Bounds x="2940" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_OntvangenBeoordeeldeILS_di" bpmnElement="Task_OntvangenBeoordeeldeILS">
+        <dc:Bounds x="3100" y="420" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_AccorderenProjectplanDO_di" bpmnElement="Task_AccorderenProjectplanDO">
+        <dc:Bounds x="3260" y="420" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_R31_di" bpmnElement="EndEvent_R31">
+        <dc:Bounds x="3420" y="442" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3250" y="483" width="376" height="28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Annotation_IN11_di" bpmnElement="Annotation_IN11">
+        <dc:Bounds x="250" y="150" width="200" height="45" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Annotation_KV4_di" bpmnElement="Annotation_KV4">
+        <dc:Bounds x="250" y="95" width="200" height="45" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_StartEvent_R24_Task_OpdrachtExternIB_di" bpmnElement="Flow_StartEvent_R24_Task_OpdrachtExternIB">
+        <di:waypoint x="268" y="460" />
+        <di:waypoint x="300" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_OpdrachtExternIB_Gateway_OnderzoekenSplit_di" bpmnElement="Flow_Task_OpdrachtExternIB_Gateway_OnderzoekenSplit">
+        <di:waypoint x="400" y="460" />
+        <di:waypoint x="450" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_OnderzoekenSplit_Task_LatenUitvoerenAanvullendeOnderzoeken_di" bpmnElement="Flow_Gateway_OnderzoekenSplit_Task_LatenUitvoerenAanvullendeOnderzoeken">
+        <di:waypoint x="500" y="460" />
+        <di:waypoint x="515" y="460" />
+        <di:waypoint x="515" y="415" />
+        <di:waypoint x="530" y="415" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_OnderzoekenSplit_Task_LatenInventariserenVergunningen_di" bpmnElement="Flow_Gateway_OnderzoekenSplit_Task_LatenInventariserenVergunningen">
+        <di:waypoint x="500" y="460" />
+        <di:waypoint x="515" y="460" />
+        <di:waypoint x="515" y="505" />
+        <di:waypoint x="530" y="505" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_LatenUitvoerenAanvullendeOnderzoeken_Gateway_OnderzoekenJoin_di" bpmnElement="Flow_Task_LatenUitvoerenAanvullendeOnderzoeken_Gateway_OnderzoekenJoin">
+        <di:waypoint x="630" y="415" />
+        <di:waypoint x="660" y="415" />
+        <di:waypoint x="660" y="460" />
+        <di:waypoint x="690" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_LatenInventariserenVergunningen_Gateway_OnderzoekenJoin_di" bpmnElement="Flow_Task_LatenInventariserenVergunningen_Gateway_OnderzoekenJoin">
+        <di:waypoint x="630" y="505" />
+        <di:waypoint x="660" y="505" />
+        <di:waypoint x="660" y="460" />
+        <di:waypoint x="690" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_OnderzoekenJoin_Task_LatenOpstellenConceptDO_di" bpmnElement="Flow_Gateway_OnderzoekenJoin_Task_LatenOpstellenConceptDO">
+        <di:waypoint x="740" y="460" />
+        <di:waypoint x="770" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_LatenOpstellenConceptDO_Task_BesprekenConceptDO_di" bpmnElement="Flow_Task_LatenOpstellenConceptDO_Task_BesprekenConceptDO">
+        <di:waypoint x="870" y="460" />
+        <di:waypoint x="900" y="460" />
+        <di:waypoint x="900" y="280" />
+        <di:waypoint x="930" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_BesprekenConceptDO_Gateway_ConceptDOAkkoord_di" bpmnElement="Flow_Task_BesprekenConceptDO_Gateway_ConceptDOAkkoord">
+        <di:waypoint x="1030" y="280" />
+        <di:waypoint x="1090" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_ConceptDOAkkoord_Task_LatenAanpassenDO_di" bpmnElement="Flow_Gateway_ConceptDOAkkoord_Task_LatenAanpassenDO">
+        <di:waypoint x="1140" y="280" />
+        <di:waypoint x="1155" y="280" />
+        <di:waypoint x="1155" y="460" />
+        <di:waypoint x="1170" y="460" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1146" y="260" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_ConceptDOAkkoord_Gateway_DOAkkoordJoin_di" bpmnElement="Flow_Gateway_ConceptDOAkkoord_Gateway_DOAkkoordJoin">
+        <di:waypoint x="1140" y="280" />
+        <di:waypoint x="1360" y="280" />
+        <di:waypoint x="1360" y="460" />
+        <di:waypoint x="1580" y="460" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1146" y="260" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_LatenAanpassenDO_Task_ToetsenAanpassingen_di" bpmnElement="Flow_Task_LatenAanpassenDO_Task_ToetsenAanpassingen">
+        <di:waypoint x="1270" y="460" />
+        <di:waypoint x="1300" y="460" />
+        <di:waypoint x="1300" y="280" />
+        <di:waypoint x="1330" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_ToetsenAanpassingen_Gateway_AanpassingenAkkoord_di" bpmnElement="Flow_Task_ToetsenAanpassingen_Gateway_AanpassingenAkkoord">
+        <di:waypoint x="1430" y="280" />
+        <di:waypoint x="1490" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_AanpassingenAkkoord_Task_LatenAanpassenDO_di" bpmnElement="Flow_Gateway_AanpassingenAkkoord_Task_LatenAanpassenDO">
+        <di:waypoint x="1515" y="305" />
+        <di:waypoint x="1515" y="340" />
+        <di:waypoint x="1220" y="340" />
+        <di:waypoint x="1220" y="500" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1521" y="285" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_AanpassingenAkkoord_Gateway_DOAkkoordJoin_di" bpmnElement="Flow_Gateway_AanpassingenAkkoord_Gateway_DOAkkoordJoin">
+        <di:waypoint x="1540" y="280" />
+        <di:waypoint x="1560" y="280" />
+        <di:waypoint x="1560" y="460" />
+        <di:waypoint x="1580" y="460" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1546" y="260" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_DOAkkoordJoin_Gateway_DOSplit_di" bpmnElement="Flow_Gateway_DOAkkoordJoin_Gateway_DOSplit">
+        <di:waypoint x="1630" y="460" />
+        <di:waypoint x="1660" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_DOSplit_Task_LatenOpstellenDefinitiefDO_di" bpmnElement="Flow_Gateway_DOSplit_Task_LatenOpstellenDefinitiefDO">
+        <di:waypoint x="1710" y="460" />
+        <di:waypoint x="1725" y="460" />
+        <di:waypoint x="1725" y="415" />
+        <di:waypoint x="1740" y="415" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_DOSplit_Task_LatenOpstellenDefinitieveDORaming_di" bpmnElement="Flow_Gateway_DOSplit_Task_LatenOpstellenDefinitieveDORaming">
+        <di:waypoint x="1710" y="460" />
+        <di:waypoint x="1725" y="460" />
+        <di:waypoint x="1725" y="505" />
+        <di:waypoint x="1740" y="505" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_LatenOpstellenDefinitiefDO_Gateway_DOJoin_di" bpmnElement="Flow_Task_LatenOpstellenDefinitiefDO_Gateway_DOJoin">
+        <di:waypoint x="1840" y="415" />
+        <di:waypoint x="1870" y="415" />
+        <di:waypoint x="1870" y="460" />
+        <di:waypoint x="1900" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_LatenOpstellenDefinitieveDORaming_Gateway_DOJoin_di" bpmnElement="Flow_Task_LatenOpstellenDefinitieveDORaming_Gateway_DOJoin">
+        <di:waypoint x="1840" y="505" />
+        <di:waypoint x="1870" y="505" />
+        <di:waypoint x="1870" y="460" />
+        <di:waypoint x="1900" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_DOJoin_Task_OpstellenProjectramingDO_di" bpmnElement="Flow_Gateway_DOJoin_Task_OpstellenProjectramingDO">
+        <di:waypoint x="1950" y="460" />
+        <di:waypoint x="1965" y="460" />
+        <di:waypoint x="1965" y="620" />
+        <di:waypoint x="1980" y="620" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_OpstellenProjectramingDO_Gateway_RamingBinnenKrediet_di" bpmnElement="Flow_Task_OpstellenProjectramingDO_Gateway_RamingBinnenKrediet">
+        <di:waypoint x="2080" y="620" />
+        <di:waypoint x="2140" y="620" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_RamingBinnenKrediet_Task_AccorderenBeschikbaarKrediet_di" bpmnElement="Flow_Gateway_RamingBinnenKrediet_Task_AccorderenBeschikbaarKrediet">
+        <di:waypoint x="2190" y="620" />
+        <di:waypoint x="2205" y="620" />
+        <di:waypoint x="2205" y="880" />
+        <di:waypoint x="2220" y="880" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2196" y="600" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_RamingBinnenKrediet_Task_OpstellenMemoProjectkredietDO_di" bpmnElement="Flow_Gateway_RamingBinnenKrediet_Task_OpstellenMemoProjectkredietDO">
+        <di:waypoint x="2190" y="620" />
+        <di:waypoint x="2205" y="620" />
+        <di:waypoint x="2205" y="460" />
+        <di:waypoint x="2220" y="460" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2196" y="600" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_AccorderenBeschikbaarKrediet_Gateway_KredietJoin_di" bpmnElement="Flow_Task_AccorderenBeschikbaarKrediet_Gateway_KredietJoin">
+        <di:waypoint x="2320" y="880" />
+        <di:waypoint x="2510" y="880" />
+        <di:waypoint x="2510" y="460" />
+        <di:waypoint x="2700" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_OpstellenMemoProjectkredietDO_Task_BesluitenOverProjectkredietDO_di" bpmnElement="Flow_Task_OpstellenMemoProjectkredietDO_Task_BesluitenOverProjectkredietDO">
+        <di:waypoint x="2320" y="460" />
+        <di:waypoint x="2350" y="460" />
+        <di:waypoint x="2350" y="740" />
+        <di:waypoint x="2380" y="740" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_BesluitenOverProjectkredietDO_Task_VerwerkenProjectramingDO_di" bpmnElement="Flow_Task_BesluitenOverProjectkredietDO_Task_VerwerkenProjectramingDO">
+        <di:waypoint x="2480" y="740" />
+        <di:waypoint x="2510" y="740" />
+        <di:waypoint x="2510" y="880" />
+        <di:waypoint x="2540" y="880" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_VerwerkenProjectramingDO_Gateway_KredietJoin_di" bpmnElement="Flow_Task_VerwerkenProjectramingDO_Gateway_KredietJoin">
+        <di:waypoint x="2640" y="880" />
+        <di:waypoint x="2670" y="880" />
+        <di:waypoint x="2670" y="460" />
+        <di:waypoint x="2700" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_KredietJoin_Task_InvullenILS_di" bpmnElement="Flow_Gateway_KredietJoin_Task_InvullenILS">
+        <di:waypoint x="2750" y="460" />
+        <di:waypoint x="2780" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_InvullenILS_Task_BeoordelenRetournerenILS_di" bpmnElement="Flow_Task_InvullenILS_Task_BeoordelenRetournerenILS">
+        <di:waypoint x="2880" y="460" />
+        <di:waypoint x="2910" y="460" />
+        <di:waypoint x="2910" y="140" />
+        <di:waypoint x="2940" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_BeoordelenRetournerenILS_Task_OntvangenBeoordeeldeILS_di" bpmnElement="Flow_Task_BeoordelenRetournerenILS_Task_OntvangenBeoordeeldeILS">
+        <di:waypoint x="3040" y="140" />
+        <di:waypoint x="3070" y="140" />
+        <di:waypoint x="3070" y="460" />
+        <di:waypoint x="3100" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_OntvangenBeoordeeldeILS_Task_AccorderenProjectplanDO_di" bpmnElement="Flow_Task_OntvangenBeoordeeldeILS_Task_AccorderenProjectplanDO">
+        <di:waypoint x="3200" y="460" />
+        <di:waypoint x="3260" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_AccorderenProjectplanDO_EndEvent_R31_di" bpmnElement="Flow_Task_AccorderenProjectplanDO_EndEvent_R31">
+        <di:waypoint x="3360" y="460" />
+        <di:waypoint x="3420" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Assoc_Annotation_IN11_di" bpmnElement="Assoc_Annotation_IN11">
+        <di:waypoint x="350" y="420" />
+        <di:waypoint x="350" y="195" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Assoc_Annotation_KV4_di" bpmnElement="Assoc_Annotation_KV4">
+        <di:waypoint x="350" y="420" />
+        <di:waypoint x="350" y="140" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/examples/organizations/flevoland/rip-phase-24/rip-aanpassen-do.form
+++ b/examples/organizations/flevoland/rip-phase-24/rip-aanpassen-do.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-aanpassen-do",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Have the DO amended by the external firm"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Have the external engineering firm amend the detailed design in line with the findings."
+    },
+    {
+      "id": "F_Versie",
+      "type": "textfield",
+      "label": "Amended DO version",
+      "key": "aangepastDoVersie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Verwerkt",
+      "type": "textarea",
+      "label": "How the findings were incorporated",
+      "key": "verwerkteBevindingen",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Aangepast",
+      "type": "datetime",
+      "label": "Amended on",
+      "key": "doAangepastOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-aanvullende-conditionerende-onderzoeken.form
+++ b/examples/organizations/flevoland/rip-phase-24/rip-aanvullende-conditionerende-onderzoeken.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-aanvullende-conditionerende-onderzoeken",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Have supplementary conditioning surveys carried out"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Have the external engineering firm carry out the supplementary conditioning surveys needed for the detailed design."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Survey dossier reference",
+      "key": "onderzoekenReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Uitgevoerd",
+      "type": "textarea",
+      "label": "Surveys carried out",
+      "key": "uitgevoerdeOnderzoeken",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Gereed",
+      "type": "datetime",
+      "label": "Completed on",
+      "key": "onderzoekenGereedOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-accorderen-beschikbaar-krediet.form
+++ b/examples/organizations/flevoland/rip-phase-24/rip-accorderen-beschikbaar-krediet.form
@@ -1,0 +1,52 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-accorderen-beschikbaar-krediet",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Approve the available credit"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Finance approves the DO project estimate against the credit already available."
+    },
+    {
+      "id": "F_Door",
+      "type": "textfield",
+      "label": "Approved by",
+      "key": "kredietGeaccordeerdDoor",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Approved on",
+      "key": "kredietGeaccordeerdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Comments",
+      "key": "kredietOpmerkingen"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-accorderen-projectplan-do.form
+++ b/examples/organizations/flevoland/rip-phase-24/rip-accorderen-projectplan-do.form
@@ -1,0 +1,71 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-accorderen-projectplan-do",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Approve the project plan — 6. Closing the DO phase"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Approve the project plan so the DO phase can be closed and R3.1 (drawing up the draft specification and drawings) can start."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Project plan reference",
+      "key": "projectplanDoReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Akkoord",
+      "type": "select",
+      "label": "Project plan approved",
+      "key": "akkoordProjectplanDo",
+      "values": [
+        {
+          "label": "Yes",
+          "value": "ja"
+        },
+        {
+          "label": "No",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Adopted on",
+      "key": "projectplanDoVastgesteldOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Comments",
+      "key": "accordeerOpmerkingenDo"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-beoordelen-ils.form
+++ b/examples/organizations/flevoland/rip-phase-24/rip-beoordelen-ils.form
@@ -1,0 +1,78 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-beoordelen-ils",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Assess and return the ILS"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Advisers and asset management assess the completed ILS and return it to the project leader."
+    },
+    {
+      "id": "F_Oordeel",
+      "type": "select",
+      "label": "Assessment",
+      "key": "ilsOordeel",
+      "values": [
+        {
+          "label": "Approved",
+          "value": "akkoord"
+        },
+        {
+          "label": "Approved with comments",
+          "value": "akkoordMetOpmerkingen"
+        },
+        {
+          "label": "Not approved",
+          "value": "nietAkkoord"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Assessment comments",
+      "key": "ilsBeoordelingOpmerkingen",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Door",
+      "type": "textfield",
+      "label": "Assessed by",
+      "key": "ilsBeoordeeldDoor",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Assessed on",
+      "key": "ilsBeoordeeldOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-besluit-projectkrediet-do.document
+++ b/examples/organizations/flevoland/rip-phase-24/rip-besluit-projectkrediet-do.document
@@ -1,0 +1,218 @@
+{
+  "id": "rip-besluit-projectkrediet-do",
+  "name": "RIP — Project Credit Decision, DO phase (Besluit projectkrediet)",
+  "description": "Records the Infra consultation decision on the project credit requested in the DO memo.",
+  "processKey": "RipR24Process",
+  "serviceId": "RipR24",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{memoDoReferentie}}",
+      "variableKey": "memoDoReferentie",
+      "source": "process",
+      "label": "Memo reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{besluitProjectkredietDo}}",
+      "variableKey": "besluitProjectkredietDo",
+      "source": "process",
+      "label": "Decision"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{toegekendBedragDo}}",
+      "variableKey": "toegekendBedragDo",
+      "source": "process",
+      "label": "Granted amount"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{besluitDatumDo}}",
+      "variableKey": "besluitDatumDo",
+      "source": "process",
+      "label": "Decision date"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{besluitToelichtingDo}}",
+      "variableKey": "besluitToelichtingDo",
+      "source": "process",
+      "label": "Explanation"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Decision on memo {{memoDoReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Decision on the project credit",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Decision on the project credit"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "On {{besluitDatumDo}} the Infra consultation decided on the project credit requested in memo {{memoDoReferentie}} for project {{projectNumber}} — {{projectName}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Decision: {{besluitProjectkredietDo}}. Granted amount: EUR {{toegekendBedragDo}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Explanation: {{besluitToelichtingDo}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Decided by the Infra consultation"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-besluiten-projectkrediet-do.form
+++ b/examples/organizations/flevoland/rip-phase-24/rip-besluiten-projectkrediet-do.form
@@ -1,0 +1,72 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-besluiten-projectkrediet-do",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Decide on the project credit"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Record the Infra consultation decision on the requested project credit."
+    },
+    {
+      "id": "F_Besluit",
+      "type": "select",
+      "label": "Decision",
+      "key": "besluitProjectkredietDo",
+      "values": [
+        {
+          "label": "Granted",
+          "value": "toegekend"
+        },
+        {
+          "label": "Refused",
+          "value": "afgewezen"
+        },
+        {
+          "label": "Deferred",
+          "value": "aangehouden"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bedrag",
+      "type": "number",
+      "label": "Granted amount (EUR)",
+      "key": "toegekendBedragDo"
+    },
+    {
+      "id": "F_Datum",
+      "type": "datetime",
+      "label": "Decision date",
+      "key": "besluitDatumDo",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Toel",
+      "type": "textarea",
+      "label": "Explanation",
+      "key": "besluitToelichtingDo"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-bespreken-concept-do.form
+++ b/examples/organizations/flevoland/rip-phase-24/rip-bespreken-concept-do.form
@@ -1,0 +1,74 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-bespreken-concept-do",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Discuss the draft DO and draft DO estimate"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Review the draft detailed design and its estimate, record the findings, and decide whether the design can go to final."
+    },
+    {
+      "id": "F_Bev",
+      "type": "textfield",
+      "label": "Findings form reference",
+      "key": "bevindingenformulierReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bevindingen",
+      "type": "textarea",
+      "label": "Findings",
+      "key": "bevindingen",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Akkoord",
+      "type": "select",
+      "label": "Draft DO approved",
+      "key": "conceptDoAkkoord",
+      "values": [
+        {
+          "label": "Yes — proceed to the final DO",
+          "value": "ja"
+        },
+        {
+          "label": "No — the external firm must amend the DO",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Besproken",
+      "type": "datetime",
+      "label": "Discussed on",
+      "key": "conceptDoBesprokenOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-bevindingenformulier-do.document
+++ b/examples/organizations/flevoland/rip-phase-24/rip-bevindingenformulier-do.document
@@ -1,0 +1,218 @@
+{
+  "id": "rip-bevindingenformulier-do",
+  "name": "RIP — Findings Form, DO phase (Bevindingenformulier)",
+  "description": "Format Bevindingenformulier. Records the review findings on the draft DO and the draft DO estimate.",
+  "processKey": "RipR24Process",
+  "serviceId": "RipR24",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{bevindingenformulierReferentie}}",
+      "variableKey": "bevindingenformulierReferentie",
+      "source": "process",
+      "label": "Findings form reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{conceptDoReferentie}}",
+      "variableKey": "conceptDoReferentie",
+      "source": "process",
+      "label": "Draft DO reference"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{bevindingen}}",
+      "variableKey": "bevindingen",
+      "source": "process",
+      "label": "Findings"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{conceptDoAkkoord}}",
+      "variableKey": "conceptDoAkkoord",
+      "source": "process",
+      "label": "Outcome"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{conceptDoBesprokenOp}}",
+      "variableKey": "conceptDoBesprokenOp",
+      "source": "process",
+      "label": "Discussed on"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Findings {{bevindingenformulierReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Findings on the draft DO",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Findings on the draft DO"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The draft detailed design {{conceptDoReferentie}} and its estimate were discussed on {{conceptDoBesprokenOp}} for project {{projectNumber}} — {{projectName}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Findings: {{bevindingen}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Outcome: {{conceptDoAkkoord}}. Where not approved, the external engineering firm amends the design and PKT reviews the amendments before the final DO is drawn up."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Recorded by the RIP team"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-concept-do-dossier.document
+++ b/examples/organizations/flevoland/rip-phase-24/rip-concept-do-dossier.document
@@ -1,0 +1,218 @@
+{
+  "id": "rip-concept-do-dossier",
+  "name": "RIP — Draft Detailed Design (Concept DO)",
+  "description": "The draft detailed design dossier: draft DO, draft DO estimate, V&G plan and design rationale, produced by the external engineering firm.",
+  "processKey": "RipR24Process",
+  "serviceId": "RipR24",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{conceptDoReferentie}}",
+      "variableKey": "conceptDoReferentie",
+      "source": "process",
+      "label": "Draft DO reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{conceptDoRamingReferentie}}",
+      "variableKey": "conceptDoRamingReferentie",
+      "source": "process",
+      "label": "Draft DO estimate reference"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{conceptDoRamingBedrag}}",
+      "variableKey": "conceptDoRamingBedrag",
+      "source": "process",
+      "label": "Draft DO estimate"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{vgPlanReferentie}}",
+      "variableKey": "vgPlanReferentie",
+      "source": "process",
+      "label": "V&G plan reference"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{ontwerptoelichtingReferentie}}",
+      "variableKey": "ontwerptoelichtingReferentie",
+      "source": "process",
+      "label": "Design rationale reference"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Draft DO {{conceptDoReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Draft detailed design",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Draft detailed design"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Draft detailed design {{conceptDoReferentie}} for project {{projectNumber}} — {{projectName}}, with draft estimate {{conceptDoRamingReferentie}} at EUR {{conceptDoRamingBedrag}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Accompanied by V&G plan {{vgPlanReferentie}} and design rationale {{ontwerptoelichtingReferentie}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The dossier is put to the RIP team, the applicant, the advisers and the site manager for review before the final DO is drawn up."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up by the external engineering firm"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-concept-do.form
+++ b/examples/organizations/flevoland/rip-phase-24/rip-concept-do.form
@@ -1,0 +1,71 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-concept-do",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Have the draft DO and draft DO estimate drawn up"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Have the external engineering firm produce the draft detailed design and its estimate, working from the VO, the project estimate, the conditioning surveys and the risk file."
+    },
+    {
+      "id": "F_DO",
+      "type": "textfield",
+      "label": "Draft DO reference",
+      "key": "conceptDoReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Raming",
+      "type": "textfield",
+      "label": "Draft DO estimate reference",
+      "key": "conceptDoRamingReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_VG",
+      "type": "textfield",
+      "label": "V&G plan reference",
+      "key": "vgPlanReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Ontwerp",
+      "type": "textfield",
+      "label": "Design rationale reference",
+      "key": "ontwerptoelichtingReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bedrag",
+      "type": "number",
+      "label": "Draft DO estimate (EUR)",
+      "key": "conceptDoRamingBedrag",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-definitief-do.form
+++ b/examples/organizations/flevoland/rip-phase-24/rip-definitief-do.form
@@ -1,0 +1,52 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-definitief-do",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Have the final DO drawn up"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Have the external engineering firm produce the final detailed design."
+    },
+    {
+      "id": "F_DO",
+      "type": "textfield",
+      "label": "Final DO reference",
+      "key": "doReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Gereed",
+      "type": "datetime",
+      "label": "Final DO delivered on",
+      "key": "doGereedOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Notes",
+      "key": "doOpmerkingen"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-definitieve-do-raming.form
+++ b/examples/organizations/flevoland/rip-phase-24/rip-definitieve-do-raming.form
@@ -1,0 +1,70 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-definitieve-do-raming",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Have the final DO estimate drawn up"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Have the external engineering firm produce the final DO estimate and the matching SSK estimate, from the risk file, the project estimate and the final DO."
+    },
+    {
+      "id": "F_Raming",
+      "type": "textfield",
+      "label": "DO estimate reference",
+      "key": "doRamingReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_SSK",
+      "type": "textfield",
+      "label": "SSK estimate reference",
+      "key": "sskRamingDoReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bedrag",
+      "type": "number",
+      "label": "DO estimate (EUR)",
+      "key": "doRamingBedrag",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Risico",
+      "type": "textfield",
+      "label": "Risk file reference",
+      "key": "risicodossierReferentie"
+    },
+    {
+      "id": "F_Gereed",
+      "type": "datetime",
+      "label": "Estimate delivered on",
+      "key": "doRamingGereedOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-do-raming.document
+++ b/examples/organizations/flevoland/rip-phase-24/rip-do-raming.document
@@ -1,0 +1,216 @@
+{
+  "id": "rip-do-raming",
+  "name": "RIP — DO Estimate (DO-raming / SSK-raming)",
+  "description": "The final DO estimate and matching SSK estimate for the detailed design.",
+  "processKey": "RipR24Process",
+  "serviceId": "RipR24",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{doRamingReferentie}}",
+      "variableKey": "doRamingReferentie",
+      "source": "process",
+      "label": "DO estimate reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{sskRamingDoReferentie}}",
+      "variableKey": "sskRamingDoReferentie",
+      "source": "process",
+      "label": "SSK estimate reference"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{doRamingBedrag}}",
+      "variableKey": "doRamingBedrag",
+      "source": "process",
+      "label": "DO estimate"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{doReferentie}}",
+      "variableKey": "doReferentie",
+      "source": "process",
+      "label": "Final DO reference"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{risicodossierReferentie}}",
+      "variableKey": "risicodossierReferentie",
+      "source": "process",
+      "label": "Risk file reference"
+    },
+    {
+      "id": "b8",
+      "placeholder": "{{doRamingGereedOp}}",
+      "variableKey": "doRamingGereedOp",
+      "source": "process",
+      "label": "Delivered on"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "DO estimate {{doRamingReferentie}} · SSK estimate {{sskRamingDoReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "DO cost estimate",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "DO cost estimate"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "DO estimate {{doRamingReferentie}} and SSK estimate {{sskRamingDoReferentie}} cover the final detailed design {{doReferentie}} for project {{projectNumber}} — {{projectName}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The estimated cost is EUR {{doRamingBedrag}}, drawn up against risk file {{risicodossierReferentie}} and delivered on {{doRamingGereedOp}}."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up by the external engineering firm"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-ils-flevoland.document
+++ b/examples/organizations/flevoland/rip-phase-24/rip-ils-flevoland.document
@@ -1,0 +1,232 @@
+{
+  "id": "rip-ils-flevoland",
+  "name": "RIP — ILS Province of Flevoland",
+  "description": "The Province of Flevoland ILS form completed for the detailed design and assessed by advisers and asset management.",
+  "processKey": "RipR24Process",
+  "serviceId": "RipR24",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{ilsReferentie}}",
+      "variableKey": "ilsReferentie",
+      "source": "process",
+      "label": "ILS reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{ilsIngevuldOp}}",
+      "variableKey": "ilsIngevuldOp",
+      "source": "process",
+      "label": "Completed on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{ilsToelichting}}",
+      "variableKey": "ilsToelichting",
+      "source": "process",
+      "label": "Notes for the assessor"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{ilsOordeel}}",
+      "variableKey": "ilsOordeel",
+      "source": "process",
+      "label": "Assessment"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{ilsBeoordeeldDoor}}",
+      "variableKey": "ilsBeoordeeldDoor",
+      "source": "process",
+      "label": "Assessed by"
+    },
+    {
+      "id": "b8",
+      "placeholder": "{{ilsBeoordeeldOp}}",
+      "variableKey": "ilsBeoordeeldOp",
+      "source": "process",
+      "label": "Assessed on"
+    },
+    {
+      "id": "b9",
+      "placeholder": "{{ilsBeoordelingOpmerkingen}}",
+      "variableKey": "ilsBeoordelingOpmerkingen",
+      "source": "process",
+      "label": "Assessment comments"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "ILS {{ilsReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "ILS assessment",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "ILS assessment"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "ILS {{ilsReferentie}} for project {{projectNumber}} — {{projectName}} was completed on {{ilsIngevuldOp}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Notes for the assessor: {{ilsToelichting}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Assessment: {{ilsOordeel}}, by {{ilsBeoordeeldDoor}} on {{ilsBeoordeeldOp}}. Comments: {{ilsBeoordelingOpmerkingen}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Assessed by advisers and asset management"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-inventariseren-vergunningen.form
+++ b/examples/organizations/flevoland/rip-phase-24/rip-inventariseren-vergunningen.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-inventariseren-vergunningen",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Have the permit scan carried out"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Have the external engineering firm inventory the permits the project needs, using the permit scan format."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Permit scan reference",
+      "key": "vergunningenscanReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Vergunningen",
+      "type": "textarea",
+      "label": "Permits identified",
+      "key": "benodigdeVergunningen",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Gereed",
+      "type": "datetime",
+      "label": "Completed on",
+      "key": "vergunningenscanGereedOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-invullen-ils.form
+++ b/examples/organizations/flevoland/rip-phase-24/rip-invullen-ils.form
@@ -1,0 +1,52 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-invullen-ils",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Complete the ILS"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Complete the Province of Flevoland ILS (Integrale Levensduur Systematiek) form for the detailed design, so asset management can assess it."
+    },
+    {
+      "id": "F_ILS",
+      "type": "textfield",
+      "label": "ILS reference",
+      "key": "ilsReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Ingevuld",
+      "type": "datetime",
+      "label": "Completed on",
+      "key": "ilsIngevuldOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Toel",
+      "type": "textarea",
+      "label": "Notes for the assessor",
+      "key": "ilsToelichting"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-memo-projectkrediet-do.document
+++ b/examples/organizations/flevoland/rip-phase-24/rip-memo-projectkrediet-do.document
@@ -1,0 +1,218 @@
+{
+  "id": "rip-memo-projectkrediet-do",
+  "name": "RIP — Project Credit Memo, DO phase (Memo projectkrediet)",
+  "description": "Format Memo projectkrediet. The soft claim raised when the DO estimate exceeds the available project credit.",
+  "processKey": "RipR24Process",
+  "serviceId": "RipR24",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{memoDoReferentie}}",
+      "variableKey": "memoDoReferentie",
+      "source": "process",
+      "label": "Memo reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{gevraagdKredietDo}}",
+      "variableKey": "gevraagdKredietDo",
+      "source": "process",
+      "label": "Requested project credit"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{dekkingstekortDo}}",
+      "variableKey": "dekkingstekortDo",
+      "source": "process",
+      "label": "Shortfall"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{beschikbaarProjectkrediet}}",
+      "variableKey": "beschikbaarProjectkrediet",
+      "source": "process",
+      "label": "Available project credit"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{memoDoOnderbouwing}}",
+      "variableKey": "memoDoOnderbouwing",
+      "source": "process",
+      "label": "Substantiation"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Memo {{memoDoReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Request for additional project credit",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Request for additional project credit"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The DO project estimate for project {{projectNumber}} — {{projectName}} falls outside the available project credit of EUR {{beschikbaarProjectkrediet}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "This memo ({{memoDoReferentie}}) requests EUR {{gevraagdKredietDo}}, a shortfall of EUR {{dekkingstekortDo}} against the current credit."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Substantiation: {{memoDoOnderbouwing}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up by the project leader"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-memo-projectkrediet-do.form
+++ b/examples/organizations/flevoland/rip-phase-24/rip-memo-projectkrediet-do.form
@@ -1,0 +1,59 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-memo-projectkrediet-do",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Draw up the project credit memo (soft claim)"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The DO estimate exceeds the available project credit. Draw up the memo so the Infra consultation can decide on the additional credit."
+    },
+    {
+      "id": "F_Memo",
+      "type": "textfield",
+      "label": "Memo reference",
+      "key": "memoDoReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Gevraagd",
+      "type": "number",
+      "label": "Requested project credit (EUR)",
+      "key": "gevraagdKredietDo",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Tekort",
+      "type": "number",
+      "label": "Shortfall against the current credit (EUR)",
+      "key": "dekkingstekortDo"
+    },
+    {
+      "id": "F_Onderbouwing",
+      "type": "textarea",
+      "label": "Substantiation",
+      "key": "memoDoOnderbouwing",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-ontvangen-beoordeelde-ils.form
+++ b/examples/organizations/flevoland/rip-phase-24/rip-ontvangen-beoordeelde-ils.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-ontvangen-beoordeelde-ils",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Receive the assessed ILS"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Record receipt of the assessed ILS and how its comments are carried into the project plan."
+    },
+    {
+      "id": "F_Ontvangen",
+      "type": "datetime",
+      "label": "Received on",
+      "key": "ilsOntvangenOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Verwerkt",
+      "type": "textarea",
+      "label": "How the assessment is carried through",
+      "key": "ilsVerwerking",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-opdracht-extern-ib.form
+++ b/examples/organizations/flevoland/rip-phase-24/rip-opdracht-extern-ib.form
@@ -1,0 +1,70 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-opdracht-extern-ib",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Commission the external engineering firm"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Open the DO phase by commissioning the external engineering firm against the project plan adopted at the close of the VO phase."
+    },
+    {
+      "id": "F_Projectplan",
+      "type": "textfield",
+      "label": "Adopted project plan reference (from R2.3)",
+      "key": "projectplanVoReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_IB",
+      "type": "textfield",
+      "label": "External engineering firm",
+      "key": "externIngenieursbureau",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opdracht",
+      "type": "textfield",
+      "label": "Commission reference",
+      "key": "opdrachtReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_OpdrachtDatum",
+      "type": "datetime",
+      "label": "Commissioned on",
+      "key": "opdrachtDatum",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Scope",
+      "type": "textarea",
+      "label": "Scope of the commission",
+      "key": "opdrachtScope"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-opstellen-projectraming-do.form
+++ b/examples/organizations/flevoland/rip-phase-24/rip-opstellen-projectraming-do.form
@@ -1,0 +1,78 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-opstellen-projectraming-do",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Draw up the DO project estimate"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Consolidate the DO estimate into the project estimate and record whether it falls within the project credit. That answer routes the remainder of the phase."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "DO project estimate reference",
+      "key": "projectramingDoReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bedrag",
+      "type": "number",
+      "label": "DO project estimate (EUR)",
+      "key": "projectramingDoBedrag",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Krediet",
+      "type": "number",
+      "label": "Available project credit (EUR)",
+      "key": "beschikbaarProjectkrediet",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Binnen",
+      "type": "select",
+      "label": "Estimate falls within the project credit",
+      "key": "ramingBinnenKrediet",
+      "values": [
+        {
+          "label": "Yes — within the project credit",
+          "value": "ja"
+        },
+        {
+          "label": "No — additional credit needed",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Comments",
+      "key": "projectramingDoOpmerkingen"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-projectplan-do.document
+++ b/examples/organizations/flevoland/rip-phase-24/rip-projectplan-do.document
@@ -1,0 +1,234 @@
+{
+  "id": "rip-projectplan-do",
+  "name": "RIP — Adopted Project Plan, DO phase (Vastgesteld Projectplan DO)",
+  "description": "The project plan as adopted at the close of the DO phase. Hands over to R3.1 Laten opstellen concept bestektekeningen.",
+  "processKey": "RipR24Process",
+  "serviceId": "RipR24",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{projectplanDoReferentie}}",
+      "variableKey": "projectplanDoReferentie",
+      "source": "process",
+      "label": "Project plan reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{projectplanDoVastgesteldOp}}",
+      "variableKey": "projectplanDoVastgesteldOp",
+      "source": "process",
+      "label": "Adopted on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{doReferentie}}",
+      "variableKey": "doReferentie",
+      "source": "process",
+      "label": "Final DO reference"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{projectramingDoReferentie}}",
+      "variableKey": "projectramingDoReferentie",
+      "source": "process",
+      "label": "DO project estimate reference"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{ilsReferentie}}",
+      "variableKey": "ilsReferentie",
+      "source": "process",
+      "label": "ILS reference"
+    },
+    {
+      "id": "b8",
+      "placeholder": "{{accordeerOpmerkingenDo}}",
+      "variableKey": "accordeerOpmerkingenDo",
+      "source": "process",
+      "label": "Comments"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project plan {{projectplanDoReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Adopted project plan — closing the DO phase",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Adopted project plan — closing the DO phase"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project plan {{projectplanDoReferentie}} for project {{projectNumber}} — {{projectName}} was adopted on {{projectplanDoVastgesteldOp}}, closing the DO phase."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The plan incorporates the final detailed design {{doReferentie}}, the DO project estimate {{projectramingDoReferentie}} and the assessed ILS {{ilsReferentie}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Comments: {{accordeerOpmerkingenDo}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "With this adoption the project moves to R3.1, drawing up the draft specification and drawings."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Approved by the project leader"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-projectraming-do.document
+++ b/examples/organizations/flevoland/rip-phase-24/rip-projectraming-do.document
@@ -1,0 +1,218 @@
+{
+  "id": "rip-projectraming-do",
+  "name": "RIP — DO Project Estimate (Projectraming DO)",
+  "description": "The DO estimate consolidated into the project estimate, and its position against the available project credit.",
+  "processKey": "RipR24Process",
+  "serviceId": "RipR24",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{projectramingDoReferentie}}",
+      "variableKey": "projectramingDoReferentie",
+      "source": "process",
+      "label": "DO project estimate reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{projectramingDoBedrag}}",
+      "variableKey": "projectramingDoBedrag",
+      "source": "process",
+      "label": "DO project estimate"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{beschikbaarProjectkrediet}}",
+      "variableKey": "beschikbaarProjectkrediet",
+      "source": "process",
+      "label": "Available project credit"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{ramingBinnenKrediet}}",
+      "variableKey": "ramingBinnenKrediet",
+      "source": "process",
+      "label": "Within the credit"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{projectramingDoOpmerkingen}}",
+      "variableKey": "projectramingDoOpmerkingen",
+      "source": "process",
+      "label": "Comments"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "DO project estimate {{projectramingDoReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "DO project estimate",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "DO project estimate"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "DO project estimate {{projectramingDoReferentie}} for project {{projectNumber}} — {{projectName}} amounts to EUR {{projectramingDoBedrag}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Available project credit: EUR {{beschikbaarProjectkrediet}}. Within the credit: {{ramingBinnenKrediet}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Comments: {{projectramingDoOpmerkingen}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up by the cost and contract specialist"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-toetsen-aanpassingen.form
+++ b/examples/organizations/flevoland/rip-phase-24/rip-toetsen-aanpassingen.form
@@ -1,0 +1,71 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-toetsen-aanpassingen",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Review the amendments (PKT)"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "PKT reviews whether the amendments address the findings raised on the draft DO."
+    },
+    {
+      "id": "F_Toetser",
+      "type": "textfield",
+      "label": "Reviewed by",
+      "key": "aanpassingenGetoetstDoor",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Akkoord",
+      "type": "select",
+      "label": "Amendments approved",
+      "key": "aanpassingenAkkoord",
+      "values": [
+        {
+          "label": "Yes — proceed to the final DO",
+          "value": "ja"
+        },
+        {
+          "label": "No — further amendment needed",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Review comments",
+      "key": "aanpassingenOpmerkingen"
+    },
+    {
+      "id": "F_Getoetst",
+      "type": "datetime",
+      "label": "Reviewed on",
+      "key": "aanpassingenGetoetstOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-vergunningenscan.document
+++ b/examples/organizations/flevoland/rip-phase-24/rip-vergunningenscan.document
@@ -1,0 +1,195 @@
+{
+  "id": "rip-vergunningenscan",
+  "name": "RIP — Permit Scan (Vergunningenscan)",
+  "description": "Format Vergunningenscan. Inventory of the permits the project needs, produced by the external engineering firm in R2.4.",
+  "processKey": "RipR24Process",
+  "serviceId": "RipR24",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{vergunningenscanReferentie}}",
+      "variableKey": "vergunningenscanReferentie",
+      "source": "process",
+      "label": "Permit scan reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{benodigdeVergunningen}}",
+      "variableKey": "benodigdeVergunningen",
+      "source": "process",
+      "label": "Permits identified"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{vergunningenscanGereedOp}}",
+      "variableKey": "vergunningenscanGereedOp",
+      "source": "process",
+      "label": "Completed on"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Permit scan {{vergunningenscanReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Permits required",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Permits required"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Permit scan {{vergunningenscanReferentie}} for project {{projectNumber}} — {{projectName}} was completed on {{vergunningenscanGereedOp}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Permits identified: {{benodigdeVergunningen}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up by the external engineering firm"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-24/rip-verwerken-projectraming-do.form
+++ b/examples/organizations/flevoland/rip-phase-24/rip-verwerken-projectraming-do.form
@@ -1,0 +1,58 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-verwerken-projectraming-do",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Process the project estimate and Infra framework credit"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Record the DO project estimate and the credit decision in the Infra framework credit administration."
+    },
+    {
+      "id": "F_Bedrag",
+      "type": "number",
+      "label": "Amount processed (EUR)",
+      "key": "verwerktBedragDo",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Admin",
+      "type": "textfield",
+      "label": "Administration reference",
+      "key": "administratieReferentieDo"
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Processed on",
+      "key": "verwerktOpDo",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Comments",
+      "key": "verwerkingsOpmerkingenDo"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}


### PR DESCRIPTION
> **Stacked on #53 (R2.3).** Base is `feat/rip-phase-23`, so this PR shows only R2.4's 28 files. GitHub retargets it to `acc` automatically when #53 merges.

Models **R2.4 (DO en -raming)** from `rip-phases-left/R2 Planvoorbereiding/R2_4 - DO en -raming.pdf`. Fourth rung of the Flevoland RIP ladder.

`RipR24Process` — 29 flow nodes, 33 sequence flows, 6 lanes, 18 forms, 9 document templates. All six lanes on the overzichtsplaat are modelled.

## Flow

```
Start (from R2.3)
 └─ Opdracht extern ingenieursbureau         (Projectleider) ──▷ IN1.1, KV4.
 └─ AND split
      ├─ Laten uitvoeren aanvullende conditionerende onderzoeken
      └─ Laten inventariseren vergunningen door extern IB
 └─ Laten opstellen concept DO en concept DO-raming
 └─ Bespreken concept DO en concept DO-raming
        (RIP-team + Aandrager + Adviseurs + Vestigingsmanager)
 └─ XOR  Akkoord?
      ├─ nee → Laten aanpassen DO door extern IB
      │         └─ Toetsen aanpassingen door PKT
      │              └─ XOR Akkoord?   nee ⟲ back to Laten aanpassen · ja ↓
      └─ ja ────────────────────────────────────────────────────┐
 └─ AND split ──────────────────────────────────────────────────┘
      ├─ Laten opstellen definitief DO
      └─ Laten opstellen definitieve DO-raming
 └─ Opstellen Projectraming DO               (Kosten- en contractdeskundige)
 └─ XOR  Raming binnen projectkrediet?
      ├─ ja  → Accorderen beschikbaar krediet         (Financiën)
      └─ nee → Opstellen memo projectkrediet          (Projectleider)
                └─ Besluiten over projectkrediet      (Infra-overleg)
                     └─ Verwerken projectraming       (Financiën)
 └─ Invullen ILS
      └─ Beoordelen en retourneren ILS  (Adviseurs, Beheerder Assetmanagement)
           └─ Ontvangen beoordeelde ILS
 └─ Accorderen Projectplan 6. Afronding DO-fase → R3.1
```

## New in this phase: a rework loop

R2.1–R2.3 had none. When PKT rejects the amendments, `Toetsen aanpassingen` routes back to `Laten aanpassen DO`, so the design cycles until approved. Both `Akkoord?` gateways converge on the same join before the final DO is drawn up.

## Faseladder contract

| | Item | State |
|---|---|---|
| 1 | Process-definition key | `RipR24Process` |
| 2 | Tenant `flevoland` | at deploy |
| 3 | `municipality` untouched; no form sets a board-supplied variable | verified |
| 4 | `businessKey` | 0 occurrences |
| 5 | External-task topics | **none** — no serviceTasks, so no new worker subscription needed |
| 6 | `formRefBinding="deployment"` | all 18, zero `latest` |

`boardOwner` and `ronl:organization` stay unauthored, as in the other three bundles — the deploy path injects them. All candidate groups are `rip-*`, so board derivation resolves to **`infra-board`**.

Two candidate groups are new to the ladder and may need adding to RBA's rip-model: **`rip-beheerder-assetmanagement`** and **`rip-vestigingsmanager`**. Neither affects board derivation.

## Ladder

Entry is *Opdracht extern ingenieursbureau* — exactly R2.3's exit. Closes on *Accorderen Projectplan 6. Afronding DO-fase*, which is R3.1's entry.

## How this one was built

R2.3's layout was hand-placed and that was where the errors clustered. This bundle comes from a small generator that emits the BPMN from a node/edge table with automatic orthogonal edge routing, including the backward loop edge. Both validators passed on the first run with no coordinate iteration.

## Verification

All four bundles validated together on this branch (stacking makes that possible):

```
R2.1  bpmn: OK   bundle: OK
R2.2  bpmn: OK   bundle: OK
R2.3  bpmn: OK   bundle: OK
R2.4  bpmn: OK   bundle: OK

id collisions across all four bundles: none
```

- **Structural BPMN** — ids, reference resolution, incoming/outgoing agreement, reachability, one-lane-per-node, deterministic exclusive gateways, DI integrity.
- **Bundle cross-check** — every `formRef`/`documentRef` resolves to a file whose internal id agrees, every `{{placeholder}}` has a binding, every gateway condition names a variable some form sets. The two remaining notes (`projectNumber`/`projectName` from the board) match R2.2 and R2.3.

Document ids reusing an earlier phase's name carry a `-do` suffix (`rip-bevindingenformulier-do`, `rip-memo-projectkrediet-do`, `rip-besluit-projectkrediet-do`) so nothing collides in LDE's document store.

## Not deployed

The engine still carries only `RipR21Process` and `RipR22Process`. R2.3 deploys first.
