### PR TITLE
feat(rip): add R3.2 Afronding bestek en tekeningen bundle for Flevoland

### DIFF
--- a/examples/organizations/flevoland/rip-phase-32/RipR32Process.bpmn
+++ b/examples/organizations/flevoland/rip-phase-32/RipR32Process.bpmn
@@ -1,0 +1,497 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:ronl="http://ronl.nl/schema/1.0" id="Definitions_RipR32Process" targetNamespace="http://example.com/rip-phase-32" exporter="Camunda Modeler" exporterVersion="5.45.0">
+  <bpmn:collaboration id="Collaboration_RipR32Process">
+    <bpmn:participant id="Participant_RipR32Process" name="R3.2 - Afronding bestek en tekeningen" processRef="RipR32Process" />
+  </bpmn:collaboration>
+  <bpmn:process id="RipR32Process" name="R3.2 - Afronding bestek en tekeningen" isExecutable="true" camunda:historyTimeToLive="180">
+    <bpmn:laneSet id="LaneSet_RipR32Process">
+      <bpmn:lane id="Lane_DirectievoerderVestigingsmanager" name="Directievoerder, Vestigingsmanager">
+        <bpmn:flowNodeRef>Task_BeoordelenConceptToezichtplan</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_ToezichtplanAkkoord</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_AccorderenVersturenConceptToezichtplan</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_Projectleider" name="Projectleider">
+        <bpmn:flowNodeRef>StartEvent_R32</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_VerzamelenDocumenten</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_StrandSplit</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_OpstellenVersturenConceptToezichtplan</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_AanpassenConceptToezichtplan</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_OntvangenGeaccordeerdToezichtplan</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_OntvangenProjectramingBestekPl</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_VersturenGeaccordeerdeProjectraming</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_OpstellenMemoProjectkredietBestek</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_StrandJoin</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_VersturenGetoetsteDocumenten</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_AccorderenProjectplanContractvorming</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndEvent_R41</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_AO" name="AO">
+        <bpmn:flowNodeRef>Task_AccorderenProjectramingBestek</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_ProjectramingAkkoord</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_KredietJoin</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_KostenContractdeskundige" name="Kosten- en contractdeskundige">
+        <bpmn:flowNodeRef>Task_OpstellenProjectramingBestek</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_OntvangstSplit</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_OntvangenProjectramingBestekKcd</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_OntvangstJoin</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_InfraOverleg" name="Infra-overleg">
+        <bpmn:flowNodeRef>Task_BesluitenOverProjectkredietBestek</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_Financien" name="Financiën">
+        <bpmn:flowNodeRef>Task_AccorderenBeschikbaarKrediet</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_VerwerkenProjectramingBestek</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_DeelnemersEvaluatie" name="Deelnemers evaluatie">
+        <bpmn:flowNodeRef>Task_EvaluerenContractvorming</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+
+    <bpmn:startEvent id="StartEvent_R32" name="Start R3.2 - Afronding bestek&#10;en tekeningen (vanuit R3.1)">
+      <bpmn:outgoing>Flow_StartEvent_R32_Task_VerzamelenDocumenten</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:userTask id="Task_VerzamelenDocumenten" name="Verzamelen getoetste contract-&#10;en aanbestedingsdocumenten" camunda:formRef="rip-verzamelen-contractdocumenten" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-contractdocumenten">
+      <bpmn:incoming>Flow_StartEvent_R32_Task_VerzamelenDocumenten</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_VerzamelenDocumenten_Gateway_StrandSplit</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:parallelGateway id="Gateway_StrandSplit">
+      <bpmn:incoming>Flow_Task_VerzamelenDocumenten_Gateway_StrandSplit</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_StrandSplit_Task_OpstellenVersturenConceptToezichtplan</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_StrandSplit_Task_OpstellenProjectramingBestek</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:userTask id="Task_OpstellenVersturenConceptToezichtplan" name="Opstellen en versturen&#10;concept toezichtplan" camunda:formRef="rip-opstellen-concept-toezichtplan" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-concept-toezichtplan">
+      <bpmn:incoming>Flow_Gateway_StrandSplit_Task_OpstellenVersturenConceptToezichtplan</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_OpstellenVersturenConceptToezichtplan_Task_BeoordelenConceptToezichtplan</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_BeoordelenConceptToezichtplan" name="Beoordelen&#10;concept toezichtplan" camunda:formRef="rip-beoordelen-concept-toezichtplan" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-directievoerder,rip-vestigingsmanager">
+      <bpmn:incoming>Flow_Task_OpstellenVersturenConceptToezichtplan_Task_BeoordelenConceptToezichtplan</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_AanpassenConceptToezichtplan_Task_BeoordelenConceptToezichtplan</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_BeoordelenConceptToezichtplan_Gateway_ToezichtplanAkkoord</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_ToezichtplanAkkoord" name="Akkoord?">
+      <bpmn:incoming>Flow_Task_BeoordelenConceptToezichtplan_Gateway_ToezichtplanAkkoord</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_ToezichtplanAkkoord_Task_AanpassenConceptToezichtplan</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_ToezichtplanAkkoord_Task_AccorderenVersturenConceptToezichtplan</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_AanpassenConceptToezichtplan" name="Aanpassen&#10;concept toezichtplan" camunda:formRef="rip-aanpassen-concept-toezichtplan" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
+      <bpmn:incoming>Flow_Gateway_ToezichtplanAkkoord_Task_AanpassenConceptToezichtplan</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_AanpassenConceptToezichtplan_Task_BeoordelenConceptToezichtplan</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_AccorderenVersturenConceptToezichtplan" name="Accorderen en versturen&#10;concept toezichtplan" camunda:formRef="rip-accorderen-concept-toezichtplan" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-directievoerder,rip-vestigingsmanager">
+      <bpmn:incoming>Flow_Gateway_ToezichtplanAkkoord_Task_AccorderenVersturenConceptToezichtplan</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_AccorderenVersturenConceptToezichtplan_Task_OntvangenGeaccordeerdToezichtplan</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_OntvangenGeaccordeerdToezichtplan" name="Ontvangen geaccordeerd&#10;concept toezichtplan" camunda:formRef="rip-ontvangen-geaccordeerd-toezichtplan" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
+      <bpmn:incoming>Flow_Task_AccorderenVersturenConceptToezichtplan_Task_OntvangenGeaccordeerdToezichtplan</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_OntvangenGeaccordeerdToezichtplan_Gateway_StrandJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_OpstellenProjectramingBestek" name="Opstellen&#10;projectraming bestek" camunda:formRef="rip-opstellen-projectraming-bestek" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-kosten-contractdeskundige" ronl:documentRef="rip-projectraming-bestek">
+      <bpmn:incoming>Flow_Gateway_StrandSplit_Task_OpstellenProjectramingBestek</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_OpstellenProjectramingBestek_Task_AccorderenBeschikbaarKrediet</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_AccorderenBeschikbaarKrediet" name="Accorderen beschikbaar krediet&#10;en versturen naar PL en KCD" camunda:formRef="rip-accorderen-beschikbaar-krediet-bestek" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-financien">
+      <bpmn:incoming>Flow_Task_OpstellenProjectramingBestek_Task_AccorderenBeschikbaarKrediet</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_AccorderenBeschikbaarKrediet_Gateway_OntvangstSplit</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:parallelGateway id="Gateway_OntvangstSplit">
+      <bpmn:incoming>Flow_Task_AccorderenBeschikbaarKrediet_Gateway_OntvangstSplit</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_OntvangstSplit_Task_OntvangenProjectramingBestekKcd</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_OntvangstSplit_Task_OntvangenProjectramingBestekPl</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:userTask id="Task_OntvangenProjectramingBestekKcd" name="Ontvangen&#10;projectraming bestek" camunda:formRef="rip-ontvangen-projectraming-bestek-kcd" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-kosten-contractdeskundige">
+      <bpmn:incoming>Flow_Gateway_OntvangstSplit_Task_OntvangenProjectramingBestekKcd</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_OntvangenProjectramingBestekKcd_Gateway_OntvangstJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_OntvangenProjectramingBestekPl" name="Ontvangen&#10;projectraming bestek" camunda:formRef="rip-ontvangen-projectraming-bestek-pl" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
+      <bpmn:incoming>Flow_Gateway_OntvangstSplit_Task_OntvangenProjectramingBestekPl</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_OntvangenProjectramingBestekPl_Task_VersturenGeaccordeerdeProjectraming</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_VersturenGeaccordeerdeProjectraming" name="Versturen geaccordeerde&#10;projectraming bestek" camunda:formRef="rip-versturen-geaccordeerde-projectraming" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
+      <bpmn:incoming>Flow_Task_OntvangenProjectramingBestekPl_Task_VersturenGeaccordeerdeProjectraming</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_VersturenGeaccordeerdeProjectraming_Gateway_OntvangstJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:parallelGateway id="Gateway_OntvangstJoin">
+      <bpmn:incoming>Flow_Task_OntvangenProjectramingBestekKcd_Gateway_OntvangstJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_VersturenGeaccordeerdeProjectraming_Gateway_OntvangstJoin</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_OntvangstJoin_Task_AccorderenProjectramingBestek</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:userTask id="Task_AccorderenProjectramingBestek" name="Accorderen&#10;projectraming bestek" camunda:formRef="rip-accorderen-projectraming-bestek" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-ao">
+      <bpmn:incoming>Flow_Gateway_OntvangstJoin_Task_AccorderenProjectramingBestek</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_AccorderenProjectramingBestek_Gateway_ProjectramingAkkoord</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_ProjectramingAkkoord" name="Akkoord&#10;projectraming bestek?">
+      <bpmn:incoming>Flow_Task_AccorderenProjectramingBestek_Gateway_ProjectramingAkkoord</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_ProjectramingAkkoord_Task_OpstellenMemoProjectkredietBestek</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_ProjectramingAkkoord_Gateway_KredietJoin</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_OpstellenMemoProjectkredietBestek" name="Opstellen memo projectkrediet&#10;(zachte claim)" camunda:formRef="rip-memo-projectkrediet-bestek" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-memo-projectkrediet-bestek">
+      <bpmn:incoming>Flow_Gateway_ProjectramingAkkoord_Task_OpstellenMemoProjectkredietBestek</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_OpstellenMemoProjectkredietBestek_Task_BesluitenOverProjectkredietBestek</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_BesluitenOverProjectkredietBestek" name="Besluiten over&#10;projectkrediet" camunda:formRef="rip-besluiten-projectkrediet-bestek" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-infra-overleg" ronl:documentRef="rip-besluit-projectkrediet-bestek">
+      <bpmn:incoming>Flow_Task_OpstellenMemoProjectkredietBestek_Task_BesluitenOverProjectkredietBestek</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_BesluitenOverProjectkredietBestek_Task_VerwerkenProjectramingBestek</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_VerwerkenProjectramingBestek" name="Verwerken projectraming&#10;en raamkrediet Infra" camunda:formRef="rip-verwerken-projectraming-bestek" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-financien">
+      <bpmn:incoming>Flow_Task_BesluitenOverProjectkredietBestek_Task_VerwerkenProjectramingBestek</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_VerwerkenProjectramingBestek_Gateway_KredietJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_KredietJoin">
+      <bpmn:incoming>Flow_Gateway_ProjectramingAkkoord_Gateway_KredietJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_VerwerkenProjectramingBestek_Gateway_KredietJoin</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_KredietJoin_Gateway_StrandJoin</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:parallelGateway id="Gateway_StrandJoin">
+      <bpmn:incoming>Flow_Task_OntvangenGeaccordeerdToezichtplan_Gateway_StrandJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Gateway_KredietJoin_Gateway_StrandJoin</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_StrandJoin_Task_VersturenGetoetsteDocumenten</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:userTask id="Task_VersturenGetoetsteDocumenten" name="Versturen getoetste contract-&#10;en aanbestedingsdocumenten" camunda:formRef="rip-versturen-contractdocumenten" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
+      <bpmn:incoming>Flow_Gateway_StrandJoin_Task_VersturenGetoetsteDocumenten</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_VersturenGetoetsteDocumenten_Task_EvaluerenContractvorming</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_EvaluerenContractvorming" name="Evalueren&#10;contractvorming" camunda:formRef="rip-evalueren-contractvorming" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-deelnemers-evaluatie" ronl:documentRef="rip-evaluatie-contractvorming">
+      <bpmn:incoming>Flow_Task_VersturenGetoetsteDocumenten_Task_EvaluerenContractvorming</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_EvaluerenContractvorming_Task_AccorderenProjectplanContractvorming</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_AccorderenProjectplanContractvorming" name="Accorderen Projectplan&#10;7. Afronden contractvormingsfase" camunda:formRef="rip-accorderen-projectplan-contractvorming" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-projectplan-contractvorming">
+      <bpmn:incoming>Flow_Task_EvaluerenContractvorming_Task_AccorderenProjectplanContractvorming</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_AccorderenProjectplanContractvorming_EndEvent_R41</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_R41" name="Vastgesteld Projectplan (contractvorming)&#10;→ R4.1 Verzoeken tot aanbesteden">
+      <bpmn:incoming>Flow_Task_AccorderenProjectplanContractvorming_EndEvent_R41</bpmn:incoming>
+    </bpmn:endEvent>
+
+    <bpmn:sequenceFlow id="Flow_StartEvent_R32_Task_VerzamelenDocumenten" sourceRef="StartEvent_R32" targetRef="Task_VerzamelenDocumenten" />
+    <bpmn:sequenceFlow id="Flow_Task_VerzamelenDocumenten_Gateway_StrandSplit" sourceRef="Task_VerzamelenDocumenten" targetRef="Gateway_StrandSplit" />
+    <bpmn:sequenceFlow id="Flow_Gateway_StrandSplit_Task_OpstellenVersturenConceptToezichtplan" sourceRef="Gateway_StrandSplit" targetRef="Task_OpstellenVersturenConceptToezichtplan" />
+    <bpmn:sequenceFlow id="Flow_Task_OpstellenVersturenConceptToezichtplan_Task_BeoordelenConceptToezichtplan" sourceRef="Task_OpstellenVersturenConceptToezichtplan" targetRef="Task_BeoordelenConceptToezichtplan" />
+    <bpmn:sequenceFlow id="Flow_Task_BeoordelenConceptToezichtplan_Gateway_ToezichtplanAkkoord" sourceRef="Task_BeoordelenConceptToezichtplan" targetRef="Gateway_ToezichtplanAkkoord" />
+    <bpmn:sequenceFlow id="Flow_Gateway_ToezichtplanAkkoord_Task_AanpassenConceptToezichtplan" name="nee" sourceRef="Gateway_ToezichtplanAkkoord" targetRef="Task_AanpassenConceptToezichtplan">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${toezichtplanAkkoord == "nee"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_ToezichtplanAkkoord_Task_AccorderenVersturenConceptToezichtplan" name="ja" sourceRef="Gateway_ToezichtplanAkkoord" targetRef="Task_AccorderenVersturenConceptToezichtplan">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${toezichtplanAkkoord == "ja"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Task_AanpassenConceptToezichtplan_Task_BeoordelenConceptToezichtplan" sourceRef="Task_AanpassenConceptToezichtplan" targetRef="Task_BeoordelenConceptToezichtplan" />
+    <bpmn:sequenceFlow id="Flow_Task_AccorderenVersturenConceptToezichtplan_Task_OntvangenGeaccordeerdToezichtplan" sourceRef="Task_AccorderenVersturenConceptToezichtplan" targetRef="Task_OntvangenGeaccordeerdToezichtplan" />
+    <bpmn:sequenceFlow id="Flow_Task_OntvangenGeaccordeerdToezichtplan_Gateway_StrandJoin" sourceRef="Task_OntvangenGeaccordeerdToezichtplan" targetRef="Gateway_StrandJoin" />
+    <bpmn:sequenceFlow id="Flow_Gateway_StrandSplit_Task_OpstellenProjectramingBestek" sourceRef="Gateway_StrandSplit" targetRef="Task_OpstellenProjectramingBestek" />
+    <bpmn:sequenceFlow id="Flow_Task_OpstellenProjectramingBestek_Task_AccorderenBeschikbaarKrediet" sourceRef="Task_OpstellenProjectramingBestek" targetRef="Task_AccorderenBeschikbaarKrediet" />
+    <bpmn:sequenceFlow id="Flow_Task_AccorderenBeschikbaarKrediet_Gateway_OntvangstSplit" sourceRef="Task_AccorderenBeschikbaarKrediet" targetRef="Gateway_OntvangstSplit" />
+    <bpmn:sequenceFlow id="Flow_Gateway_OntvangstSplit_Task_OntvangenProjectramingBestekKcd" sourceRef="Gateway_OntvangstSplit" targetRef="Task_OntvangenProjectramingBestekKcd" />
+    <bpmn:sequenceFlow id="Flow_Gateway_OntvangstSplit_Task_OntvangenProjectramingBestekPl" sourceRef="Gateway_OntvangstSplit" targetRef="Task_OntvangenProjectramingBestekPl" />
+    <bpmn:sequenceFlow id="Flow_Task_OntvangenProjectramingBestekKcd_Gateway_OntvangstJoin" sourceRef="Task_OntvangenProjectramingBestekKcd" targetRef="Gateway_OntvangstJoin" />
+    <bpmn:sequenceFlow id="Flow_Task_OntvangenProjectramingBestekPl_Task_VersturenGeaccordeerdeProjectraming" sourceRef="Task_OntvangenProjectramingBestekPl" targetRef="Task_VersturenGeaccordeerdeProjectraming" />
+    <bpmn:sequenceFlow id="Flow_Task_VersturenGeaccordeerdeProjectraming_Gateway_OntvangstJoin" sourceRef="Task_VersturenGeaccordeerdeProjectraming" targetRef="Gateway_OntvangstJoin" />
+    <bpmn:sequenceFlow id="Flow_Gateway_OntvangstJoin_Task_AccorderenProjectramingBestek" sourceRef="Gateway_OntvangstJoin" targetRef="Task_AccorderenProjectramingBestek" />
+    <bpmn:sequenceFlow id="Flow_Task_AccorderenProjectramingBestek_Gateway_ProjectramingAkkoord" sourceRef="Task_AccorderenProjectramingBestek" targetRef="Gateway_ProjectramingAkkoord" />
+    <bpmn:sequenceFlow id="Flow_Gateway_ProjectramingAkkoord_Task_OpstellenMemoProjectkredietBestek" name="nee" sourceRef="Gateway_ProjectramingAkkoord" targetRef="Task_OpstellenMemoProjectkredietBestek">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${projectramingBestekAkkoord == "nee"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_ProjectramingAkkoord_Gateway_KredietJoin" name="ja" sourceRef="Gateway_ProjectramingAkkoord" targetRef="Gateway_KredietJoin">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${projectramingBestekAkkoord == "ja"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Task_OpstellenMemoProjectkredietBestek_Task_BesluitenOverProjectkredietBestek" sourceRef="Task_OpstellenMemoProjectkredietBestek" targetRef="Task_BesluitenOverProjectkredietBestek" />
+    <bpmn:sequenceFlow id="Flow_Task_BesluitenOverProjectkredietBestek_Task_VerwerkenProjectramingBestek" sourceRef="Task_BesluitenOverProjectkredietBestek" targetRef="Task_VerwerkenProjectramingBestek" />
+    <bpmn:sequenceFlow id="Flow_Task_VerwerkenProjectramingBestek_Gateway_KredietJoin" sourceRef="Task_VerwerkenProjectramingBestek" targetRef="Gateway_KredietJoin" />
+    <bpmn:sequenceFlow id="Flow_Gateway_KredietJoin_Gateway_StrandJoin" sourceRef="Gateway_KredietJoin" targetRef="Gateway_StrandJoin" />
+    <bpmn:sequenceFlow id="Flow_Gateway_StrandJoin_Task_VersturenGetoetsteDocumenten" sourceRef="Gateway_StrandJoin" targetRef="Task_VersturenGetoetsteDocumenten" />
+    <bpmn:sequenceFlow id="Flow_Task_VersturenGetoetsteDocumenten_Task_EvaluerenContractvorming" sourceRef="Task_VersturenGetoetsteDocumenten" targetRef="Task_EvaluerenContractvorming" />
+    <bpmn:sequenceFlow id="Flow_Task_EvaluerenContractvorming_Task_AccorderenProjectplanContractvorming" sourceRef="Task_EvaluerenContractvorming" targetRef="Task_AccorderenProjectplanContractvorming" />
+    <bpmn:sequenceFlow id="Flow_Task_AccorderenProjectplanContractvorming_EndEvent_R41" sourceRef="Task_AccorderenProjectplanContractvorming" targetRef="EndEvent_R41" />
+  </bpmn:process>
+
+  <bpmndi:BPMNDiagram id="BPMNDiagram_RipR32Process">
+    <bpmndi:BPMNPlane id="BPMNPlane_RipR32Process" bpmnElement="Collaboration_RipR32Process">
+      <bpmndi:BPMNShape id="Participant_RipR32Process_di" bpmnElement="Participant_RipR32Process" isHorizontal="true">
+        <dc:Bounds x="160" y="80" width="2806" height="1000" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_DirectievoerderVestigingsmanager_di" bpmnElement="Lane_DirectievoerderVestigingsmanager" isHorizontal="true">
+        <dc:Bounds x="190" y="80" width="2776" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Projectleider_di" bpmnElement="Lane_Projectleider" isHorizontal="true">
+        <dc:Bounds x="190" y="200" width="2776" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_AO_di" bpmnElement="Lane_AO" isHorizontal="true">
+        <dc:Bounds x="190" y="400" width="2776" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_KostenContractdeskundige_di" bpmnElement="Lane_KostenContractdeskundige" isHorizontal="true">
+        <dc:Bounds x="190" y="520" width="2776" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_InfraOverleg_di" bpmnElement="Lane_InfraOverleg" isHorizontal="true">
+        <dc:Bounds x="190" y="720" width="2776" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Financien_di" bpmnElement="Lane_Financien" isHorizontal="true">
+        <dc:Bounds x="190" y="840" width="2776" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_DeelnemersEvaluatie_di" bpmnElement="Lane_DeelnemersEvaluatie" isHorizontal="true">
+        <dc:Bounds x="190" y="960" width="2776" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_R32_di" bpmnElement="StartEvent_R32">
+        <dc:Bounds x="232" y="242" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="134" y="283" width="232" height="28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_VerzamelenDocumenten_di" bpmnElement="Task_VerzamelenDocumenten">
+        <dc:Bounds x="300" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_StrandSplit_di" bpmnElement="Gateway_StrandSplit">
+        <dc:Bounds x="460" y="235" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_OpstellenVersturenConceptToezichtplan_di" bpmnElement="Task_OpstellenVersturenConceptToezichtplan">
+        <dc:Bounds x="540" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_BeoordelenConceptToezichtplan_di" bpmnElement="Task_BeoordelenConceptToezichtplan">
+        <dc:Bounds x="700" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_ToezichtplanAkkoord_di" bpmnElement="Gateway_ToezichtplanAkkoord" isMarkerVisible="true">
+        <dc:Bounds x="860" y="115" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="840" y="170" width="90" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_AanpassenConceptToezichtplan_di" bpmnElement="Task_AanpassenConceptToezichtplan">
+        <dc:Bounds x="940" y="310" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_AccorderenVersturenConceptToezichtplan_di" bpmnElement="Task_AccorderenVersturenConceptToezichtplan">
+        <dc:Bounds x="1020" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_OntvangenGeaccordeerdToezichtplan_di" bpmnElement="Task_OntvangenGeaccordeerdToezichtplan">
+        <dc:Bounds x="1180" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_OpstellenProjectramingBestek_di" bpmnElement="Task_OpstellenProjectramingBestek">
+        <dc:Bounds x="540" y="540" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_AccorderenBeschikbaarKrediet_di" bpmnElement="Task_AccorderenBeschikbaarKrediet">
+        <dc:Bounds x="700" y="860" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_OntvangstSplit_di" bpmnElement="Gateway_OntvangstSplit">
+        <dc:Bounds x="860" y="555" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_OntvangenProjectramingBestekKcd_di" bpmnElement="Task_OntvangenProjectramingBestekKcd">
+        <dc:Bounds x="1020" y="630" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_OntvangenProjectramingBestekPl_di" bpmnElement="Task_OntvangenProjectramingBestekPl">
+        <dc:Bounds x="1100" y="310" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_VersturenGeaccordeerdeProjectraming_di" bpmnElement="Task_VersturenGeaccordeerdeProjectraming">
+        <dc:Bounds x="1260" y="310" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_OntvangstJoin_di" bpmnElement="Gateway_OntvangstJoin">
+        <dc:Bounds x="1420" y="555" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_AccorderenProjectramingBestek_di" bpmnElement="Task_AccorderenProjectramingBestek">
+        <dc:Bounds x="1500" y="420" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_ProjectramingAkkoord_di" bpmnElement="Gateway_ProjectramingAkkoord" isMarkerVisible="true">
+        <dc:Bounds x="1660" y="435" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1601" y="490" width="168" height="28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_OpstellenMemoProjectkredietBestek_di" bpmnElement="Task_OpstellenMemoProjectkredietBestek">
+        <dc:Bounds x="1740" y="310" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_BesluitenOverProjectkredietBestek_di" bpmnElement="Task_BesluitenOverProjectkredietBestek">
+        <dc:Bounds x="1900" y="740" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_VerwerkenProjectramingBestek_di" bpmnElement="Task_VerwerkenProjectramingBestek">
+        <dc:Bounds x="2060" y="860" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_KredietJoin_di" bpmnElement="Gateway_KredietJoin" isMarkerVisible="true">
+        <dc:Bounds x="2220" y="435" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_StrandJoin_di" bpmnElement="Gateway_StrandJoin">
+        <dc:Bounds x="2300" y="235" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_VersturenGetoetsteDocumenten_di" bpmnElement="Task_VersturenGetoetsteDocumenten">
+        <dc:Bounds x="2380" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_EvaluerenContractvorming_di" bpmnElement="Task_EvaluerenContractvorming">
+        <dc:Bounds x="2540" y="980" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_AccorderenProjectplanContractvorming_di" bpmnElement="Task_AccorderenProjectplanContractvorming">
+        <dc:Bounds x="2700" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_R41_di" bpmnElement="EndEvent_R41">
+        <dc:Bounds x="2860" y="242" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2714" y="283" width="328" height="28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_StartEvent_R32_Task_VerzamelenDocumenten_di" bpmnElement="Flow_StartEvent_R32_Task_VerzamelenDocumenten">
+        <di:waypoint x="268" y="260" />
+        <di:waypoint x="300" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_VerzamelenDocumenten_Gateway_StrandSplit_di" bpmnElement="Flow_Task_VerzamelenDocumenten_Gateway_StrandSplit">
+        <di:waypoint x="400" y="260" />
+        <di:waypoint x="460" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_StrandSplit_Task_OpstellenVersturenConceptToezichtplan_di" bpmnElement="Flow_Gateway_StrandSplit_Task_OpstellenVersturenConceptToezichtplan">
+        <di:waypoint x="510" y="260" />
+        <di:waypoint x="540" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_OpstellenVersturenConceptToezichtplan_Task_BeoordelenConceptToezichtplan_di" bpmnElement="Flow_Task_OpstellenVersturenConceptToezichtplan_Task_BeoordelenConceptToezichtplan">
+        <di:waypoint x="640" y="260" />
+        <di:waypoint x="670" y="260" />
+        <di:waypoint x="670" y="140" />
+        <di:waypoint x="700" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_BeoordelenConceptToezichtplan_Gateway_ToezichtplanAkkoord_di" bpmnElement="Flow_Task_BeoordelenConceptToezichtplan_Gateway_ToezichtplanAkkoord">
+        <di:waypoint x="800" y="140" />
+        <di:waypoint x="860" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_ToezichtplanAkkoord_Task_AanpassenConceptToezichtplan_di" bpmnElement="Flow_Gateway_ToezichtplanAkkoord_Task_AanpassenConceptToezichtplan">
+        <di:waypoint x="910" y="140" />
+        <di:waypoint x="925" y="140" />
+        <di:waypoint x="925" y="350" />
+        <di:waypoint x="940" y="350" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="916" y="120" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_ToezichtplanAkkoord_Task_AccorderenVersturenConceptToezichtplan_di" bpmnElement="Flow_Gateway_ToezichtplanAkkoord_Task_AccorderenVersturenConceptToezichtplan">
+        <di:waypoint x="910" y="140" />
+        <di:waypoint x="1020" y="140" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="916" y="120" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_AanpassenConceptToezichtplan_Task_BeoordelenConceptToezichtplan_di" bpmnElement="Flow_Task_AanpassenConceptToezichtplan_Task_BeoordelenConceptToezichtplan">
+        <di:waypoint x="990" y="390" />
+        <di:waypoint x="990" y="190" />
+        <di:waypoint x="750" y="190" />
+        <di:waypoint x="750" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_AccorderenVersturenConceptToezichtplan_Task_OntvangenGeaccordeerdToezichtplan_di" bpmnElement="Flow_Task_AccorderenVersturenConceptToezichtplan_Task_OntvangenGeaccordeerdToezichtplan">
+        <di:waypoint x="1120" y="140" />
+        <di:waypoint x="1150" y="140" />
+        <di:waypoint x="1150" y="260" />
+        <di:waypoint x="1180" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_OntvangenGeaccordeerdToezichtplan_Gateway_StrandJoin_di" bpmnElement="Flow_Task_OntvangenGeaccordeerdToezichtplan_Gateway_StrandJoin">
+        <di:waypoint x="1280" y="260" />
+        <di:waypoint x="2300" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_StrandSplit_Task_OpstellenProjectramingBestek_di" bpmnElement="Flow_Gateway_StrandSplit_Task_OpstellenProjectramingBestek">
+        <di:waypoint x="510" y="260" />
+        <di:waypoint x="525" y="260" />
+        <di:waypoint x="525" y="580" />
+        <di:waypoint x="540" y="580" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_OpstellenProjectramingBestek_Task_AccorderenBeschikbaarKrediet_di" bpmnElement="Flow_Task_OpstellenProjectramingBestek_Task_AccorderenBeschikbaarKrediet">
+        <di:waypoint x="640" y="580" />
+        <di:waypoint x="670" y="580" />
+        <di:waypoint x="670" y="900" />
+        <di:waypoint x="700" y="900" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_AccorderenBeschikbaarKrediet_Gateway_OntvangstSplit_di" bpmnElement="Flow_Task_AccorderenBeschikbaarKrediet_Gateway_OntvangstSplit">
+        <di:waypoint x="800" y="900" />
+        <di:waypoint x="830" y="900" />
+        <di:waypoint x="830" y="580" />
+        <di:waypoint x="860" y="580" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_OntvangstSplit_Task_OntvangenProjectramingBestekKcd_di" bpmnElement="Flow_Gateway_OntvangstSplit_Task_OntvangenProjectramingBestekKcd">
+        <di:waypoint x="910" y="580" />
+        <di:waypoint x="965" y="580" />
+        <di:waypoint x="965" y="670" />
+        <di:waypoint x="1020" y="670" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_OntvangstSplit_Task_OntvangenProjectramingBestekPl_di" bpmnElement="Flow_Gateway_OntvangstSplit_Task_OntvangenProjectramingBestekPl">
+        <di:waypoint x="910" y="580" />
+        <di:waypoint x="1005" y="580" />
+        <di:waypoint x="1005" y="350" />
+        <di:waypoint x="1100" y="350" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_OntvangenProjectramingBestekKcd_Gateway_OntvangstJoin_di" bpmnElement="Flow_Task_OntvangenProjectramingBestekKcd_Gateway_OntvangstJoin">
+        <di:waypoint x="1120" y="670" />
+        <di:waypoint x="1270" y="670" />
+        <di:waypoint x="1270" y="580" />
+        <di:waypoint x="1420" y="580" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_OntvangenProjectramingBestekPl_Task_VersturenGeaccordeerdeProjectraming_di" bpmnElement="Flow_Task_OntvangenProjectramingBestekPl_Task_VersturenGeaccordeerdeProjectraming">
+        <di:waypoint x="1200" y="350" />
+        <di:waypoint x="1260" y="350" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_VersturenGeaccordeerdeProjectraming_Gateway_OntvangstJoin_di" bpmnElement="Flow_Task_VersturenGeaccordeerdeProjectraming_Gateway_OntvangstJoin">
+        <di:waypoint x="1360" y="350" />
+        <di:waypoint x="1390" y="350" />
+        <di:waypoint x="1390" y="580" />
+        <di:waypoint x="1420" y="580" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_OntvangstJoin_Task_AccorderenProjectramingBestek_di" bpmnElement="Flow_Gateway_OntvangstJoin_Task_AccorderenProjectramingBestek">
+        <di:waypoint x="1470" y="580" />
+        <di:waypoint x="1485" y="580" />
+        <di:waypoint x="1485" y="460" />
+        <di:waypoint x="1500" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_AccorderenProjectramingBestek_Gateway_ProjectramingAkkoord_di" bpmnElement="Flow_Task_AccorderenProjectramingBestek_Gateway_ProjectramingAkkoord">
+        <di:waypoint x="1600" y="460" />
+        <di:waypoint x="1660" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_ProjectramingAkkoord_Task_OpstellenMemoProjectkredietBestek_di" bpmnElement="Flow_Gateway_ProjectramingAkkoord_Task_OpstellenMemoProjectkredietBestek">
+        <di:waypoint x="1710" y="460" />
+        <di:waypoint x="1725" y="460" />
+        <di:waypoint x="1725" y="350" />
+        <di:waypoint x="1740" y="350" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1716" y="440" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_ProjectramingAkkoord_Gateway_KredietJoin_di" bpmnElement="Flow_Gateway_ProjectramingAkkoord_Gateway_KredietJoin">
+        <di:waypoint x="1710" y="460" />
+        <di:waypoint x="2220" y="460" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1716" y="440" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_OpstellenMemoProjectkredietBestek_Task_BesluitenOverProjectkredietBestek_di" bpmnElement="Flow_Task_OpstellenMemoProjectkredietBestek_Task_BesluitenOverProjectkredietBestek">
+        <di:waypoint x="1840" y="350" />
+        <di:waypoint x="1870" y="350" />
+        <di:waypoint x="1870" y="780" />
+        <di:waypoint x="1900" y="780" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_BesluitenOverProjectkredietBestek_Task_VerwerkenProjectramingBestek_di" bpmnElement="Flow_Task_BesluitenOverProjectkredietBestek_Task_VerwerkenProjectramingBestek">
+        <di:waypoint x="2000" y="780" />
+        <di:waypoint x="2030" y="780" />
+        <di:waypoint x="2030" y="900" />
+        <di:waypoint x="2060" y="900" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_VerwerkenProjectramingBestek_Gateway_KredietJoin_di" bpmnElement="Flow_Task_VerwerkenProjectramingBestek_Gateway_KredietJoin">
+        <di:waypoint x="2160" y="900" />
+        <di:waypoint x="2190" y="900" />
+        <di:waypoint x="2190" y="460" />
+        <di:waypoint x="2220" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_KredietJoin_Gateway_StrandJoin_di" bpmnElement="Flow_Gateway_KredietJoin_Gateway_StrandJoin">
+        <di:waypoint x="2270" y="460" />
+        <di:waypoint x="2285" y="460" />
+        <di:waypoint x="2285" y="260" />
+        <di:waypoint x="2300" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_StrandJoin_Task_VersturenGetoetsteDocumenten_di" bpmnElement="Flow_Gateway_StrandJoin_Task_VersturenGetoetsteDocumenten">
+        <di:waypoint x="2350" y="260" />
+        <di:waypoint x="2380" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_VersturenGetoetsteDocumenten_Task_EvaluerenContractvorming_di" bpmnElement="Flow_Task_VersturenGetoetsteDocumenten_Task_EvaluerenContractvorming">
+        <di:waypoint x="2480" y="260" />
+        <di:waypoint x="2510" y="260" />
+        <di:waypoint x="2510" y="1020" />
+        <di:waypoint x="2540" y="1020" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_EvaluerenContractvorming_Task_AccorderenProjectplanContractvorming_di" bpmnElement="Flow_Task_EvaluerenContractvorming_Task_AccorderenProjectplanContractvorming">
+        <di:waypoint x="2640" y="1020" />
+        <di:waypoint x="2670" y="1020" />
+        <di:waypoint x="2670" y="260" />
+        <di:waypoint x="2700" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_AccorderenProjectplanContractvorming_EndEvent_R41_di" bpmnElement="Flow_Task_AccorderenProjectplanContractvorming_EndEvent_R41">
+        <di:waypoint x="2800" y="260" />
+        <di:waypoint x="2860" y="260" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/examples/organizations/flevoland/rip-phase-32/rip-aanpassen-concept-toezichtplan.form
+++ b/examples/organizations/flevoland/rip-phase-32/rip-aanpassen-concept-toezichtplan.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-aanpassen-concept-toezichtplan",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Amend the draft supervision plan"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Amend the toezichtplan in line with the assessment findings and resubmit it."
+    },
+    {
+      "id": "F_Versie",
+      "type": "textfield",
+      "label": "Amended version",
+      "key": "toezichtplanVersie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Verwerkt",
+      "type": "textarea",
+      "label": "How the findings were incorporated",
+      "key": "toezichtplanVerwerkteBevindingen",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Aangepast",
+      "type": "datetime",
+      "label": "Amended on",
+      "key": "toezichtplanAangepastOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-32/rip-accorderen-beschikbaar-krediet-bestek.form
+++ b/examples/organizations/flevoland/rip-phase-32/rip-accorderen-beschikbaar-krediet-bestek.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-accorderen-beschikbaar-krediet-bestek",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Approve the available credit and send it on"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Finance approves the available credit against the specification project estimate and sends it to the project leader and the cost and contract specialist."
+    },
+    {
+      "id": "F_Krediet",
+      "type": "number",
+      "label": "Available project credit (EUR)",
+      "key": "beschikbaarProjectkrediet",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Door",
+      "type": "textfield",
+      "label": "Approved by",
+      "key": "kredietBestekGeaccordeerdDoor",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Approved and sent on",
+      "key": "kredietBestekGeaccordeerdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-32/rip-accorderen-concept-toezichtplan.form
+++ b/examples/organizations/flevoland/rip-phase-32/rip-accorderen-concept-toezichtplan.form
@@ -1,0 +1,52 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-accorderen-concept-toezichtplan",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Approve and send the supervision plan"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Record approval of the toezichtplan and send it to the project leader."
+    },
+    {
+      "id": "F_Door",
+      "type": "textfield",
+      "label": "Approved by",
+      "key": "toezichtplanGeaccordeerdDoor",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Approved on",
+      "key": "toezichtplanGeaccordeerdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Comments",
+      "key": "toezichtplanAccordeerOpmerkingen"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-32/rip-accorderen-projectplan-contractvorming.form
+++ b/examples/organizations/flevoland/rip-phase-32/rip-accorderen-projectplan-contractvorming.form
@@ -1,0 +1,71 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-accorderen-projectplan-contractvorming",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Approve the project plan — 7. Closing the contract formation phase"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Approve the project plan so the contract formation phase can be closed and R4.1 (requesting the tender) can start."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Project plan reference",
+      "key": "projectplanContractvormingReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Akkoord",
+      "type": "select",
+      "label": "Project plan approved",
+      "key": "akkoordProjectplanContractvorming",
+      "values": [
+        {
+          "label": "Yes",
+          "value": "ja"
+        },
+        {
+          "label": "No",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Adopted on",
+      "key": "projectplanContractvormingVastgesteldOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Comments",
+      "key": "accordeerOpmerkingenContractvorming"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-32/rip-accorderen-projectraming-bestek.form
+++ b/examples/organizations/flevoland/rip-phase-32/rip-accorderen-projectraming-bestek.form
@@ -1,0 +1,71 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-accorderen-projectraming-bestek",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Decide on the specification project estimate"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The AO decides whether the specification project estimate is approved. A rejection raises a project credit memo."
+    },
+    {
+      "id": "F_Akkoord",
+      "type": "select",
+      "label": "Project estimate approved",
+      "key": "projectramingBestekAkkoord",
+      "values": [
+        {
+          "label": "Yes — approved",
+          "value": "ja"
+        },
+        {
+          "label": "No — amendment required",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Door",
+      "type": "textfield",
+      "label": "Decided by",
+      "key": "projectramingBesluitDoor",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Decided on",
+      "key": "projectramingBesluitOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Comments",
+      "key": "projectramingBesluitOpmerkingen"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-32/rip-beoordelen-concept-toezichtplan.form
+++ b/examples/organizations/flevoland/rip-phase-32/rip-beoordelen-concept-toezichtplan.form
@@ -1,0 +1,74 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-beoordelen-concept-toezichtplan",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Assess the draft supervision plan"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Directievoerder and vestigingsmanager assess the draft toezichtplan and decide whether it can be approved."
+    },
+    {
+      "id": "F_Akkoord",
+      "type": "select",
+      "label": "Draft supervision plan approved",
+      "key": "toezichtplanAkkoord",
+      "values": [
+        {
+          "label": "Yes — approved",
+          "value": "ja"
+        },
+        {
+          "label": "No — amendment required",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bev",
+      "type": "textarea",
+      "label": "Assessment findings",
+      "key": "toezichtplanBevindingen",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Door",
+      "type": "textfield",
+      "label": "Assessed by",
+      "key": "toezichtplanBeoordeeldDoor",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Assessed on",
+      "key": "toezichtplanBeoordeeldOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-32/rip-besluit-projectkrediet-bestek.document
+++ b/examples/organizations/flevoland/rip-phase-32/rip-besluit-projectkrediet-bestek.document
@@ -1,0 +1,218 @@
+{
+  "id": "rip-besluit-projectkrediet-bestek",
+  "name": "RIP — Project Credit Decision, contract formation (Besluit projectkrediet)",
+  "description": "Records the Infra consultation decision on the project credit requested in the contract formation memo.",
+  "processKey": "RipR32Process",
+  "serviceId": "RipR32",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{memoBestekReferentie}}",
+      "variableKey": "memoBestekReferentie",
+      "source": "process",
+      "label": "Memo reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{besluitProjectkredietBestek}}",
+      "variableKey": "besluitProjectkredietBestek",
+      "source": "process",
+      "label": "Decision"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{toegekendBedragBestek}}",
+      "variableKey": "toegekendBedragBestek",
+      "source": "process",
+      "label": "Granted amount"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{besluitDatumBestek}}",
+      "variableKey": "besluitDatumBestek",
+      "source": "process",
+      "label": "Decision date"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{besluitToelichtingBestek}}",
+      "variableKey": "besluitToelichtingBestek",
+      "source": "process",
+      "label": "Explanation"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Decision on memo {{memoBestekReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Decision on the project credit",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Decision on the project credit"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "On {{besluitDatumBestek}} the Infra consultation decided on the credit requested in memo {{memoBestekReferentie}} for project {{projectNumber}} — {{projectName}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Decision: {{besluitProjectkredietBestek}}. Granted amount: EUR {{toegekendBedragBestek}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Explanation: {{besluitToelichtingBestek}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Decided by the Infra consultation"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-32/rip-besluiten-projectkrediet-bestek.form
+++ b/examples/organizations/flevoland/rip-phase-32/rip-besluiten-projectkrediet-bestek.form
@@ -1,0 +1,72 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-besluiten-projectkrediet-bestek",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Decide on the project credit"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Record the Infra consultation decision on the requested project credit."
+    },
+    {
+      "id": "F_Besluit",
+      "type": "select",
+      "label": "Decision",
+      "key": "besluitProjectkredietBestek",
+      "values": [
+        {
+          "label": "Granted",
+          "value": "toegekend"
+        },
+        {
+          "label": "Refused",
+          "value": "afgewezen"
+        },
+        {
+          "label": "Deferred",
+          "value": "aangehouden"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bedrag",
+      "type": "number",
+      "label": "Granted amount (EUR)",
+      "key": "toegekendBedragBestek"
+    },
+    {
+      "id": "F_Datum",
+      "type": "datetime",
+      "label": "Decision date",
+      "key": "besluitDatumBestek",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Toel",
+      "type": "textarea",
+      "label": "Explanation",
+      "key": "besluitToelichtingBestek"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-32/rip-concept-toezichtplan.document
+++ b/examples/organizations/flevoland/rip-phase-32/rip-concept-toezichtplan.document
@@ -1,0 +1,246 @@
+{
+  "id": "rip-concept-toezichtplan",
+  "name": "RIP — Draft Supervision Plan (Concept toezichtplan)",
+  "description": "Format Toezichtplan. The draft supervision plan drawn up in R3.2 and approved by the directievoerder and vestigingsmanager.",
+  "processKey": "RipR32Process",
+  "serviceId": "RipR32",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{conceptToezichtplanReferentie}}",
+      "variableKey": "conceptToezichtplanReferentie",
+      "source": "process",
+      "label": "Supervision plan reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{conceptToezichtplanVerstuurdOp}}",
+      "variableKey": "conceptToezichtplanVerstuurdOp",
+      "source": "process",
+      "label": "Sent on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{toezichtplanAkkoord}}",
+      "variableKey": "toezichtplanAkkoord",
+      "source": "process",
+      "label": "Assessment outcome"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{toezichtplanBeoordeeldDoor}}",
+      "variableKey": "toezichtplanBeoordeeldDoor",
+      "source": "process",
+      "label": "Assessed by"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{toezichtplanBeoordeeldOp}}",
+      "variableKey": "toezichtplanBeoordeeldOp",
+      "source": "process",
+      "label": "Assessed on"
+    },
+    {
+      "id": "b8",
+      "placeholder": "{{toezichtplanBevindingen}}",
+      "variableKey": "toezichtplanBevindingen",
+      "source": "process",
+      "label": "Findings"
+    },
+    {
+      "id": "b9",
+      "placeholder": "{{toezichtplanGeaccordeerdDoor}}",
+      "variableKey": "toezichtplanGeaccordeerdDoor",
+      "source": "process",
+      "label": "Approved by"
+    },
+    {
+      "id": "b10",
+      "placeholder": "{{toezichtplanGeaccordeerdOp}}",
+      "variableKey": "toezichtplanGeaccordeerdOp",
+      "source": "process",
+      "label": "Approved on"
+    },
+    {
+      "id": "b11",
+      "placeholder": "{{toezichtplanOntvangenOp}}",
+      "variableKey": "toezichtplanOntvangenOp",
+      "source": "process",
+      "label": "Received on"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Supervision plan {{conceptToezichtplanReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Draft supervision plan",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Draft supervision plan"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Draft toezichtplan {{conceptToezichtplanReferentie}} for project {{projectNumber}} — {{projectName}} was sent for assessment on {{conceptToezichtplanVerstuurdOp}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Assessment: {{toezichtplanAkkoord}}, by {{toezichtplanBeoordeeldDoor}} on {{toezichtplanBeoordeeldOp}}. Findings: {{toezichtplanBevindingen}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Approved by {{toezichtplanGeaccordeerdDoor}} on {{toezichtplanGeaccordeerdOp}} and received back on {{toezichtplanOntvangenOp}}."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up by the project leader"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-32/rip-contractdocumenten.document
+++ b/examples/organizations/flevoland/rip-phase-32/rip-contractdocumenten.document
@@ -1,0 +1,232 @@
+{
+  "id": "rip-contractdocumenten",
+  "name": "RIP — Contract and Tender Documents (Getoetste contract- en aanbestedingsdocumenten)",
+  "description": "The reviewed contract and tender document set assembled at the start of R3.2 and sent on at its close.",
+  "processKey": "RipR32Process",
+  "serviceId": "RipR32",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{contractdocumentenReferentie}}",
+      "variableKey": "contractdocumentenReferentie",
+      "source": "process",
+      "label": "Document set reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{contractdocumentenVerzameldOp}}",
+      "variableKey": "contractdocumentenVerzameldOp",
+      "source": "process",
+      "label": "Collected on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{bestekReferentie}}",
+      "variableKey": "bestekReferentie",
+      "source": "process",
+      "label": "Bestek reference"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{inschrijvingsleidraadReferentie}}",
+      "variableKey": "inschrijvingsleidraadReferentie",
+      "source": "process",
+      "label": "Inschrijvingsleidraad reference"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{definitieveBestekstekeningenReferentie}}",
+      "variableKey": "definitieveBestekstekeningenReferentie",
+      "source": "process",
+      "label": "Final drawings reference"
+    },
+    {
+      "id": "b8",
+      "placeholder": "{{contractdocumentenVerstuurdOp}}",
+      "variableKey": "contractdocumentenVerstuurdOp",
+      "source": "process",
+      "label": "Sent on"
+    },
+    {
+      "id": "b9",
+      "placeholder": "{{contractdocumentenVerstuurdAan}}",
+      "variableKey": "contractdocumentenVerstuurdAan",
+      "source": "process",
+      "label": "Sent to"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Document set {{contractdocumentenReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Contract and tender documents",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Contract and tender documents"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Document set {{contractdocumentenReferentie}} for project {{projectNumber}} — {{projectName}} was collected on {{contractdocumentenVerzameldOp}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "It comprises bestek {{bestekReferentie}}, inschrijvingsleidraad {{inschrijvingsleidraadReferentie}} and final drawings {{definitieveBestekstekeningenReferentie}}, all reviewed in R3.1."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Sent on {{contractdocumentenVerstuurdOp}} to {{contractdocumentenVerstuurdAan}}."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Assembled by the project leader"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-32/rip-evaluatie-contractvorming.document
+++ b/examples/organizations/flevoland/rip-phase-32/rip-evaluatie-contractvorming.document
@@ -1,0 +1,195 @@
+{
+  "id": "rip-evaluatie-contractvorming",
+  "name": "RIP — Contract Formation Evaluation (Evaluatie DO en bestek)",
+  "description": "The Qualtrics evaluation of the DO and bestek phase, carried out by the participants at the close of contract formation.",
+  "processKey": "RipR32Process",
+  "serviceId": "RipR32",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{evaluatieContractvormingReferentie}}",
+      "variableKey": "evaluatieContractvormingReferentie",
+      "source": "process",
+      "label": "Qualtrics reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{evaluatieContractvormingOp}}",
+      "variableKey": "evaluatieContractvormingOp",
+      "source": "process",
+      "label": "Evaluated on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{evaluatieContractvormingBevindingen}}",
+      "variableKey": "evaluatieContractvormingBevindingen",
+      "source": "process",
+      "label": "Main findings"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Evaluation {{evaluatieContractvormingReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Evaluation of contract formation",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Evaluation of contract formation"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The DO and bestek phase for project {{projectNumber}} — {{projectName}} was evaluated on {{evaluatieContractvormingOp}}, recorded in Qualtrics under {{evaluatieContractvormingReferentie}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Main findings: {{evaluatieContractvormingBevindingen}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Evaluated by the participants"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-32/rip-evalueren-contractvorming.form
+++ b/examples/organizations/flevoland/rip-phase-32/rip-evalueren-contractvorming.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-evalueren-contractvorming",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Evaluate the contract formation phase"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Participants evaluate the DO and bestek phase in Qualtrics."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Qualtrics evaluation reference",
+      "key": "evaluatieContractvormingReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Evaluated on",
+      "key": "evaluatieContractvormingOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bev",
+      "type": "textarea",
+      "label": "Main findings",
+      "key": "evaluatieContractvormingBevindingen",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-32/rip-memo-projectkrediet-bestek.document
+++ b/examples/organizations/flevoland/rip-phase-32/rip-memo-projectkrediet-bestek.document
@@ -1,0 +1,218 @@
+{
+  "id": "rip-memo-projectkrediet-bestek",
+  "name": "RIP — Project Credit Memo, contract formation (Memo projectkrediet)",
+  "description": "Format Memo projectkrediet. The soft claim raised when the specification project estimate is not approved against the available credit.",
+  "processKey": "RipR32Process",
+  "serviceId": "RipR32",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{memoBestekReferentie}}",
+      "variableKey": "memoBestekReferentie",
+      "source": "process",
+      "label": "Memo reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{gevraagdKredietBestek}}",
+      "variableKey": "gevraagdKredietBestek",
+      "source": "process",
+      "label": "Requested project credit"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{dekkingstekortBestek}}",
+      "variableKey": "dekkingstekortBestek",
+      "source": "process",
+      "label": "Shortfall"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{beschikbaarProjectkrediet}}",
+      "variableKey": "beschikbaarProjectkrediet",
+      "source": "process",
+      "label": "Available project credit"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{memoBestekOnderbouwing}}",
+      "variableKey": "memoBestekOnderbouwing",
+      "source": "process",
+      "label": "Substantiation"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Memo {{memoBestekReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Request for additional project credit",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Request for additional project credit"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The specification project estimate for project {{projectNumber}} — {{projectName}} was not approved against the available credit of EUR {{beschikbaarProjectkrediet}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "This memo ({{memoBestekReferentie}}) requests EUR {{gevraagdKredietBestek}}, a shortfall of EUR {{dekkingstekortBestek}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Substantiation: {{memoBestekOnderbouwing}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up by the project leader"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-32/rip-memo-projectkrediet-bestek.form
+++ b/examples/organizations/flevoland/rip-phase-32/rip-memo-projectkrediet-bestek.form
@@ -1,0 +1,59 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-memo-projectkrediet-bestek",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Draw up the project credit memo (soft claim)"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The specification project estimate was not approved against the available credit. Draw up the memo so the Infra consultation can decide."
+    },
+    {
+      "id": "F_Memo",
+      "type": "textfield",
+      "label": "Memo reference",
+      "key": "memoBestekReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Gevraagd",
+      "type": "number",
+      "label": "Requested project credit (EUR)",
+      "key": "gevraagdKredietBestek",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Tekort",
+      "type": "number",
+      "label": "Shortfall (EUR)",
+      "key": "dekkingstekortBestek"
+    },
+    {
+      "id": "F_Onderbouwing",
+      "type": "textarea",
+      "label": "Substantiation",
+      "key": "memoBestekOnderbouwing",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-32/rip-ontvangen-geaccordeerd-toezichtplan.form
+++ b/examples/organizations/flevoland/rip-phase-32/rip-ontvangen-geaccordeerd-toezichtplan.form
@@ -1,0 +1,43 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-ontvangen-geaccordeerd-toezichtplan",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Receive the approved supervision plan"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Record receipt of the approved toezichtplan."
+    },
+    {
+      "id": "F_Ontvangen",
+      "type": "datetime",
+      "label": "Received on",
+      "key": "toezichtplanOntvangenOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Notes",
+      "key": "toezichtplanOntvangstOpmerkingen"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-32/rip-ontvangen-projectraming-bestek-kcd.form
+++ b/examples/organizations/flevoland/rip-phase-32/rip-ontvangen-projectraming-bestek-kcd.form
@@ -1,0 +1,43 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-ontvangen-projectraming-bestek-kcd",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Receive the project estimate (cost and contract specialist)"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Record receipt of the approved specification project estimate."
+    },
+    {
+      "id": "F_Ontvangen",
+      "type": "datetime",
+      "label": "Received on",
+      "key": "projectramingOntvangenKcdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Notes",
+      "key": "projectramingOntvangstKcdOpmerkingen"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-32/rip-ontvangen-projectraming-bestek-pl.form
+++ b/examples/organizations/flevoland/rip-phase-32/rip-ontvangen-projectraming-bestek-pl.form
@@ -1,0 +1,43 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-ontvangen-projectraming-bestek-pl",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Receive the project estimate (project leader)"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Record receipt of the approved specification project estimate."
+    },
+    {
+      "id": "F_Ontvangen",
+      "type": "datetime",
+      "label": "Received on",
+      "key": "projectramingOntvangenPlOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Notes",
+      "key": "projectramingOntvangstPlOpmerkingen"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-32/rip-opstellen-concept-toezichtplan.form
+++ b/examples/organizations/flevoland/rip-phase-32/rip-opstellen-concept-toezichtplan.form
@@ -1,0 +1,52 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-opstellen-concept-toezichtplan",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Draw up and send the draft supervision plan"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Draw up the concept toezichtplan against the Format Toezichtplan and send it for assessment."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Draft supervision plan reference",
+      "key": "conceptToezichtplanReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Format",
+      "type": "textfield",
+      "label": "Format Toezichtplan version",
+      "key": "formatToezichtplanVersie"
+    },
+    {
+      "id": "F_Verstuurd",
+      "type": "datetime",
+      "label": "Sent on",
+      "key": "conceptToezichtplanVerstuurdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-32/rip-opstellen-projectraming-bestek.form
+++ b/examples/organizations/flevoland/rip-phase-32/rip-opstellen-projectraming-bestek.form
@@ -1,0 +1,61 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-opstellen-projectraming-bestek",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Draw up the specification project estimate"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Draw up the projectraming bestek against the Format Projectraming, using the bestek and the SSK estimate from R3.1."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Project estimate reference",
+      "key": "projectramingBestekReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bedrag",
+      "type": "number",
+      "label": "Project estimate (EUR)",
+      "key": "projectramingBestekBedrag",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_SSK",
+      "type": "textfield",
+      "label": "SSK estimate reference (from R3.1)",
+      "key": "sskRamingBestekReferentie"
+    },
+    {
+      "id": "F_Gereed",
+      "type": "datetime",
+      "label": "Drawn up on",
+      "key": "projectramingBestekGereedOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-32/rip-projectplan-contractvorming.document
+++ b/examples/organizations/flevoland/rip-phase-32/rip-projectplan-contractvorming.document
@@ -1,0 +1,234 @@
+{
+  "id": "rip-projectplan-contractvorming",
+  "name": "RIP — Adopted Project Plan, contract formation (Vastgesteld Projectplan)",
+  "description": "The project plan as adopted at the close of the contract formation phase. Hands over to R4.1 Verzoeken tot aanbesteden.",
+  "processKey": "RipR32Process",
+  "serviceId": "RipR32",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{projectplanContractvormingReferentie}}",
+      "variableKey": "projectplanContractvormingReferentie",
+      "source": "process",
+      "label": "Project plan reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{projectplanContractvormingVastgesteldOp}}",
+      "variableKey": "projectplanContractvormingVastgesteldOp",
+      "source": "process",
+      "label": "Adopted on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{contractdocumentenReferentie}}",
+      "variableKey": "contractdocumentenReferentie",
+      "source": "process",
+      "label": "Document set reference"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{projectramingBestekReferentie}}",
+      "variableKey": "projectramingBestekReferentie",
+      "source": "process",
+      "label": "Project estimate reference"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{conceptToezichtplanReferentie}}",
+      "variableKey": "conceptToezichtplanReferentie",
+      "source": "process",
+      "label": "Supervision plan reference"
+    },
+    {
+      "id": "b8",
+      "placeholder": "{{accordeerOpmerkingenContractvorming}}",
+      "variableKey": "accordeerOpmerkingenContractvorming",
+      "source": "process",
+      "label": "Comments"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project plan {{projectplanContractvormingReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Adopted project plan — closing contract formation",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Adopted project plan — closing contract formation"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project plan {{projectplanContractvormingReferentie}} for project {{projectNumber}} — {{projectName}} was adopted on {{projectplanContractvormingVastgesteldOp}}, closing the contract formation phase."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "It incorporates document set {{contractdocumentenReferentie}}, project estimate {{projectramingBestekReferentie}} and supervision plan {{conceptToezichtplanReferentie}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Comments: {{accordeerOpmerkingenContractvorming}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "With this adoption the project moves to R4.1, requesting the tender."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Approved by the project leader"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-32/rip-projectraming-bestek.document
+++ b/examples/organizations/flevoland/rip-phase-32/rip-projectraming-bestek.document
@@ -1,0 +1,260 @@
+{
+  "id": "rip-projectraming-bestek",
+  "name": "RIP — Specification Project Estimate (Projectraming bestek)",
+  "description": "Format Projectraming. The project estimate drawn up against the bestek, decided on by the AO.",
+  "processKey": "RipR32Process",
+  "serviceId": "RipR32",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{projectramingBestekReferentie}}",
+      "variableKey": "projectramingBestekReferentie",
+      "source": "process",
+      "label": "Project estimate reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{projectramingBestekBedrag}}",
+      "variableKey": "projectramingBestekBedrag",
+      "source": "process",
+      "label": "Project estimate"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{projectramingBestekGereedOp}}",
+      "variableKey": "projectramingBestekGereedOp",
+      "source": "process",
+      "label": "Drawn up on"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{sskRamingBestekReferentie}}",
+      "variableKey": "sskRamingBestekReferentie",
+      "source": "process",
+      "label": "SSK estimate reference"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{beschikbaarProjectkrediet}}",
+      "variableKey": "beschikbaarProjectkrediet",
+      "source": "process",
+      "label": "Available project credit"
+    },
+    {
+      "id": "b8",
+      "placeholder": "{{kredietBestekGeaccordeerdDoor}}",
+      "variableKey": "kredietBestekGeaccordeerdDoor",
+      "source": "process",
+      "label": "Credit approved by"
+    },
+    {
+      "id": "b9",
+      "placeholder": "{{kredietBestekGeaccordeerdOp}}",
+      "variableKey": "kredietBestekGeaccordeerdOp",
+      "source": "process",
+      "label": "Credit approved on"
+    },
+    {
+      "id": "b10",
+      "placeholder": "{{projectramingBestekAkkoord}}",
+      "variableKey": "projectramingBestekAkkoord",
+      "source": "process",
+      "label": "AO decision"
+    },
+    {
+      "id": "b11",
+      "placeholder": "{{projectramingBesluitDoor}}",
+      "variableKey": "projectramingBesluitDoor",
+      "source": "process",
+      "label": "Decided by"
+    },
+    {
+      "id": "b12",
+      "placeholder": "{{projectramingBesluitOp}}",
+      "variableKey": "projectramingBesluitOp",
+      "source": "process",
+      "label": "Decided on"
+    },
+    {
+      "id": "b13",
+      "placeholder": "{{projectramingBesluitOpmerkingen}}",
+      "variableKey": "projectramingBesluitOpmerkingen",
+      "source": "process",
+      "label": "Comments"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project estimate {{projectramingBestekReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Specification project estimate",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Specification project estimate"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project estimate {{projectramingBestekReferentie}} for project {{projectNumber}} — {{projectName}} amounts to EUR {{projectramingBestekBedrag}}, drawn up on {{projectramingBestekGereedOp}} against SSK estimate {{sskRamingBestekReferentie}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Available project credit: EUR {{beschikbaarProjectkrediet}}, approved by {{kredietBestekGeaccordeerdDoor}} on {{kredietBestekGeaccordeerdOp}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "AO decision: {{projectramingBestekAkkoord}}, by {{projectramingBesluitDoor}} on {{projectramingBesluitOp}}. {{projectramingBesluitOpmerkingen}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up by the cost and contract specialist"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-32/rip-versturen-contractdocumenten.form
+++ b/examples/organizations/flevoland/rip-phase-32/rip-versturen-contractdocumenten.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-versturen-contractdocumenten",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Send the reviewed contract and tender documents"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Send the reviewed contract and tender document set on, so the tender phase can be prepared."
+    },
+    {
+      "id": "F_Verstuurd",
+      "type": "datetime",
+      "label": "Sent on",
+      "key": "contractdocumentenVerstuurdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Aan",
+      "type": "textfield",
+      "label": "Sent to",
+      "key": "contractdocumentenVerstuurdAan",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-32/rip-versturen-geaccordeerde-projectraming.form
+++ b/examples/organizations/flevoland/rip-phase-32/rip-versturen-geaccordeerde-projectraming.form
@@ -1,0 +1,43 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-versturen-geaccordeerde-projectraming",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Send the approved project estimate on"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Send the approved specification project estimate to the AO for a decision."
+    },
+    {
+      "id": "F_Verstuurd",
+      "type": "datetime",
+      "label": "Sent on",
+      "key": "projectramingVerstuurdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Aan",
+      "type": "textfield",
+      "label": "Sent to",
+      "key": "projectramingVerstuurdAan"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-32/rip-verwerken-projectraming-bestek.form
+++ b/examples/organizations/flevoland/rip-phase-32/rip-verwerken-projectraming-bestek.form
@@ -1,0 +1,52 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-verwerken-projectraming-bestek",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Process the project estimate and Infra framework credit"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Record the specification project estimate and the credit decision in the Infra framework credit administration."
+    },
+    {
+      "id": "F_Bedrag",
+      "type": "number",
+      "label": "Amount processed (EUR)",
+      "key": "verwerktBedragBestek",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Admin",
+      "type": "textfield",
+      "label": "Administration reference",
+      "key": "administratieReferentieBestek"
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Processed on",
+      "key": "verwerktOpBestek",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-32/rip-verzamelen-contractdocumenten.form
+++ b/examples/organizations/flevoland/rip-phase-32/rip-verzamelen-contractdocumenten.form
@@ -1,0 +1,73 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-verzamelen-contractdocumenten",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Collect the reviewed contract and tender documents"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Bring together the bestek, the inschrijvingsleidraad, the SSK estimate and the final drawings approved in R3.1 into one set."
+    },
+    {
+      "id": "F_Set",
+      "type": "textfield",
+      "label": "Document set reference",
+      "key": "contractdocumentenReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bestek",
+      "type": "textfield",
+      "label": "Bestek reference (from R3.1)",
+      "key": "bestekReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Leidraad",
+      "type": "textfield",
+      "label": "Inschrijvingsleidraad reference (from R3.1)",
+      "key": "inschrijvingsleidraadReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Tek",
+      "type": "textfield",
+      "label": "Final drawings reference (from R3.1)",
+      "key": "definitieveBestekstekeningenReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Verzameld",
+      "type": "datetime",
+      "label": "Collected on",
+      "key": "contractdocumentenVerzameldOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}


### PR DESCRIPTION
> **Stacked on #56 (R3.1) → #54 (R2.4) → #53 (R2.3) → `acc`.** Base is `feat/rip-phase-31`, so this PR shows only R3.2's 26 files. GitHub retargets as the stack merges down.

Models **R3.2 (Afronding bestek en tekeningen)** from `rip-phases-left/R3. Contractvorming/R3_2 Afronding bestek en tekeningen.pdf` (sheet dated 23-3-2026). Closes stage R3.

`RipR32Process` — 27 flow nodes, 30 sequence flows, **7 lanes**, 18 forms, 7 document templates. All seven lanes modelled.

## Flow

```
Start (from R3.1)
 └─ Verzamelen getoetste contract- en aanbestedingsdocumenten  (Projectleider)
 └─ AND split
      ├── toezichtplan strand ──────────────────────────────────────────
      │   Opstellen en versturen concept toezichtplan   (Projectleider)
      │   Beoordelen concept toezichtplan   (Directievoerder, Vestigingsmanager)
      │   XOR Akkoord?
      │     ├─ nee → Aanpassen concept toezichtplan ⟲ back to Beoordelen
      │     └─ ja  → Accorderen en versturen concept toezichtplan
      │              └─ Ontvangen geaccordeerd concept toezichtplan
      └── projectraming strand ─────────────────────────────────────────
          Opstellen projectraming bestek    (Kosten- en contractdeskundige)
          Accorderen beschikbaar krediet en versturen naar PL en KCD (Financiën)
          AND split → Ontvangen projectraming bestek (KCD) ┐
                    → Ontvangen projectraming bestek (PL)  │
                      └─ Versturen geaccordeerde projectraming bestek
          Accorderen projectraming bestek   (AO)
          XOR Akkoord projectraming bestek?
            ├─ nee → Opstellen memo projectkrediet   (Projectleider)
            │         └─ Besluiten over projectkrediet  (Infra-overleg)
            │              └─ Verwerken projectraming    (Financiën)
            └─ ja  → join
 └─ AND join
 └─ Versturen getoetste contract- en aanbestedingsdocumenten  (Projectleider)
 └─ Evalueren contractvorming                    (Deelnemers evaluatie)
 └─ Accorderen Projectplan 7. Afronden contractvormingsfase   (Projectleider)
 └─ → R4.1 Verzoeken tot aanbesteden
```

## Reading of the sheet

**The two strands are parallel, not sequential.** Column positions decide it: both strand openers sit immediately right of the collect step — concept toezichtplan at c112 and projectraming bestek at c115, against the collect step at c92 — and they rejoin before the documents are sent on.

**The toezichtplan rework loop returns to *Beoordelen*, not to *Accorderen*.** On the sheet the amend box sits at the gateway's own column while the approve box sits to its right, which is the same shape as R3.1's drawing loop.

## Faseladder contract

| | Item | State |
|---|---|---|
| 1 | Process-definition key | `RipR32Process` |
| 2 | Tenant `flevoland` | at deploy |
| 3 | `municipality` untouched; no form sets a board-supplied variable | verified |
| 4 | `businessKey` | 0 |
| 5 | External-task topics | **none** — no serviceTasks |
| 6 | `formRefBinding="deployment"` | all 18, zero `latest` |

No `leadRole` set — the catalogue's `lead` for R3.2 is "Kosten- en contractdeskundige", which has no key in rip-model's `ROLES`, so setting one would silently degrade to `projectleider`. The intended fallback applies instead.

`boardOwner` and `ronl:organization` stay unauthored; the deploy path injects them.

## Candidate groups

One new: **`rip-deelnemers-evaluatie`**. `rip-ao`, used here for the AO lane, was already introduced by **R2.1** — so the two AO lanes share a group rather than diverging.

Ladder total is now **24 distinct groups**, all matching `rip-[\w-]+` → `infra-board`.

## Verification

```
R2.1  bpmn: OK   bundle: OK
R2.2  bpmn: OK   bundle: OK
R2.3  bpmn: OK   bundle: OK
R2.4  bpmn: OK   bundle: OK
R3.1  bpmn: OK   bundle: OK
R3.2  bpmn: OK   bundle: OK

id collisions across all six: none
```

Both checkers passed on the first generator run — third phase running.

## Not deployed

Engine still carries only `RipR21Process` and `RipR22Process`.
