### PR TITLE
feat(rip): add R3.1 Opstellen bestek en tekeningen bundle for Flevoland

### DIFF
--- a/examples/organizations/flevoland/rip-phase-31/RipR31Process.bpmn
+++ b/examples/organizations/flevoland/rip-phase-31/RipR31Process.bpmn
@@ -1,0 +1,546 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:ronl="http://ronl.nl/schema/1.0" id="Definitions_RipR31Process" targetNamespace="http://example.com/rip-phase-31" exporter="Camunda Modeler" exporterVersion="5.45.0">
+  <bpmn:collaboration id="Collaboration_RipR31Process">
+    <bpmn:participant id="Participant_RipR31Process" name="R3.1 - Opstellen bestek en tekeningen" processRef="RipR31Process" />
+  </bpmn:collaboration>
+  <bpmn:process id="RipR31Process" name="R3.1 - Opstellen bestek en tekeningen" isExecutable="true" camunda:historyTimeToLive="180">
+    <bpmn:laneSet id="LaneSet_RipR31Process">
+      <bpmn:lane id="Lane_KcInkoopPl" name="Kosten- en contractdeskundige, Inkoopadviseur werken, Projectleider">
+        <bpmn:flowNodeRef>Task_ToetsenInschrijfleidraad</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_InschrijfleidraadAkkoord</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_ToetsenAanpassingenInschrijfleidraad</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_AanpassingenInschrijfleidraadAkkoord</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_InschrijfleidraadTrackJoin</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_KcOmgevingDirectieToezichtPl" name="Kosten- en contractdeskundige, Omgevingsmanager, Directievoerder, Toezichthouder, Projectleider">
+        <bpmn:flowNodeRef>Task_ToetsenBestek</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_BestekAkkoord</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_ToetsenAanpassingenBestek</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_AanpassingenBestekAkkoord</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_BestekTrackJoin</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_OntwerperDirectiePlTechnisch" name="Ontwerper, Directievoerder, Projectleider, Technisch adviseur">
+        <bpmn:flowNodeRef>Task_ToetsenConceptBestekstekeningen</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_ConceptBestekstekeningenAkkoord</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_ToetsenAanpassingenBestekstekeningen</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_AanpassingenBestekstekeningenAkkoord</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_Projectleider" name="Projectleider">
+        <bpmn:flowNodeRef>StartEvent_R31</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_LatenOpstellenConceptBestekstekeningen</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_LatenAanpassenBestekstekeningen</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_BestekstekeningenJoin</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_DefinitiefMakenBestekstekeningen</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_LatenOpstellenBestek</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_ToetsingSplit</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_LatenAanpassenBestek</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_LatenAanpassenInschrijfleidraad</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_ToetsingJoin</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndEvent_R32</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+
+    <bpmn:startEvent id="StartEvent_R31" name="Start R3.1 - Opstellen bestek&#10;en tekeningen (vanuit R2.4)">
+      <bpmn:outgoing>Flow_StartEvent_R31_Task_LatenOpstellenConceptBestekstekeningen</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:userTask id="Task_LatenOpstellenConceptBestekstekeningen" name="Laten opstellen&#10;concept bestekstekeningen" camunda:formRef="rip-concept-bestekstekeningen" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-concept-bestekstekeningen">
+      <bpmn:incoming>Flow_StartEvent_R31_Task_LatenOpstellenConceptBestekstekeningen</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_LatenOpstellenConceptBestekstekeningen_Task_ToetsenConceptBestekstekeningen</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_ToetsenConceptBestekstekeningen" name="Toetsen concept&#10;bestekstekeningen" camunda:formRef="rip-toetsen-concept-bestekstekeningen" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-ontwerper,rip-directievoerder,rip-projectleider,rip-technisch-adviseur" ronl:documentRef="rip-bevindingenformulier-bestekstekeningen">
+      <bpmn:incoming>Flow_Task_LatenOpstellenConceptBestekstekeningen_Task_ToetsenConceptBestekstekeningen</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_ToetsenConceptBestekstekeningen_Gateway_ConceptBestekstekeningenAkkoord</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_ConceptBestekstekeningenAkkoord" name="Akkoord?">
+      <bpmn:incoming>Flow_Task_ToetsenConceptBestekstekeningen_Gateway_ConceptBestekstekeningenAkkoord</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_ConceptBestekstekeningenAkkoord_Task_LatenAanpassenBestekstekeningen</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_ConceptBestekstekeningenAkkoord_Gateway_BestekstekeningenJoin</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_LatenAanpassenBestekstekeningen" name="Laten aanpassen&#10;bestekstekeningen" camunda:formRef="rip-aanpassen-bestekstekeningen" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
+      <bpmn:incoming>Flow_Gateway_ConceptBestekstekeningenAkkoord_Task_LatenAanpassenBestekstekeningen</bpmn:incoming>
+      <bpmn:incoming>Flow_Gateway_AanpassingenBestekstekeningenAkkoord_Task_LatenAanpassenBestekstekeningen</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_LatenAanpassenBestekstekeningen_Task_ToetsenAanpassingenBestekstekeningen</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_ToetsenAanpassingenBestekstekeningen" name="Toetsen aanpassingen&#10;bestekstekeningen" camunda:formRef="rip-toetsen-aanpassingen-bestekstekeningen" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-ontwerper,rip-directievoerder,rip-projectleider,rip-technisch-adviseur">
+      <bpmn:incoming>Flow_Task_LatenAanpassenBestekstekeningen_Task_ToetsenAanpassingenBestekstekeningen</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_ToetsenAanpassingenBestekstekeningen_Gateway_AanpassingenBestekstekeningenAkkoord</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_AanpassingenBestekstekeningenAkkoord" name="Akkoord?">
+      <bpmn:incoming>Flow_Task_ToetsenAanpassingenBestekstekeningen_Gateway_AanpassingenBestekstekeningenAkkoord</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_AanpassingenBestekstekeningenAkkoord_Task_LatenAanpassenBestekstekeningen</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_AanpassingenBestekstekeningenAkkoord_Gateway_BestekstekeningenJoin</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:exclusiveGateway id="Gateway_BestekstekeningenJoin">
+      <bpmn:incoming>Flow_Gateway_ConceptBestekstekeningenAkkoord_Gateway_BestekstekeningenJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Gateway_AanpassingenBestekstekeningenAkkoord_Gateway_BestekstekeningenJoin</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_BestekstekeningenJoin_Task_DefinitiefMakenBestekstekeningen</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_DefinitiefMakenBestekstekeningen" name="Definitief laten maken&#10;concept bestekstekeningen" camunda:formRef="rip-definitieve-bestekstekeningen" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-definitieve-bestekstekeningen">
+      <bpmn:incoming>Flow_Gateway_BestekstekeningenJoin_Task_DefinitiefMakenBestekstekeningen</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_DefinitiefMakenBestekstekeningen_Task_LatenOpstellenBestek</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_LatenOpstellenBestek" name="Laten opstellen bestek" camunda:formRef="rip-opstellen-bestek" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-bestek">
+      <bpmn:incoming>Flow_Task_DefinitiefMakenBestekstekeningen_Task_LatenOpstellenBestek</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_LatenOpstellenBestek_Gateway_ToetsingSplit</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:parallelGateway id="Gateway_ToetsingSplit">
+      <bpmn:incoming>Flow_Task_LatenOpstellenBestek_Gateway_ToetsingSplit</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_ToetsingSplit_Task_ToetsenBestek</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_ToetsingSplit_Task_ToetsenInschrijfleidraad</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:userTask id="Task_ToetsenBestek" name="Toetsen bestek" camunda:formRef="rip-toetsen-bestek" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-kosten-contractdeskundige,rip-omgevingsmanager,rip-directievoerder,rip-toezichthouder,rip-projectleider" ronl:documentRef="rip-bevindingenformulier-bestek">
+      <bpmn:incoming>Flow_Gateway_ToetsingSplit_Task_ToetsenBestek</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_ToetsenBestek_Gateway_BestekAkkoord</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_BestekAkkoord" name="Akkoord?">
+      <bpmn:incoming>Flow_Task_ToetsenBestek_Gateway_BestekAkkoord</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_BestekAkkoord_Task_LatenAanpassenBestek</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_BestekAkkoord_Gateway_BestekTrackJoin</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_LatenAanpassenBestek" name="Laten aanpassen bestek" camunda:formRef="rip-aanpassen-bestek" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
+      <bpmn:incoming>Flow_Gateway_BestekAkkoord_Task_LatenAanpassenBestek</bpmn:incoming>
+      <bpmn:incoming>Flow_Gateway_AanpassingenBestekAkkoord_Task_LatenAanpassenBestek</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_LatenAanpassenBestek_Task_ToetsenAanpassingenBestek</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_ToetsenAanpassingenBestek" name="Toetsen aanpassingen&#10;bestek" camunda:formRef="rip-toetsen-aanpassingen-bestek" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-kosten-contractdeskundige,rip-omgevingsmanager,rip-directievoerder,rip-toezichthouder,rip-projectleider">
+      <bpmn:incoming>Flow_Task_LatenAanpassenBestek_Task_ToetsenAanpassingenBestek</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_ToetsenAanpassingenBestek_Gateway_AanpassingenBestekAkkoord</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_AanpassingenBestekAkkoord" name="Akkoord?">
+      <bpmn:incoming>Flow_Task_ToetsenAanpassingenBestek_Gateway_AanpassingenBestekAkkoord</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_AanpassingenBestekAkkoord_Task_LatenAanpassenBestek</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_AanpassingenBestekAkkoord_Gateway_BestekTrackJoin</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:exclusiveGateway id="Gateway_BestekTrackJoin">
+      <bpmn:incoming>Flow_Gateway_BestekAkkoord_Gateway_BestekTrackJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Gateway_AanpassingenBestekAkkoord_Gateway_BestekTrackJoin</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_BestekTrackJoin_Gateway_ToetsingJoin</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_ToetsenInschrijfleidraad" name="Toetsen&#10;inschrijfleidraad" camunda:formRef="rip-toetsen-inschrijfleidraad" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-kosten-contractdeskundige,rip-inkoopadviseur-werken,rip-projectleider" ronl:documentRef="rip-bevindingenformulier-inschrijfleidraad">
+      <bpmn:incoming>Flow_Gateway_ToetsingSplit_Task_ToetsenInschrijfleidraad</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_ToetsenInschrijfleidraad_Gateway_InschrijfleidraadAkkoord</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_InschrijfleidraadAkkoord" name="Akkoord?">
+      <bpmn:incoming>Flow_Task_ToetsenInschrijfleidraad_Gateway_InschrijfleidraadAkkoord</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_InschrijfleidraadAkkoord_Task_LatenAanpassenInschrijfleidraad</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_InschrijfleidraadAkkoord_Gateway_InschrijfleidraadTrackJoin</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_LatenAanpassenInschrijfleidraad" name="Laten aanpassen&#10;inschrijfleidraad" camunda:formRef="rip-aanpassen-inschrijfleidraad" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
+      <bpmn:incoming>Flow_Gateway_InschrijfleidraadAkkoord_Task_LatenAanpassenInschrijfleidraad</bpmn:incoming>
+      <bpmn:incoming>Flow_Gateway_AanpassingenInschrijfleidraadAkkoord_Task_LatenAanpassenInschrijfleidraad</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_LatenAanpassenInschrijfleidraad_Task_ToetsenAanpassingenInschrijfleidraad</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_ToetsenAanpassingenInschrijfleidraad" name="Toetsen aanpassingen&#10;inschrijfleidraad" camunda:formRef="rip-toetsen-aanpassingen-inschrijfleidraad" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-kosten-contractdeskundige,rip-inkoopadviseur-werken,rip-projectleider">
+      <bpmn:incoming>Flow_Task_LatenAanpassenInschrijfleidraad_Task_ToetsenAanpassingenInschrijfleidraad</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_ToetsenAanpassingenInschrijfleidraad_Gateway_AanpassingenInschrijfleidraadAkkoord</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_AanpassingenInschrijfleidraadAkkoord" name="Akkoord?">
+      <bpmn:incoming>Flow_Task_ToetsenAanpassingenInschrijfleidraad_Gateway_AanpassingenInschrijfleidraadAkkoord</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_AanpassingenInschrijfleidraadAkkoord_Task_LatenAanpassenInschrijfleidraad</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_AanpassingenInschrijfleidraadAkkoord_Gateway_InschrijfleidraadTrackJoin</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:exclusiveGateway id="Gateway_InschrijfleidraadTrackJoin">
+      <bpmn:incoming>Flow_Gateway_InschrijfleidraadAkkoord_Gateway_InschrijfleidraadTrackJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Gateway_AanpassingenInschrijfleidraadAkkoord_Gateway_InschrijfleidraadTrackJoin</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_InschrijfleidraadTrackJoin_Gateway_ToetsingJoin</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:parallelGateway id="Gateway_ToetsingJoin">
+      <bpmn:incoming>Flow_Gateway_BestekTrackJoin_Gateway_ToetsingJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Gateway_InschrijfleidraadTrackJoin_Gateway_ToetsingJoin</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_ToetsingJoin_EndEvent_R32</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:endEvent id="EndEvent_R32" name="Getoetste contract- en aanbestedingsdocumenten&#10;→ R3.2 Verzamelen getoetste documenten">
+      <bpmn:incoming>Flow_Gateway_ToetsingJoin_EndEvent_R32</bpmn:incoming>
+    </bpmn:endEvent>
+
+    <bpmn:sequenceFlow id="Flow_StartEvent_R31_Task_LatenOpstellenConceptBestekstekeningen" sourceRef="StartEvent_R31" targetRef="Task_LatenOpstellenConceptBestekstekeningen" />
+    <bpmn:sequenceFlow id="Flow_Task_LatenOpstellenConceptBestekstekeningen_Task_ToetsenConceptBestekstekeningen" sourceRef="Task_LatenOpstellenConceptBestekstekeningen" targetRef="Task_ToetsenConceptBestekstekeningen" />
+    <bpmn:sequenceFlow id="Flow_Task_ToetsenConceptBestekstekeningen_Gateway_ConceptBestekstekeningenAkkoord" sourceRef="Task_ToetsenConceptBestekstekeningen" targetRef="Gateway_ConceptBestekstekeningenAkkoord" />
+    <bpmn:sequenceFlow id="Flow_Gateway_ConceptBestekstekeningenAkkoord_Task_LatenAanpassenBestekstekeningen" name="nee" sourceRef="Gateway_ConceptBestekstekeningenAkkoord" targetRef="Task_LatenAanpassenBestekstekeningen">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${conceptBestekstekeningenAkkoord == "nee"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_ConceptBestekstekeningenAkkoord_Gateway_BestekstekeningenJoin" name="ja" sourceRef="Gateway_ConceptBestekstekeningenAkkoord" targetRef="Gateway_BestekstekeningenJoin">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${conceptBestekstekeningenAkkoord == "ja"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Task_LatenAanpassenBestekstekeningen_Task_ToetsenAanpassingenBestekstekeningen" sourceRef="Task_LatenAanpassenBestekstekeningen" targetRef="Task_ToetsenAanpassingenBestekstekeningen" />
+    <bpmn:sequenceFlow id="Flow_Task_ToetsenAanpassingenBestekstekeningen_Gateway_AanpassingenBestekstekeningenAkkoord" sourceRef="Task_ToetsenAanpassingenBestekstekeningen" targetRef="Gateway_AanpassingenBestekstekeningenAkkoord" />
+    <bpmn:sequenceFlow id="Flow_Gateway_AanpassingenBestekstekeningenAkkoord_Task_LatenAanpassenBestekstekeningen" name="nee" sourceRef="Gateway_AanpassingenBestekstekeningenAkkoord" targetRef="Task_LatenAanpassenBestekstekeningen">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${aanpassingenBestekstekeningenAkkoord == "nee"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_AanpassingenBestekstekeningenAkkoord_Gateway_BestekstekeningenJoin" name="ja" sourceRef="Gateway_AanpassingenBestekstekeningenAkkoord" targetRef="Gateway_BestekstekeningenJoin">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${aanpassingenBestekstekeningenAkkoord == "ja"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_BestekstekeningenJoin_Task_DefinitiefMakenBestekstekeningen" sourceRef="Gateway_BestekstekeningenJoin" targetRef="Task_DefinitiefMakenBestekstekeningen" />
+    <bpmn:sequenceFlow id="Flow_Task_DefinitiefMakenBestekstekeningen_Task_LatenOpstellenBestek" sourceRef="Task_DefinitiefMakenBestekstekeningen" targetRef="Task_LatenOpstellenBestek" />
+    <bpmn:sequenceFlow id="Flow_Task_LatenOpstellenBestek_Gateway_ToetsingSplit" sourceRef="Task_LatenOpstellenBestek" targetRef="Gateway_ToetsingSplit" />
+    <bpmn:sequenceFlow id="Flow_Gateway_ToetsingSplit_Task_ToetsenBestek" sourceRef="Gateway_ToetsingSplit" targetRef="Task_ToetsenBestek" />
+    <bpmn:sequenceFlow id="Flow_Task_ToetsenBestek_Gateway_BestekAkkoord" sourceRef="Task_ToetsenBestek" targetRef="Gateway_BestekAkkoord" />
+    <bpmn:sequenceFlow id="Flow_Gateway_BestekAkkoord_Task_LatenAanpassenBestek" name="nee" sourceRef="Gateway_BestekAkkoord" targetRef="Task_LatenAanpassenBestek">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${bestekAkkoord == "nee"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_BestekAkkoord_Gateway_BestekTrackJoin" name="ja" sourceRef="Gateway_BestekAkkoord" targetRef="Gateway_BestekTrackJoin">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${bestekAkkoord == "ja"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Task_LatenAanpassenBestek_Task_ToetsenAanpassingenBestek" sourceRef="Task_LatenAanpassenBestek" targetRef="Task_ToetsenAanpassingenBestek" />
+    <bpmn:sequenceFlow id="Flow_Task_ToetsenAanpassingenBestek_Gateway_AanpassingenBestekAkkoord" sourceRef="Task_ToetsenAanpassingenBestek" targetRef="Gateway_AanpassingenBestekAkkoord" />
+    <bpmn:sequenceFlow id="Flow_Gateway_AanpassingenBestekAkkoord_Task_LatenAanpassenBestek" name="nee" sourceRef="Gateway_AanpassingenBestekAkkoord" targetRef="Task_LatenAanpassenBestek">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${aanpassingenBestekAkkoord == "nee"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_AanpassingenBestekAkkoord_Gateway_BestekTrackJoin" name="ja" sourceRef="Gateway_AanpassingenBestekAkkoord" targetRef="Gateway_BestekTrackJoin">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${aanpassingenBestekAkkoord == "ja"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_BestekTrackJoin_Gateway_ToetsingJoin" sourceRef="Gateway_BestekTrackJoin" targetRef="Gateway_ToetsingJoin" />
+    <bpmn:sequenceFlow id="Flow_Gateway_ToetsingSplit_Task_ToetsenInschrijfleidraad" sourceRef="Gateway_ToetsingSplit" targetRef="Task_ToetsenInschrijfleidraad" />
+    <bpmn:sequenceFlow id="Flow_Task_ToetsenInschrijfleidraad_Gateway_InschrijfleidraadAkkoord" sourceRef="Task_ToetsenInschrijfleidraad" targetRef="Gateway_InschrijfleidraadAkkoord" />
+    <bpmn:sequenceFlow id="Flow_Gateway_InschrijfleidraadAkkoord_Task_LatenAanpassenInschrijfleidraad" name="nee" sourceRef="Gateway_InschrijfleidraadAkkoord" targetRef="Task_LatenAanpassenInschrijfleidraad">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${inschrijfleidraadAkkoord == "nee"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_InschrijfleidraadAkkoord_Gateway_InschrijfleidraadTrackJoin" name="ja" sourceRef="Gateway_InschrijfleidraadAkkoord" targetRef="Gateway_InschrijfleidraadTrackJoin">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${inschrijfleidraadAkkoord == "ja"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Task_LatenAanpassenInschrijfleidraad_Task_ToetsenAanpassingenInschrijfleidraad" sourceRef="Task_LatenAanpassenInschrijfleidraad" targetRef="Task_ToetsenAanpassingenInschrijfleidraad" />
+    <bpmn:sequenceFlow id="Flow_Task_ToetsenAanpassingenInschrijfleidraad_Gateway_AanpassingenInschrijfleidraadAkkoord" sourceRef="Task_ToetsenAanpassingenInschrijfleidraad" targetRef="Gateway_AanpassingenInschrijfleidraadAkkoord" />
+    <bpmn:sequenceFlow id="Flow_Gateway_AanpassingenInschrijfleidraadAkkoord_Task_LatenAanpassenInschrijfleidraad" name="nee" sourceRef="Gateway_AanpassingenInschrijfleidraadAkkoord" targetRef="Task_LatenAanpassenInschrijfleidraad">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${aanpassingenInschrijfleidraadAkkoord == "nee"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_AanpassingenInschrijfleidraadAkkoord_Gateway_InschrijfleidraadTrackJoin" name="ja" sourceRef="Gateway_AanpassingenInschrijfleidraadAkkoord" targetRef="Gateway_InschrijfleidraadTrackJoin">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${aanpassingenInschrijfleidraadAkkoord == "ja"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_InschrijfleidraadTrackJoin_Gateway_ToetsingJoin" sourceRef="Gateway_InschrijfleidraadTrackJoin" targetRef="Gateway_ToetsingJoin" />
+    <bpmn:sequenceFlow id="Flow_Gateway_ToetsingJoin_EndEvent_R32" sourceRef="Gateway_ToetsingJoin" targetRef="EndEvent_R32" />
+
+    <bpmn:textAnnotation id="Annotation_CO1_Maatregelenplan">
+      <bpmn:text>CO1. Opstellen maatregelenplan</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Assoc_Annotation_CO1_Maatregelenplan" sourceRef="Task_LatenOpstellenBestek" targetRef="Annotation_CO1_Maatregelenplan" />
+    <bpmn:textAnnotation id="Annotation_CO1_InformerenAannemer">
+      <bpmn:text>CO1. Informeren aannemer</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Assoc_Annotation_CO1_InformerenAannemer" sourceRef="Gateway_ToetsingJoin" targetRef="Annotation_CO1_InformerenAannemer" />
+  </bpmn:process>
+
+  <bpmndi:BPMNDiagram id="BPMNDiagram_RipR31Process">
+    <bpmndi:BPMNPlane id="BPMNPlane_RipR31Process" bpmnElement="Collaboration_RipR31Process">
+      <bpmndi:BPMNShape id="Participant_RipR31Process_di" bpmnElement="Participant_RipR31Process" isHorizontal="true">
+        <dc:Bounds x="160" y="80" width="2356" height="620" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_KcInkoopPl_di" bpmnElement="Lane_KcInkoopPl" isHorizontal="true">
+        <dc:Bounds x="190" y="80" width="2326" height="140" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_KcOmgevingDirectieToezichtPl_di" bpmnElement="Lane_KcOmgevingDirectieToezichtPl" isHorizontal="true">
+        <dc:Bounds x="190" y="220" width="2326" height="140" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_OntwerperDirectiePlTechnisch_di" bpmnElement="Lane_OntwerperDirectiePlTechnisch" isHorizontal="true">
+        <dc:Bounds x="190" y="360" width="2326" height="140" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Projectleider_di" bpmnElement="Lane_Projectleider" isHorizontal="true">
+        <dc:Bounds x="190" y="500" width="2326" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_R31_di" bpmnElement="StartEvent_R31">
+        <dc:Bounds x="232" y="532" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="134" y="573" width="232" height="28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_LatenOpstellenConceptBestekstekeningen_di" bpmnElement="Task_LatenOpstellenConceptBestekstekeningen">
+        <dc:Bounds x="300" y="510" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_ToetsenConceptBestekstekeningen_di" bpmnElement="Task_ToetsenConceptBestekstekeningen">
+        <dc:Bounds x="460" y="380" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_ConceptBestekstekeningenAkkoord_di" bpmnElement="Gateway_ConceptBestekstekeningenAkkoord" isMarkerVisible="true">
+        <dc:Bounds x="620" y="395" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="600" y="450" width="90" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_LatenAanpassenBestekstekeningen_di" bpmnElement="Task_LatenAanpassenBestekstekeningen">
+        <dc:Bounds x="700" y="510" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_ToetsenAanpassingenBestekstekeningen_di" bpmnElement="Task_ToetsenAanpassingenBestekstekeningen">
+        <dc:Bounds x="860" y="380" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_AanpassingenBestekstekeningenAkkoord_di" bpmnElement="Gateway_AanpassingenBestekstekeningenAkkoord" isMarkerVisible="true">
+        <dc:Bounds x="1020" y="395" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1000" y="450" width="90" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_BestekstekeningenJoin_di" bpmnElement="Gateway_BestekstekeningenJoin" isMarkerVisible="true">
+        <dc:Bounds x="1110" y="525" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_DefinitiefMakenBestekstekeningen_di" bpmnElement="Task_DefinitiefMakenBestekstekeningen">
+        <dc:Bounds x="1190" y="510" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_LatenOpstellenBestek_di" bpmnElement="Task_LatenOpstellenBestek">
+        <dc:Bounds x="1350" y="510" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_ToetsingSplit_di" bpmnElement="Gateway_ToetsingSplit">
+        <dc:Bounds x="1510" y="525" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_ToetsenBestek_di" bpmnElement="Task_ToetsenBestek">
+        <dc:Bounds x="1590" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_BestekAkkoord_di" bpmnElement="Gateway_BestekAkkoord" isMarkerVisible="true">
+        <dc:Bounds x="1750" y="255" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1730" y="310" width="90" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_LatenAanpassenBestek_di" bpmnElement="Task_LatenAanpassenBestek">
+        <dc:Bounds x="1830" y="510" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_ToetsenAanpassingenBestek_di" bpmnElement="Task_ToetsenAanpassingenBestek">
+        <dc:Bounds x="1990" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_AanpassingenBestekAkkoord_di" bpmnElement="Gateway_AanpassingenBestekAkkoord" isMarkerVisible="true">
+        <dc:Bounds x="2150" y="255" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2130" y="310" width="90" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_BestekTrackJoin_di" bpmnElement="Gateway_BestekTrackJoin" isMarkerVisible="true">
+        <dc:Bounds x="2240" y="255" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_ToetsenInschrijfleidraad_di" bpmnElement="Task_ToetsenInschrijfleidraad">
+        <dc:Bounds x="1590" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_InschrijfleidraadAkkoord_di" bpmnElement="Gateway_InschrijfleidraadAkkoord" isMarkerVisible="true">
+        <dc:Bounds x="1750" y="115" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1730" y="170" width="90" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_LatenAanpassenInschrijfleidraad_di" bpmnElement="Task_LatenAanpassenInschrijfleidraad">
+        <dc:Bounds x="1830" y="600" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_ToetsenAanpassingenInschrijfleidraad_di" bpmnElement="Task_ToetsenAanpassingenInschrijfleidraad">
+        <dc:Bounds x="1990" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_AanpassingenInschrijfleidraadAkkoord_di" bpmnElement="Gateway_AanpassingenInschrijfleidraadAkkoord" isMarkerVisible="true">
+        <dc:Bounds x="2150" y="115" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2130" y="170" width="90" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_InschrijfleidraadTrackJoin_di" bpmnElement="Gateway_InschrijfleidraadTrackJoin" isMarkerVisible="true">
+        <dc:Bounds x="2240" y="115" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_ToetsingJoin_di" bpmnElement="Gateway_ToetsingJoin">
+        <dc:Bounds x="2330" y="525" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_R32_di" bpmnElement="EndEvent_R32">
+        <dc:Bounds x="2410" y="532" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2244" y="573" width="368" height="28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Annotation_CO1_Maatregelenplan_di" bpmnElement="Annotation_CO1_Maatregelenplan">
+        <dc:Bounds x="1290" y="720" width="230" height="45" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Annotation_CO1_InformerenAannemer_di" bpmnElement="Annotation_CO1_InformerenAannemer">
+        <dc:Bounds x="2270" y="720" width="200" height="45" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_StartEvent_R31_Task_LatenOpstellenConceptBestekstekeningen_di" bpmnElement="Flow_StartEvent_R31_Task_LatenOpstellenConceptBestekstekeningen">
+        <di:waypoint x="268" y="550" />
+        <di:waypoint x="300" y="550" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_LatenOpstellenConceptBestekstekeningen_Task_ToetsenConceptBestekstekeningen_di" bpmnElement="Flow_Task_LatenOpstellenConceptBestekstekeningen_Task_ToetsenConceptBestekstekeningen">
+        <di:waypoint x="400" y="550" />
+        <di:waypoint x="430" y="550" />
+        <di:waypoint x="430" y="420" />
+        <di:waypoint x="460" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_ToetsenConceptBestekstekeningen_Gateway_ConceptBestekstekeningenAkkoord_di" bpmnElement="Flow_Task_ToetsenConceptBestekstekeningen_Gateway_ConceptBestekstekeningenAkkoord">
+        <di:waypoint x="560" y="420" />
+        <di:waypoint x="620" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_ConceptBestekstekeningenAkkoord_Task_LatenAanpassenBestekstekeningen_di" bpmnElement="Flow_Gateway_ConceptBestekstekeningenAkkoord_Task_LatenAanpassenBestekstekeningen">
+        <di:waypoint x="670" y="420" />
+        <di:waypoint x="685" y="420" />
+        <di:waypoint x="685" y="550" />
+        <di:waypoint x="700" y="550" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="676" y="400" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_ConceptBestekstekeningenAkkoord_Gateway_BestekstekeningenJoin_di" bpmnElement="Flow_Gateway_ConceptBestekstekeningenAkkoord_Gateway_BestekstekeningenJoin">
+        <di:waypoint x="670" y="420" />
+        <di:waypoint x="890" y="420" />
+        <di:waypoint x="890" y="550" />
+        <di:waypoint x="1110" y="550" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="676" y="400" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_LatenAanpassenBestekstekeningen_Task_ToetsenAanpassingenBestekstekeningen_di" bpmnElement="Flow_Task_LatenAanpassenBestekstekeningen_Task_ToetsenAanpassingenBestekstekeningen">
+        <di:waypoint x="800" y="550" />
+        <di:waypoint x="830" y="550" />
+        <di:waypoint x="830" y="420" />
+        <di:waypoint x="860" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_ToetsenAanpassingenBestekstekeningen_Gateway_AanpassingenBestekstekeningenAkkoord_di" bpmnElement="Flow_Task_ToetsenAanpassingenBestekstekeningen_Gateway_AanpassingenBestekstekeningenAkkoord">
+        <di:waypoint x="960" y="420" />
+        <di:waypoint x="1020" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_AanpassingenBestekstekeningenAkkoord_Task_LatenAanpassenBestekstekeningen_di" bpmnElement="Flow_Gateway_AanpassingenBestekstekeningenAkkoord_Task_LatenAanpassenBestekstekeningen">
+        <di:waypoint x="1045" y="445" />
+        <di:waypoint x="1045" y="480" />
+        <di:waypoint x="750" y="480" />
+        <di:waypoint x="750" y="590" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1051" y="425" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_AanpassingenBestekstekeningenAkkoord_Gateway_BestekstekeningenJoin_di" bpmnElement="Flow_Gateway_AanpassingenBestekstekeningenAkkoord_Gateway_BestekstekeningenJoin">
+        <di:waypoint x="1070" y="420" />
+        <di:waypoint x="1090" y="420" />
+        <di:waypoint x="1090" y="550" />
+        <di:waypoint x="1110" y="550" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1076" y="400" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_BestekstekeningenJoin_Task_DefinitiefMakenBestekstekeningen_di" bpmnElement="Flow_Gateway_BestekstekeningenJoin_Task_DefinitiefMakenBestekstekeningen">
+        <di:waypoint x="1160" y="550" />
+        <di:waypoint x="1190" y="550" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_DefinitiefMakenBestekstekeningen_Task_LatenOpstellenBestek_di" bpmnElement="Flow_Task_DefinitiefMakenBestekstekeningen_Task_LatenOpstellenBestek">
+        <di:waypoint x="1290" y="550" />
+        <di:waypoint x="1350" y="550" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_LatenOpstellenBestek_Gateway_ToetsingSplit_di" bpmnElement="Flow_Task_LatenOpstellenBestek_Gateway_ToetsingSplit">
+        <di:waypoint x="1450" y="550" />
+        <di:waypoint x="1510" y="550" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_ToetsingSplit_Task_ToetsenBestek_di" bpmnElement="Flow_Gateway_ToetsingSplit_Task_ToetsenBestek">
+        <di:waypoint x="1560" y="550" />
+        <di:waypoint x="1575" y="550" />
+        <di:waypoint x="1575" y="280" />
+        <di:waypoint x="1590" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_ToetsenBestek_Gateway_BestekAkkoord_di" bpmnElement="Flow_Task_ToetsenBestek_Gateway_BestekAkkoord">
+        <di:waypoint x="1690" y="280" />
+        <di:waypoint x="1750" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_BestekAkkoord_Task_LatenAanpassenBestek_di" bpmnElement="Flow_Gateway_BestekAkkoord_Task_LatenAanpassenBestek">
+        <di:waypoint x="1800" y="280" />
+        <di:waypoint x="1815" y="280" />
+        <di:waypoint x="1815" y="550" />
+        <di:waypoint x="1830" y="550" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1806" y="260" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_BestekAkkoord_Gateway_BestekTrackJoin_di" bpmnElement="Flow_Gateway_BestekAkkoord_Gateway_BestekTrackJoin">
+        <di:waypoint x="1800" y="280" />
+        <di:waypoint x="2240" y="280" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1806" y="260" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_LatenAanpassenBestek_Task_ToetsenAanpassingenBestek_di" bpmnElement="Flow_Task_LatenAanpassenBestek_Task_ToetsenAanpassingenBestek">
+        <di:waypoint x="1930" y="550" />
+        <di:waypoint x="1960" y="550" />
+        <di:waypoint x="1960" y="280" />
+        <di:waypoint x="1990" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_ToetsenAanpassingenBestek_Gateway_AanpassingenBestekAkkoord_di" bpmnElement="Flow_Task_ToetsenAanpassingenBestek_Gateway_AanpassingenBestekAkkoord">
+        <di:waypoint x="2090" y="280" />
+        <di:waypoint x="2150" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_AanpassingenBestekAkkoord_Task_LatenAanpassenBestek_di" bpmnElement="Flow_Gateway_AanpassingenBestekAkkoord_Task_LatenAanpassenBestek">
+        <di:waypoint x="2175" y="305" />
+        <di:waypoint x="2175" y="340" />
+        <di:waypoint x="1880" y="340" />
+        <di:waypoint x="1880" y="590" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2181" y="285" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_AanpassingenBestekAkkoord_Gateway_BestekTrackJoin_di" bpmnElement="Flow_Gateway_AanpassingenBestekAkkoord_Gateway_BestekTrackJoin">
+        <di:waypoint x="2200" y="280" />
+        <di:waypoint x="2240" y="280" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2206" y="260" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_BestekTrackJoin_Gateway_ToetsingJoin_di" bpmnElement="Flow_Gateway_BestekTrackJoin_Gateway_ToetsingJoin">
+        <di:waypoint x="2290" y="280" />
+        <di:waypoint x="2310" y="280" />
+        <di:waypoint x="2310" y="550" />
+        <di:waypoint x="2330" y="550" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_ToetsingSplit_Task_ToetsenInschrijfleidraad_di" bpmnElement="Flow_Gateway_ToetsingSplit_Task_ToetsenInschrijfleidraad">
+        <di:waypoint x="1560" y="550" />
+        <di:waypoint x="1575" y="550" />
+        <di:waypoint x="1575" y="140" />
+        <di:waypoint x="1590" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_ToetsenInschrijfleidraad_Gateway_InschrijfleidraadAkkoord_di" bpmnElement="Flow_Task_ToetsenInschrijfleidraad_Gateway_InschrijfleidraadAkkoord">
+        <di:waypoint x="1690" y="140" />
+        <di:waypoint x="1750" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_InschrijfleidraadAkkoord_Task_LatenAanpassenInschrijfleidraad_di" bpmnElement="Flow_Gateway_InschrijfleidraadAkkoord_Task_LatenAanpassenInschrijfleidraad">
+        <di:waypoint x="1800" y="140" />
+        <di:waypoint x="1815" y="140" />
+        <di:waypoint x="1815" y="640" />
+        <di:waypoint x="1830" y="640" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1806" y="120" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_InschrijfleidraadAkkoord_Gateway_InschrijfleidraadTrackJoin_di" bpmnElement="Flow_Gateway_InschrijfleidraadAkkoord_Gateway_InschrijfleidraadTrackJoin">
+        <di:waypoint x="1800" y="140" />
+        <di:waypoint x="2240" y="140" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1806" y="120" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_LatenAanpassenInschrijfleidraad_Task_ToetsenAanpassingenInschrijfleidraad_di" bpmnElement="Flow_Task_LatenAanpassenInschrijfleidraad_Task_ToetsenAanpassingenInschrijfleidraad">
+        <di:waypoint x="1930" y="640" />
+        <di:waypoint x="1960" y="640" />
+        <di:waypoint x="1960" y="140" />
+        <di:waypoint x="1990" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_ToetsenAanpassingenInschrijfleidraad_Gateway_AanpassingenInschrijfleidraadAkkoord_di" bpmnElement="Flow_Task_ToetsenAanpassingenInschrijfleidraad_Gateway_AanpassingenInschrijfleidraadAkkoord">
+        <di:waypoint x="2090" y="140" />
+        <di:waypoint x="2150" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_AanpassingenInschrijfleidraadAkkoord_Task_LatenAanpassenInschrijfleidraad_di" bpmnElement="Flow_Gateway_AanpassingenInschrijfleidraadAkkoord_Task_LatenAanpassenInschrijfleidraad">
+        <di:waypoint x="2175" y="165" />
+        <di:waypoint x="2175" y="195" />
+        <di:waypoint x="1880" y="195" />
+        <di:waypoint x="1880" y="680" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2181" y="145" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_AanpassingenInschrijfleidraadAkkoord_Gateway_InschrijfleidraadTrackJoin_di" bpmnElement="Flow_Gateway_AanpassingenInschrijfleidraadAkkoord_Gateway_InschrijfleidraadTrackJoin">
+        <di:waypoint x="2200" y="140" />
+        <di:waypoint x="2240" y="140" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2206" y="120" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_InschrijfleidraadTrackJoin_Gateway_ToetsingJoin_di" bpmnElement="Flow_Gateway_InschrijfleidraadTrackJoin_Gateway_ToetsingJoin">
+        <di:waypoint x="2290" y="140" />
+        <di:waypoint x="2310" y="140" />
+        <di:waypoint x="2310" y="550" />
+        <di:waypoint x="2330" y="550" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_ToetsingJoin_EndEvent_R32_di" bpmnElement="Flow_Gateway_ToetsingJoin_EndEvent_R32">
+        <di:waypoint x="2380" y="550" />
+        <di:waypoint x="2410" y="550" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Assoc_Annotation_CO1_Maatregelenplan_di" bpmnElement="Assoc_Annotation_CO1_Maatregelenplan">
+        <di:waypoint x="1400" y="510" />
+        <di:waypoint x="1405" y="765" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Assoc_Annotation_CO1_InformerenAannemer_di" bpmnElement="Assoc_Annotation_CO1_InformerenAannemer">
+        <di:waypoint x="2355" y="525" />
+        <di:waypoint x="2370" y="765" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/examples/organizations/flevoland/rip-phase-31/rip-aanpassen-bestek.form
+++ b/examples/organizations/flevoland/rip-phase-31/rip-aanpassen-bestek.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-aanpassen-bestek",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Have the specification amended"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Have the bestek amended in line with the review findings."
+    },
+    {
+      "id": "F_Versie",
+      "type": "textfield",
+      "label": "Amended bestek version",
+      "key": "aangepastBestekVersie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Verwerkt",
+      "type": "textarea",
+      "label": "How the findings were incorporated",
+      "key": "verwerkteBevindingenBestek",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Aangepast",
+      "type": "datetime",
+      "label": "Amended on",
+      "key": "bestekAangepastOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-31/rip-aanpassen-bestekstekeningen.form
+++ b/examples/organizations/flevoland/rip-phase-31/rip-aanpassen-bestekstekeningen.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-aanpassen-bestekstekeningen",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Have the specification drawings amended"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Have the drawings amended in line with the findings."
+    },
+    {
+      "id": "F_Versie",
+      "type": "textfield",
+      "label": "Amended drawings version",
+      "key": "aangepasteBestekstekeningenVersie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Verwerkt",
+      "type": "textarea",
+      "label": "How the findings were incorporated",
+      "key": "verwerkteBevindingenBestekstekeningen",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Aangepast",
+      "type": "datetime",
+      "label": "Amended on",
+      "key": "bestekstekeningenAangepastOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-31/rip-aanpassen-inschrijfleidraad.form
+++ b/examples/organizations/flevoland/rip-phase-31/rip-aanpassen-inschrijfleidraad.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-aanpassen-inschrijfleidraad",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Have the tender guide amended"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Have the inschrijvingsleidraad amended in line with the review findings."
+    },
+    {
+      "id": "F_Versie",
+      "type": "textfield",
+      "label": "Amended guide version",
+      "key": "aangepasteInschrijfleidraadVersie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Verwerkt",
+      "type": "textarea",
+      "label": "How the findings were incorporated",
+      "key": "verwerkteBevindingenInschrijfleidraad",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Aangepast",
+      "type": "datetime",
+      "label": "Amended on",
+      "key": "inschrijfleidraadAangepastOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-31/rip-bestek.document
+++ b/examples/organizations/flevoland/rip-phase-31/rip-bestek.document
@@ -1,0 +1,225 @@
+{
+  "id": "rip-bestek",
+  "name": "RIP — Specification (Bestek incl. bijlagen)",
+  "description": "The bestek with annexes, the inschrijvingsleidraad and the SSK estimate, drawn up against the final drawings.",
+  "processKey": "RipR31Process",
+  "serviceId": "RipR31",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{bestekReferentie}}",
+      "variableKey": "bestekReferentie",
+      "source": "process",
+      "label": "Bestek reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{inschrijvingsleidraadReferentie}}",
+      "variableKey": "inschrijvingsleidraadReferentie",
+      "source": "process",
+      "label": "Inschrijvingsleidraad reference"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{sskRamingBestekReferentie}}",
+      "variableKey": "sskRamingBestekReferentie",
+      "source": "process",
+      "label": "SSK estimate reference"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{maatregelenplanReferentie}}",
+      "variableKey": "maatregelenplanReferentie",
+      "source": "process",
+      "label": "Maatregelenplan reference"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{risicodossierReferentie}}",
+      "variableKey": "risicodossierReferentie",
+      "source": "process",
+      "label": "Risk file reference"
+    },
+    {
+      "id": "b8",
+      "placeholder": "{{bestekGereedOp}}",
+      "variableKey": "bestekGereedOp",
+      "source": "process",
+      "label": "Delivered on"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Bestek {{bestekReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Specification",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Specification"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Bestek {{bestekReferentie}} for project {{projectNumber}} — {{projectName}} was delivered on {{bestekGereedOp}}, with inschrijvingsleidraad {{inschrijvingsleidraadReferentie}} and SSK estimate {{sskRamingBestekReferentie}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up against final drawings, risk file {{risicodossierReferentie}} and maatregelenplan {{maatregelenplanReferentie}}, using the UAV, the moederbestek format and the inschrijvingsleidraad format."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Bestek and inschrijvingsleidraad are reviewed in parallel; each is amended and re-reviewed on its own track until approved."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up by the external party"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-31/rip-bevindingenformulier-bestek.document
+++ b/examples/organizations/flevoland/rip-phase-31/rip-bevindingenformulier-bestek.document
@@ -1,0 +1,218 @@
+{
+  "id": "rip-bevindingenformulier-bestek",
+  "name": "RIP — Findings Form, specification (Bevindingenformulier)",
+  "description": "Records the review findings on the bestek.",
+  "processKey": "RipR31Process",
+  "serviceId": "RipR31",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{bevindingenBestekReferentie}}",
+      "variableKey": "bevindingenBestekReferentie",
+      "source": "process",
+      "label": "Findings form reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{bestekReferentie}}",
+      "variableKey": "bestekReferentie",
+      "source": "process",
+      "label": "Bestek reference"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{bevindingenBestek}}",
+      "variableKey": "bevindingenBestek",
+      "source": "process",
+      "label": "Findings"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{bestekAkkoord}}",
+      "variableKey": "bestekAkkoord",
+      "source": "process",
+      "label": "Outcome"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{bestekGetoetstOp}}",
+      "variableKey": "bestekGetoetstOp",
+      "source": "process",
+      "label": "Reviewed on"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Findings {{bevindingenBestekReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Findings on the specification",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Findings on the specification"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Bestek {{bestekReferentie}} was reviewed on {{bestekGetoetstOp}} for project {{projectNumber}} — {{projectName}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Findings: {{bevindingenBestek}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Outcome: {{bestekAkkoord}}."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Recorded by the review team"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-31/rip-bevindingenformulier-bestekstekeningen.document
+++ b/examples/organizations/flevoland/rip-phase-31/rip-bevindingenformulier-bestekstekeningen.document
@@ -1,0 +1,218 @@
+{
+  "id": "rip-bevindingenformulier-bestekstekeningen",
+  "name": "RIP — Findings Form, specification drawings (Bevindingenformulier)",
+  "description": "Records the review findings on the draft bestekstekeningen.",
+  "processKey": "RipR31Process",
+  "serviceId": "RipR31",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{bevindingenBestekstekeningenReferentie}}",
+      "variableKey": "bevindingenBestekstekeningenReferentie",
+      "source": "process",
+      "label": "Findings form reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{conceptBestekstekeningenReferentie}}",
+      "variableKey": "conceptBestekstekeningenReferentie",
+      "source": "process",
+      "label": "Draft drawings reference"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{bevindingenBestekstekeningen}}",
+      "variableKey": "bevindingenBestekstekeningen",
+      "source": "process",
+      "label": "Findings"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{conceptBestekstekeningenAkkoord}}",
+      "variableKey": "conceptBestekstekeningenAkkoord",
+      "source": "process",
+      "label": "Outcome"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{bestekstekeningenGetoetstOp}}",
+      "variableKey": "bestekstekeningenGetoetstOp",
+      "source": "process",
+      "label": "Reviewed on"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Findings {{bevindingenBestekstekeningenReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Findings on the draft drawings",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Findings on the draft drawings"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Draft bestekstekeningen {{conceptBestekstekeningenReferentie}} were reviewed on {{bestekstekeningenGetoetstOp}} for project {{projectNumber}} — {{projectName}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Findings: {{bevindingenBestekstekeningen}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Outcome: {{conceptBestekstekeningenAkkoord}}. Where not approved, the drawings are amended and the amendments re-reviewed before they are made final."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Recorded by the review team"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-31/rip-bevindingenformulier-inschrijfleidraad.document
+++ b/examples/organizations/flevoland/rip-phase-31/rip-bevindingenformulier-inschrijfleidraad.document
@@ -1,0 +1,218 @@
+{
+  "id": "rip-bevindingenformulier-inschrijfleidraad",
+  "name": "RIP — Findings Form, tender guide (Bevindingenformulier)",
+  "description": "Records the review findings on the inschrijvingsleidraad.",
+  "processKey": "RipR31Process",
+  "serviceId": "RipR31",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{bevindingenInschrijfleidraadReferentie}}",
+      "variableKey": "bevindingenInschrijfleidraadReferentie",
+      "source": "process",
+      "label": "Findings form reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{inschrijvingsleidraadReferentie}}",
+      "variableKey": "inschrijvingsleidraadReferentie",
+      "source": "process",
+      "label": "Inschrijvingsleidraad reference"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{bevindingenInschrijfleidraad}}",
+      "variableKey": "bevindingenInschrijfleidraad",
+      "source": "process",
+      "label": "Findings"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{inschrijfleidraadAkkoord}}",
+      "variableKey": "inschrijfleidraadAkkoord",
+      "source": "process",
+      "label": "Outcome"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{inschrijfleidraadGetoetstOp}}",
+      "variableKey": "inschrijfleidraadGetoetstOp",
+      "source": "process",
+      "label": "Reviewed on"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Findings {{bevindingenInschrijfleidraadReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Findings on the tender guide",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Findings on the tender guide"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Inschrijvingsleidraad {{inschrijvingsleidraadReferentie}} was reviewed on {{inschrijfleidraadGetoetstOp}} for project {{projectNumber}} — {{projectName}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Findings: {{bevindingenInschrijfleidraad}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Outcome: {{inschrijfleidraadAkkoord}}."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Recorded by the review team"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-31/rip-concept-bestekstekeningen.document
+++ b/examples/organizations/flevoland/rip-phase-31/rip-concept-bestekstekeningen.document
@@ -1,0 +1,209 @@
+{
+  "id": "rip-concept-bestekstekeningen",
+  "name": "RIP — Draft Specification Drawings (Concept bestekstekeningen)",
+  "description": "The draft bestekstekeningen produced from the final DO at the start of R3.1.",
+  "processKey": "RipR31Process",
+  "serviceId": "RipR31",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{conceptBestekstekeningenReferentie}}",
+      "variableKey": "conceptBestekstekeningenReferentie",
+      "source": "process",
+      "label": "Draft drawings reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{conceptBestekstekeningenGereedOp}}",
+      "variableKey": "conceptBestekstekeningenGereedOp",
+      "source": "process",
+      "label": "Delivered on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{doReferentie}}",
+      "variableKey": "doReferentie",
+      "source": "process",
+      "label": "Final DO reference"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{ontwerptoelichtingReferentie}}",
+      "variableKey": "ontwerptoelichtingReferentie",
+      "source": "process",
+      "label": "Design rationale reference"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{uitvraagReferentie}}",
+      "variableKey": "uitvraagReferentie",
+      "source": "process",
+      "label": "Uitvraag reference"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Draft drawings {{conceptBestekstekeningenReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Draft specification drawings",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Draft specification drawings"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Draft bestekstekeningen {{conceptBestekstekeningenReferentie}} for project {{projectNumber}} — {{projectName}} were delivered on {{conceptBestekstekeningenGereedOp}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn from final DO {{doReferentie}} and design rationale {{ontwerptoelichtingReferentie}}, against uitvraag {{uitvraagReferentie}}."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up by the designer"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-31/rip-concept-bestekstekeningen.form
+++ b/examples/organizations/flevoland/rip-phase-31/rip-concept-bestekstekeningen.form
@@ -1,0 +1,67 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-concept-bestekstekeningen",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Have the draft specification drawings drawn up"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Have the draft bestekstekeningen produced from the final DO and the design rationale carried over from R2.4."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Draft drawings reference",
+      "key": "conceptBestekstekeningenReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_DO",
+      "type": "textfield",
+      "label": "Final DO reference (from R2.4)",
+      "key": "doReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Ontwerp",
+      "type": "textfield",
+      "label": "Design rationale reference",
+      "key": "ontwerptoelichtingReferentie"
+    },
+    {
+      "id": "F_Uitvraag",
+      "type": "textfield",
+      "label": "Uitvraag werkzaamheden reference",
+      "key": "uitvraagReferentie"
+    },
+    {
+      "id": "F_Gereed",
+      "type": "datetime",
+      "label": "Delivered on",
+      "key": "conceptBestekstekeningenGereedOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-31/rip-definitieve-bestekstekeningen.document
+++ b/examples/organizations/flevoland/rip-phase-31/rip-definitieve-bestekstekeningen.document
@@ -1,0 +1,195 @@
+{
+  "id": "rip-definitieve-bestekstekeningen",
+  "name": "RIP — Final Specification Drawings (Definitieve bestekstekeningen)",
+  "description": "The approved drawings made final, against which the bestek is drawn up.",
+  "processKey": "RipR31Process",
+  "serviceId": "RipR31",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{definitieveBestekstekeningenReferentie}}",
+      "variableKey": "definitieveBestekstekeningenReferentie",
+      "source": "process",
+      "label": "Final drawings reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{definitieveBestekstekeningenGereedOp}}",
+      "variableKey": "definitieveBestekstekeningenGereedOp",
+      "source": "process",
+      "label": "Finalised on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{definitieveBestekstekeningenOpmerkingen}}",
+      "variableKey": "definitieveBestekstekeningenOpmerkingen",
+      "source": "process",
+      "label": "Notes"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Final drawings {{definitieveBestekstekeningenReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Final specification drawings",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Final specification drawings"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Final bestekstekeningen {{definitieveBestekstekeningenReferentie}} for project {{projectNumber}} — {{projectName}} were finalised on {{definitieveBestekstekeningenGereedOp}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Notes: {{definitieveBestekstekeningenOpmerkingen}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up by the designer"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-31/rip-definitieve-bestekstekeningen.form
+++ b/examples/organizations/flevoland/rip-phase-31/rip-definitieve-bestekstekeningen.form
@@ -1,0 +1,52 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-definitieve-bestekstekeningen",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Have the drawings finalised"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Have the approved draft drawings made final, so the specification can be drawn up against them."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Final drawings reference",
+      "key": "definitieveBestekstekeningenReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Gereed",
+      "type": "datetime",
+      "label": "Finalised on",
+      "key": "definitieveBestekstekeningenGereedOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Notes",
+      "key": "definitieveBestekstekeningenOpmerkingen"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-31/rip-opstellen-bestek.form
+++ b/examples/organizations/flevoland/rip-phase-31/rip-opstellen-bestek.form
@@ -1,0 +1,76 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-opstellen-bestek",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Have the specification drawn up"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Have the bestek, the inschrijvingsleidraad and the SSK estimate drawn up against the final drawings, the risk file, the V&G plan, the ILS, the maatregelenplan, the UAV and the moederbestek and inschrijvingsleidraad formats."
+    },
+    {
+      "id": "F_Bestek",
+      "type": "textfield",
+      "label": "Bestek reference (incl. annexes)",
+      "key": "bestekReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Leidraad",
+      "type": "textfield",
+      "label": "Inschrijvingsleidraad reference",
+      "key": "inschrijvingsleidraadReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_SSK",
+      "type": "textfield",
+      "label": "SSK estimate reference",
+      "key": "sskRamingBestekReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Maatregelen",
+      "type": "textfield",
+      "label": "Maatregelenplan reference (CO1.)",
+      "key": "maatregelenplanReferentie"
+    },
+    {
+      "id": "F_Risico",
+      "type": "textfield",
+      "label": "Risk file reference",
+      "key": "risicodossierReferentie"
+    },
+    {
+      "id": "F_Gereed",
+      "type": "datetime",
+      "label": "Delivered on",
+      "key": "bestekGereedOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-31/rip-toetsen-aanpassingen-bestek.form
+++ b/examples/organizations/flevoland/rip-phase-31/rip-toetsen-aanpassingen-bestek.form
@@ -1,0 +1,62 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-toetsen-aanpassingen-bestek",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Review the specification amendments"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Check whether the amendments address the findings raised on the bestek."
+    },
+    {
+      "id": "F_Akkoord",
+      "type": "select",
+      "label": "Amendments approved",
+      "key": "aanpassingenBestekAkkoord",
+      "values": [
+        {
+          "label": "Yes — approved",
+          "value": "ja"
+        },
+        {
+          "label": "No — amendment required",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Review comments",
+      "key": "aanpassingenBestekOpmerkingen"
+    },
+    {
+      "id": "F_Getoetst",
+      "type": "datetime",
+      "label": "Reviewed on",
+      "key": "aanpassingenBestekGetoetstOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-31/rip-toetsen-aanpassingen-bestekstekeningen.form
+++ b/examples/organizations/flevoland/rip-phase-31/rip-toetsen-aanpassingen-bestekstekeningen.form
@@ -1,0 +1,62 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-toetsen-aanpassingen-bestekstekeningen",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Review the drawing amendments"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Check whether the amendments address the findings raised on the draft drawings."
+    },
+    {
+      "id": "F_Akkoord",
+      "type": "select",
+      "label": "Amendments approved",
+      "key": "aanpassingenBestekstekeningenAkkoord",
+      "values": [
+        {
+          "label": "Yes — approved",
+          "value": "ja"
+        },
+        {
+          "label": "No — amendment required",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Review comments",
+      "key": "aanpassingenBestekstekeningenOpmerkingen"
+    },
+    {
+      "id": "F_Getoetst",
+      "type": "datetime",
+      "label": "Reviewed on",
+      "key": "aanpassingenBestekstekeningenGetoetstOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-31/rip-toetsen-aanpassingen-inschrijfleidraad.form
+++ b/examples/organizations/flevoland/rip-phase-31/rip-toetsen-aanpassingen-inschrijfleidraad.form
@@ -1,0 +1,62 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-toetsen-aanpassingen-inschrijfleidraad",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Review the tender guide amendments"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Check whether the amendments address the findings raised on the inschrijvingsleidraad."
+    },
+    {
+      "id": "F_Akkoord",
+      "type": "select",
+      "label": "Amendments approved",
+      "key": "aanpassingenInschrijfleidraadAkkoord",
+      "values": [
+        {
+          "label": "Yes — approved",
+          "value": "ja"
+        },
+        {
+          "label": "No — amendment required",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Review comments",
+      "key": "aanpassingenInschrijfleidraadOpmerkingen"
+    },
+    {
+      "id": "F_Getoetst",
+      "type": "datetime",
+      "label": "Reviewed on",
+      "key": "aanpassingenInschrijfleidraadGetoetstOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-31/rip-toetsen-bestek.form
+++ b/examples/organizations/flevoland/rip-phase-31/rip-toetsen-bestek.form
@@ -1,0 +1,74 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-toetsen-bestek",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Review the specification"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Vaste lezers and risicogestuurd lezen review the bestek against the drawings and the SSK estimate, and record the findings."
+    },
+    {
+      "id": "F_Bev",
+      "type": "textfield",
+      "label": "Findings form reference",
+      "key": "bevindingenBestekReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bevindingen",
+      "type": "textarea",
+      "label": "Findings",
+      "key": "bevindingenBestek",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Akkoord",
+      "type": "select",
+      "label": "Bestek approved",
+      "key": "bestekAkkoord",
+      "values": [
+        {
+          "label": "Yes — approved",
+          "value": "ja"
+        },
+        {
+          "label": "No — amendment required",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Getoetst",
+      "type": "datetime",
+      "label": "Reviewed on",
+      "key": "bestekGetoetstOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-31/rip-toetsen-concept-bestekstekeningen.form
+++ b/examples/organizations/flevoland/rip-phase-31/rip-toetsen-concept-bestekstekeningen.form
@@ -1,0 +1,74 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-toetsen-concept-bestekstekeningen",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Review the draft specification drawings"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Vaste lezers and risicogestuurd lezen review the draft bestekstekeningen and record the findings."
+    },
+    {
+      "id": "F_Bev",
+      "type": "textfield",
+      "label": "Findings form reference",
+      "key": "bevindingenBestekstekeningenReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bevindingen",
+      "type": "textarea",
+      "label": "Findings",
+      "key": "bevindingenBestekstekeningen",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Akkoord",
+      "type": "select",
+      "label": "Draft drawings approved",
+      "key": "conceptBestekstekeningenAkkoord",
+      "values": [
+        {
+          "label": "Yes — approved",
+          "value": "ja"
+        },
+        {
+          "label": "No — amendment required",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Getoetst",
+      "type": "datetime",
+      "label": "Reviewed on",
+      "key": "bestekstekeningenGetoetstOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-31/rip-toetsen-inschrijfleidraad.form
+++ b/examples/organizations/flevoland/rip-phase-31/rip-toetsen-inschrijfleidraad.form
@@ -1,0 +1,74 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-toetsen-inschrijfleidraad",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Review the tender guide"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Kosten- en contractdeskundige and inkoopadviseur werken review the inschrijvingsleidraad and record the findings."
+    },
+    {
+      "id": "F_Bev",
+      "type": "textfield",
+      "label": "Findings form reference",
+      "key": "bevindingenInschrijfleidraadReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bevindingen",
+      "type": "textarea",
+      "label": "Findings",
+      "key": "bevindingenInschrijfleidraad",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Akkoord",
+      "type": "select",
+      "label": "Inschrijvingsleidraad approved",
+      "key": "inschrijfleidraadAkkoord",
+      "values": [
+        {
+          "label": "Yes — approved",
+          "value": "ja"
+        },
+        {
+          "label": "No — amendment required",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Getoetst",
+      "type": "datetime",
+      "label": "Reviewed on",
+      "key": "inschrijfleidraadGetoetstOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}


### PR DESCRIPTION
> **Stacked on #54 (R2.4), which is stacked on #53 (R2.3).** Base is `feat/rip-phase-24`, so this PR shows only R3.1's 19 files. GitHub retargets it as the stack merges down.

Models **R3.1 (Opstellen bestek en tekeningen)** from `rip-phases-left/R3. Contractvorming/R3_1 Opstellen bestek en tekeningen.pdf` (sheet dated 17-3-2026). First phase of stage R3.

`RipR31Process` — 25 flow nodes, 31 sequence flows, 4 lanes, 12 forms, 6 document templates.

## Flow

```
Start (from R2.4)
 └─ Laten opstellen concept bestekstekeningen   (Projectleider)
 └─ Toetsen concept bestekstekeningen  (Ontwerper, Directievoerder,
                                        Projectleider, Technisch adviseur)
 └─ XOR Akkoord?
      ├─ nee → Laten aanpassen bestekstekeningen
      │         └─ Toetsen aanpassingen bestekstekeningen
      │              └─ XOR Akkoord?  nee ⟲ · ja ↓
      └─ ja ─────────────────────────────────────┐
 └─ Definitief laten maken concept bestekstekeningen
 └─ Laten opstellen bestek
 └─ AND split
      ├─ Toetsen bestek       (KC, Omgevingsmanager, Directievoerder,
      │                        Toezichthouder, Projectleider)
      │    └─ XOR Akkoord?
      │         ├─ nee → Laten aanpassen bestek
      │         │         └─ Toetsen aanpassingen bestek
      │         │              └─ XOR Akkoord?  nee ⟲ · ja → join
      │         └─ ja → join
      └─ Toetsen inschrijfleidraad   (KC, Inkoopadviseur werken, Projectleider)
           └─ XOR Akkoord?
                ├─ nee → Laten aanpassen inschrijfleidraad
                │         └─ Toetsen aanpassingen inschrijfleidraad
                │              └─ XOR Akkoord?  nee ⟲ · ja → join
                └─ ja → join
 └─ AND join → R3.2
```

## Modelling decision

The sheet draws **one shared "Toetsen aanpassingen" box** after both the bestek and inschrijfleidraad reviews. This is modelled as **one re-check per document**, so each rework loop re-enters exactly where it left — mirroring the bestekstekeningen pattern earlier on the same sheet.

The alternative (one shared re-check after the join) would re-run *both* reviews on rejection even when only one document was amended, because a single XOR cannot express "back to whichever was amended". Trade-off: two `Toetsen aanpassingen` tasks where the sheet draws one.

## Faseladder contract

| | Item | State |
|---|---|---|
| 1 | Process-definition key | `RipR31Process` |
| 2 | Tenant `flevoland` | at deploy |
| 3 | `municipality` untouched; no form sets a board-supplied variable | verified |
| 4 | `businessKey` | 0 |
| 5 | External-task topics | **none** — no serviceTasks |
| 6 | `formRefBinding="deployment"` | all 12, zero `latest` |

No `leadRole` is set. Per the RBA session, `leadRole` is a process variable validated against rip-model's **unprefixed** `ROLES` keys — a different vocabulary from `candidateGroups` — and `normalizeLeadRole` silently degrades an unknown value to `projectleider`. Setting nothing means the intended fallback applies.

`boardOwner` and `ronl:organization` stay unauthored; the deploy path injects them.

**Four new candidate groups**: `rip-directievoerder`, `rip-inkoopadviseur-werken`, `rip-technisch-adviseur`, `rip-toezichthouder`. All match `rip-[\w-]+` → `infra-board`. RBA passes candidateGroups straight through to Operaton and never enumerates them, so nothing is needed there.

## Spelling note

This sheet writes **`bestekstekeningen`** throughout. R2.4's older sheet (12-8-2025) writes `bestek-tekeningen` in its forward reference. The newer R3.1 sheet governs its own naming.

## Ladder

Entry is the project plan adopted at the close of the DO phase — R2.4's exit. Closes on the reviewed contract and tender documents, which is R3.2's entry.

## Verification

All five bundles validated together on this branch:

```
R2.1  bpmn: OK   bundle: OK
R2.2  bpmn: OK   bundle: OK
R2.3  bpmn: OK   bundle: OK
R2.4  bpmn: OK   bundle: OK
R3.1  bpmn: OK   bundle: OK

id collisions across all five: none
```

Both checkers passed on the first generator run — no coordinate iteration.

## Not deployed

Engine still carries only `RipR21Process` and `RipR22Process`.
