### PR TITLE
feat(rip): add R4.1 Aanbestedingsproces bundle for Flevoland

### DIFF
--- a/examples/organizations/flevoland/rip-phase-41/RipR41Process.bpmn
+++ b/examples/organizations/flevoland/rip-phase-41/RipR41Process.bpmn
@@ -1,0 +1,514 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:ronl="http://ronl.nl/schema/1.0" id="Definitions_RipR41Process" targetNamespace="http://example.com/rip-phase-41" exporter="Camunda Modeler" exporterVersion="5.45.0">
+  <bpmn:collaboration id="Collaboration_RipR41Process">
+    <bpmn:participant id="Participant_RipR41Process" name="R4.1 - Aanbestedingsproces" processRef="RipR41Process" />
+  </bpmn:collaboration>
+  <bpmn:process id="RipR41Process" name="R4.1 - Aanbestedingsproces" isExecutable="true" camunda:historyTimeToLive="180">
+    <bpmn:laneSet id="LaneSet_RipR41Process">
+      <bpmn:lane id="Lane_KostenContractdeskundige" name="Kosten- en contractdeskundige">
+        <bpmn:flowNodeRef>StartEvent_R41</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_VerzoekenTotAanbesteden</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_HerstellenDossier</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_ActualiserenProjectraming</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_ControlerenWijzigingenNotaVanInlichtingen</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_Onregelmatigheid1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_TerzijdeLeggenOnrechtmatigeInschrijving</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_ControlerenEenheidsprijzen</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_Onregelmatigheid2</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_OpvragenVerduidelijkingInschrijving</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_Inkoopadviseur" name="Inkoopadviseur">
+        <bpmn:flowNodeRef>Task_ControlerenAanbestedingsdocumenten</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_DossierVolledig</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_AfwijzenInschrijving</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndEvent_InschrijvingAfgewezen</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_OpstellenVoornemenTotGunnen</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_AfrondenInkoopprocedure</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndEvent_Inkoopprocedure</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_Projectleider" name="Projectleider">
+        <bpmn:flowNodeRef>Gateway_Dekkingsbron</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_OpstellenNotaBesluitvormingConcerndirecteur</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_OpstellenNotaBesluitvormingAo</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_NotaJoin</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_Concerndirecteur" name="Concerndirecteur">
+        <bpmn:flowNodeRef>Task_VaststellenNotaBesluitvormingConcerndirecteur</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_Financien" name="Financiën">
+        <bpmn:flowNodeRef>Task_VerwerkenProjectramingAanbesteding</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_AO" name="AO">
+        <bpmn:flowNodeRef>Task_VaststellenNotaBesluitvormingAo</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_Projectondersteuner" name="Projectondersteuner">
+        <bpmn:flowNodeRef>Task_InformerenInkoopadviseur</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+
+    <bpmn:startEvent id="StartEvent_R41" name="Start R4.1 - Aanbestedingsproces&#10;(vanuit R3.2)">
+      <bpmn:outgoing>Flow_StartEvent_R41_Task_VerzoekenTotAanbesteden</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:userTask id="Task_VerzoekenTotAanbesteden" name="Verzoeken tot&#10;aanbesteden" camunda:formRef="rip-verzoeken-tot-aanbesteden" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-kosten-contractdeskundige">
+      <bpmn:incoming>Flow_StartEvent_R41_Task_VerzoekenTotAanbesteden</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_VerzoekenTotAanbesteden_Task_ControlerenAanbestedingsdocumenten</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_ControlerenAanbestedingsdocumenten" name="Controleren aanbestedingsdocumenten&#10;klaar voor upload" camunda:formRef="rip-controleren-aanbestedingsdocumenten" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-inkoopadviseur" ronl:documentRef="rip-aanbestedingsdossier">
+      <bpmn:incoming>Flow_Task_VerzoekenTotAanbesteden_Task_ControlerenAanbestedingsdocumenten</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_HerstellenDossier_Task_ControlerenAanbestedingsdocumenten</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_ControlerenAanbestedingsdocumenten_Gateway_DossierVolledig</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_DossierVolledig" name="Dossier&#10;volledig?">
+      <bpmn:incoming>Flow_Task_ControlerenAanbestedingsdocumenten_Gateway_DossierVolledig</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_DossierVolledig_Task_HerstellenDossier</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_DossierVolledig_Task_ActualiserenProjectraming</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_HerstellenDossier" name="Herstellen dossier" camunda:formRef="rip-herstellen-dossier" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-kosten-contractdeskundige">
+      <bpmn:incoming>Flow_Gateway_DossierVolledig_Task_HerstellenDossier</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_HerstellenDossier_Task_ControlerenAanbestedingsdocumenten</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_ActualiserenProjectraming" name="Actualiseren&#10;projectraming" camunda:formRef="rip-actualiseren-projectraming" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-kosten-contractdeskundige" ronl:documentRef="rip-projectraming-na-aanbesteding">
+      <bpmn:incoming>Flow_Gateway_DossierVolledig_Task_ActualiserenProjectraming</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_ActualiserenProjectraming_Task_ControlerenWijzigingenNotaVanInlichtingen</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_ControlerenWijzigingenNotaVanInlichtingen" name="Controleren wijzigingen&#10;Nota van inlichtingen" camunda:formRef="rip-controleren-nota-van-inlichtingen" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-kosten-contractdeskundige" ronl:documentRef="rip-nota-van-inlichtingen">
+      <bpmn:incoming>Flow_Task_ActualiserenProjectraming_Task_ControlerenWijzigingenNotaVanInlichtingen</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_ControlerenWijzigingenNotaVanInlichtingen_Gateway_Onregelmatigheid1</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_Onregelmatigheid1" name="Onregelmatigheid&#10;gevonden?">
+      <bpmn:incoming>Flow_Task_ControlerenWijzigingenNotaVanInlichtingen_Gateway_Onregelmatigheid1</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_Onregelmatigheid1_Task_TerzijdeLeggenOnrechtmatigeInschrijving</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_Onregelmatigheid1_Task_ControlerenEenheidsprijzen</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_TerzijdeLeggenOnrechtmatigeInschrijving" name="Terzijde leggen i.v.m.&#10;onrechtmatige inschrijving" camunda:formRef="rip-terzijde-leggen-inschrijving" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-kosten-contractdeskundige">
+      <bpmn:incoming>Flow_Gateway_Onregelmatigheid1_Task_TerzijdeLeggenOnrechtmatigeInschrijving</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_TerzijdeLeggenOnrechtmatigeInschrijving_Task_AfwijzenInschrijving</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_AfwijzenInschrijving" name="Afwijzen inschrijving" camunda:formRef="rip-afwijzen-inschrijving" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-inkoopadviseur">
+      <bpmn:incoming>Flow_Task_TerzijdeLeggenOnrechtmatigeInschrijving_Task_AfwijzenInschrijving</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_AfwijzenInschrijving_EndEvent_InschrijvingAfgewezen</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_InschrijvingAfgewezen" name="Inschrijving afgewezen">
+      <bpmn:incoming>Flow_Task_AfwijzenInschrijving_EndEvent_InschrijvingAfgewezen</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:userTask id="Task_ControlerenEenheidsprijzen" name="Controleren eenheidsprijzen&#10;inschrijfstaat" camunda:formRef="rip-controleren-eenheidsprijzen" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-kosten-contractdeskundige" ronl:documentRef="rip-proces-verbaal-aanbesteding">
+      <bpmn:incoming>Flow_Gateway_Onregelmatigheid1_Task_ControlerenEenheidsprijzen</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_OpvragenVerduidelijkingInschrijving_Task_ControlerenEenheidsprijzen</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_ControlerenEenheidsprijzen_Gateway_Onregelmatigheid2</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_Onregelmatigheid2" name="Onregelmatigheid&#10;gevonden?">
+      <bpmn:incoming>Flow_Task_ControlerenEenheidsprijzen_Gateway_Onregelmatigheid2</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_Onregelmatigheid2_Task_OpvragenVerduidelijkingInschrijving</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_Onregelmatigheid2_Task_OpstellenVoornemenTotGunnen</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_OpvragenVerduidelijkingInschrijving" name="Opvragen verduidelijking&#10;inschrijving" camunda:formRef="rip-opvragen-verduidelijking-inschrijving" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-kosten-contractdeskundige">
+      <bpmn:incoming>Flow_Gateway_Onregelmatigheid2_Task_OpvragenVerduidelijkingInschrijving</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_OpvragenVerduidelijkingInschrijving_Task_ControlerenEenheidsprijzen</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_OpstellenVoornemenTotGunnen" name="Opstellen voornemen tot gunnen&#10;(bij BPKV: bijlage motivering)" camunda:formRef="rip-opstellen-voornemen-tot-gunnen" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-inkoopadviseur,rip-kosten-contractdeskundige" ronl:documentRef="rip-gunningsvoornemen">
+      <bpmn:incoming>Flow_Gateway_Onregelmatigheid2_Task_OpstellenVoornemenTotGunnen</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_OpstellenVoornemenTotGunnen_Gateway_Dekkingsbron</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_Dekkingsbron" name="Over- of onderschrijding&#10;dekkingsbron?">
+      <bpmn:incoming>Flow_Task_OpstellenVoornemenTotGunnen_Gateway_Dekkingsbron</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_Dekkingsbron_Task_OpstellenNotaBesluitvormingConcerndirecteur</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_Dekkingsbron_Task_OpstellenNotaBesluitvormingAo</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_OpstellenNotaBesluitvormingConcerndirecteur" name="Opstellen nota besluitvorming&#10;(Concerndirecteur - sjabloon)" camunda:formRef="rip-nota-besluitvorming-concerndirecteur" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-nota-besluitvorming-concerndirecteur">
+      <bpmn:incoming>Flow_Gateway_Dekkingsbron_Task_OpstellenNotaBesluitvormingConcerndirecteur</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_OpstellenNotaBesluitvormingConcerndirecteur_Task_VaststellenNotaBesluitvormingConcerndirecteur</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_OpstellenNotaBesluitvormingAo" name="Opstellen nota besluitvorming&#10;(AO - sjabloon)" camunda:formRef="rip-nota-besluitvorming-ao" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-nota-besluitvorming-ao">
+      <bpmn:incoming>Flow_Gateway_Dekkingsbron_Task_OpstellenNotaBesluitvormingAo</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_OpstellenNotaBesluitvormingAo_Task_VaststellenNotaBesluitvormingAo</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_VaststellenNotaBesluitvormingConcerndirecteur" name="Vaststellen nota&#10;besluitvorming" camunda:formRef="rip-vaststellen-nota-concerndirecteur" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-concerndirecteur">
+      <bpmn:incoming>Flow_Task_OpstellenNotaBesluitvormingConcerndirecteur_Task_VaststellenNotaBesluitvormingConcerndirecteur</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_VaststellenNotaBesluitvormingConcerndirecteur_Gateway_NotaJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_VaststellenNotaBesluitvormingAo" name="Vaststellen nota&#10;besluitvorming" camunda:formRef="rip-vaststellen-nota-ao" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-ao">
+      <bpmn:incoming>Flow_Task_OpstellenNotaBesluitvormingAo_Task_VaststellenNotaBesluitvormingAo</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_VaststellenNotaBesluitvormingAo_Gateway_NotaJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_NotaJoin">
+      <bpmn:incoming>Flow_Task_VaststellenNotaBesluitvormingConcerndirecteur_Gateway_NotaJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_VaststellenNotaBesluitvormingAo_Gateway_NotaJoin</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_NotaJoin_Task_VerwerkenProjectramingAanbesteding</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_VerwerkenProjectramingAanbesteding" name="Verwerken projectraming&#10;en raamkrediet Infra" camunda:formRef="rip-verwerken-projectraming-aanbesteding" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-financien">
+      <bpmn:incoming>Flow_Gateway_NotaJoin_Task_VerwerkenProjectramingAanbesteding</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_VerwerkenProjectramingAanbesteding_Task_InformerenInkoopadviseur</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_InformerenInkoopadviseur" name="Informeren&#10;Inkoopadviseur" camunda:formRef="rip-informeren-inkoopadviseur" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectondersteuner">
+      <bpmn:incoming>Flow_Task_VerwerkenProjectramingAanbesteding_Task_InformerenInkoopadviseur</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_InformerenInkoopadviseur_Task_AfrondenInkoopprocedure</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_AfrondenInkoopprocedure" name="Afronden&#10;inkoopprocedure" camunda:formRef="rip-afronden-inkoopprocedure" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-inkoopadviseur">
+      <bpmn:incoming>Flow_Task_InformerenInkoopadviseur_Task_AfrondenInkoopprocedure</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_AfrondenInkoopprocedure_EndEvent_Inkoopprocedure</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_Inkoopprocedure" name="Inkoopprocedure afgerond&#10;→ IIN1.2.x Publiceren voornemen tot gunnen (TenderNed)">
+      <bpmn:incoming>Flow_Task_AfrondenInkoopprocedure_EndEvent_Inkoopprocedure</bpmn:incoming>
+    </bpmn:endEvent>
+
+    <bpmn:sequenceFlow id="Flow_StartEvent_R41_Task_VerzoekenTotAanbesteden" sourceRef="StartEvent_R41" targetRef="Task_VerzoekenTotAanbesteden" />
+    <bpmn:sequenceFlow id="Flow_Task_VerzoekenTotAanbesteden_Task_ControlerenAanbestedingsdocumenten" sourceRef="Task_VerzoekenTotAanbesteden" targetRef="Task_ControlerenAanbestedingsdocumenten" />
+    <bpmn:sequenceFlow id="Flow_Task_ControlerenAanbestedingsdocumenten_Gateway_DossierVolledig" sourceRef="Task_ControlerenAanbestedingsdocumenten" targetRef="Gateway_DossierVolledig" />
+    <bpmn:sequenceFlow id="Flow_Gateway_DossierVolledig_Task_HerstellenDossier" name="nee" sourceRef="Gateway_DossierVolledig" targetRef="Task_HerstellenDossier">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${dossierVolledig == "nee"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_DossierVolledig_Task_ActualiserenProjectraming" name="ja" sourceRef="Gateway_DossierVolledig" targetRef="Task_ActualiserenProjectraming">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${dossierVolledig == "ja"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Task_HerstellenDossier_Task_ControlerenAanbestedingsdocumenten" sourceRef="Task_HerstellenDossier" targetRef="Task_ControlerenAanbestedingsdocumenten" />
+    <bpmn:sequenceFlow id="Flow_Task_ActualiserenProjectraming_Task_ControlerenWijzigingenNotaVanInlichtingen" sourceRef="Task_ActualiserenProjectraming" targetRef="Task_ControlerenWijzigingenNotaVanInlichtingen" />
+    <bpmn:sequenceFlow id="Flow_Task_ControlerenWijzigingenNotaVanInlichtingen_Gateway_Onregelmatigheid1" sourceRef="Task_ControlerenWijzigingenNotaVanInlichtingen" targetRef="Gateway_Onregelmatigheid1" />
+    <bpmn:sequenceFlow id="Flow_Gateway_Onregelmatigheid1_Task_TerzijdeLeggenOnrechtmatigeInschrijving" name="ja" sourceRef="Gateway_Onregelmatigheid1" targetRef="Task_TerzijdeLeggenOnrechtmatigeInschrijving">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${onregelmatigheidNotaInlichtingen == "ja"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_Onregelmatigheid1_Task_ControlerenEenheidsprijzen" name="nee" sourceRef="Gateway_Onregelmatigheid1" targetRef="Task_ControlerenEenheidsprijzen">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${onregelmatigheidNotaInlichtingen == "nee"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Task_TerzijdeLeggenOnrechtmatigeInschrijving_Task_AfwijzenInschrijving" sourceRef="Task_TerzijdeLeggenOnrechtmatigeInschrijving" targetRef="Task_AfwijzenInschrijving" />
+    <bpmn:sequenceFlow id="Flow_Task_AfwijzenInschrijving_EndEvent_InschrijvingAfgewezen" sourceRef="Task_AfwijzenInschrijving" targetRef="EndEvent_InschrijvingAfgewezen" />
+    <bpmn:sequenceFlow id="Flow_Task_ControlerenEenheidsprijzen_Gateway_Onregelmatigheid2" sourceRef="Task_ControlerenEenheidsprijzen" targetRef="Gateway_Onregelmatigheid2" />
+    <bpmn:sequenceFlow id="Flow_Gateway_Onregelmatigheid2_Task_OpvragenVerduidelijkingInschrijving" name="ja" sourceRef="Gateway_Onregelmatigheid2" targetRef="Task_OpvragenVerduidelijkingInschrijving">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${onregelmatigheidEenheidsprijzen == "ja"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_Onregelmatigheid2_Task_OpstellenVoornemenTotGunnen" name="nee" sourceRef="Gateway_Onregelmatigheid2" targetRef="Task_OpstellenVoornemenTotGunnen">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${onregelmatigheidEenheidsprijzen == "nee"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Task_OpvragenVerduidelijkingInschrijving_Task_ControlerenEenheidsprijzen" sourceRef="Task_OpvragenVerduidelijkingInschrijving" targetRef="Task_ControlerenEenheidsprijzen" />
+    <bpmn:sequenceFlow id="Flow_Task_OpstellenVoornemenTotGunnen_Gateway_Dekkingsbron" sourceRef="Task_OpstellenVoornemenTotGunnen" targetRef="Gateway_Dekkingsbron" />
+    <bpmn:sequenceFlow id="Flow_Gateway_Dekkingsbron_Task_OpstellenNotaBesluitvormingConcerndirecteur" name="ja" sourceRef="Gateway_Dekkingsbron" targetRef="Task_OpstellenNotaBesluitvormingConcerndirecteur">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${dekkingsbronAfwijking == "ja"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_Dekkingsbron_Task_OpstellenNotaBesluitvormingAo" name="nee" sourceRef="Gateway_Dekkingsbron" targetRef="Task_OpstellenNotaBesluitvormingAo">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${dekkingsbronAfwijking == "nee"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Task_OpstellenNotaBesluitvormingConcerndirecteur_Task_VaststellenNotaBesluitvormingConcerndirecteur" sourceRef="Task_OpstellenNotaBesluitvormingConcerndirecteur" targetRef="Task_VaststellenNotaBesluitvormingConcerndirecteur" />
+    <bpmn:sequenceFlow id="Flow_Task_OpstellenNotaBesluitvormingAo_Task_VaststellenNotaBesluitvormingAo" sourceRef="Task_OpstellenNotaBesluitvormingAo" targetRef="Task_VaststellenNotaBesluitvormingAo" />
+    <bpmn:sequenceFlow id="Flow_Task_VaststellenNotaBesluitvormingConcerndirecteur_Gateway_NotaJoin" sourceRef="Task_VaststellenNotaBesluitvormingConcerndirecteur" targetRef="Gateway_NotaJoin" />
+    <bpmn:sequenceFlow id="Flow_Task_VaststellenNotaBesluitvormingAo_Gateway_NotaJoin" sourceRef="Task_VaststellenNotaBesluitvormingAo" targetRef="Gateway_NotaJoin" />
+    <bpmn:sequenceFlow id="Flow_Gateway_NotaJoin_Task_VerwerkenProjectramingAanbesteding" sourceRef="Gateway_NotaJoin" targetRef="Task_VerwerkenProjectramingAanbesteding" />
+    <bpmn:sequenceFlow id="Flow_Task_VerwerkenProjectramingAanbesteding_Task_InformerenInkoopadviseur" sourceRef="Task_VerwerkenProjectramingAanbesteding" targetRef="Task_InformerenInkoopadviseur" />
+    <bpmn:sequenceFlow id="Flow_Task_InformerenInkoopadviseur_Task_AfrondenInkoopprocedure" sourceRef="Task_InformerenInkoopadviseur" targetRef="Task_AfrondenInkoopprocedure" />
+    <bpmn:sequenceFlow id="Flow_Task_AfrondenInkoopprocedure_EndEvent_Inkoopprocedure" sourceRef="Task_AfrondenInkoopprocedure" targetRef="EndEvent_Inkoopprocedure" />
+
+    <bpmn:textAnnotation id="Annotation_IN1_Inkoopproces">
+      <bpmn:text>IN1. Uitvoeren inkoopprocedure / Inkoopproces</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Assoc_Annotation_IN1_Inkoopproces" sourceRef="Task_ControlerenAanbestedingsdocumenten" targetRef="Annotation_IN1_Inkoopproces" />
+    <bpmn:textAnnotation id="Annotation_KV2_Infranotas">
+      <bpmn:text>KV2. Infranota's</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Assoc_Annotation_KV2_Infranotas" sourceRef="Gateway_NotaJoin" targetRef="Annotation_KV2_Infranotas" />
+  </bpmn:process>
+
+  <bpmndi:BPMNDiagram id="BPMNDiagram_RipR41Process">
+    <bpmndi:BPMNPlane id="BPMNPlane_RipR41Process" bpmnElement="Collaboration_RipR41Process">
+      <bpmndi:BPMNShape id="Participant_RipR41Process_di" bpmnElement="Participant_RipR41Process" isHorizontal="true">
+        <dc:Bounds x="160" y="80" width="2726" height="1160" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_KostenContractdeskundige_di" bpmnElement="Lane_KostenContractdeskundige" isHorizontal="true">
+        <dc:Bounds x="190" y="80" width="2696" height="280" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Inkoopadviseur_di" bpmnElement="Lane_Inkoopadviseur" isHorizontal="true">
+        <dc:Bounds x="190" y="360" width="2696" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Projectleider_di" bpmnElement="Lane_Projectleider" isHorizontal="true">
+        <dc:Bounds x="190" y="560" width="2696" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Concerndirecteur_di" bpmnElement="Lane_Concerndirecteur" isHorizontal="true">
+        <dc:Bounds x="190" y="760" width="2696" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Financien_di" bpmnElement="Lane_Financien" isHorizontal="true">
+        <dc:Bounds x="190" y="880" width="2696" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_AO_di" bpmnElement="Lane_AO" isHorizontal="true">
+        <dc:Bounds x="190" y="1000" width="2696" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Projectondersteuner_di" bpmnElement="Lane_Projectondersteuner" isHorizontal="true">
+        <dc:Bounds x="190" y="1120" width="2696" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_R41_di" bpmnElement="StartEvent_R41">
+        <dc:Bounds x="232" y="212" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="122" y="253" width="256" height="28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_VerzoekenTotAanbesteden_di" bpmnElement="Task_VerzoekenTotAanbesteden">
+        <dc:Bounds x="300" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_ControlerenAanbestedingsdocumenten_di" bpmnElement="Task_ControlerenAanbestedingsdocumenten">
+        <dc:Bounds x="460" y="380" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_DossierVolledig_di" bpmnElement="Gateway_DossierVolledig" isMarkerVisible="true">
+        <dc:Bounds x="620" y="395" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="600" y="450" width="90" height="28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_HerstellenDossier_di" bpmnElement="Task_HerstellenDossier">
+        <dc:Bounds x="700" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_ActualiserenProjectraming_di" bpmnElement="Task_ActualiserenProjectraming">
+        <dc:Bounds x="860" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_ControlerenWijzigingenNotaVanInlichtingen_di" bpmnElement="Task_ControlerenWijzigingenNotaVanInlichtingen">
+        <dc:Bounds x="1020" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_Onregelmatigheid1_di" bpmnElement="Gateway_Onregelmatigheid1" isMarkerVisible="true">
+        <dc:Bounds x="1180" y="205" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1141" y="260" width="128" height="28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_TerzijdeLeggenOnrechtmatigeInschrijving_di" bpmnElement="Task_TerzijdeLeggenOnrechtmatigeInschrijving">
+        <dc:Bounds x="1260" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_AfwijzenInschrijving_di" bpmnElement="Task_AfwijzenInschrijving">
+        <dc:Bounds x="1420" y="380" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_InschrijvingAfgewezen_di" bpmnElement="EndEvent_InschrijvingAfgewezen">
+        <dc:Bounds x="1580" y="402" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1510" y="443" width="176" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_ControlerenEenheidsprijzen_di" bpmnElement="Task_ControlerenEenheidsprijzen">
+        <dc:Bounds x="1260" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_Onregelmatigheid2_di" bpmnElement="Gateway_Onregelmatigheid2" isMarkerVisible="true">
+        <dc:Bounds x="1420" y="205" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1381" y="260" width="128" height="28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_OpvragenVerduidelijkingInschrijving_di" bpmnElement="Task_OpvragenVerduidelijkingInschrijving">
+        <dc:Bounds x="1500" y="270" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_OpstellenVoornemenTotGunnen_di" bpmnElement="Task_OpstellenVoornemenTotGunnen">
+        <dc:Bounds x="1660" y="380" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_Dekkingsbron_di" bpmnElement="Gateway_Dekkingsbron" isMarkerVisible="true">
+        <dc:Bounds x="1820" y="595" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1749" y="650" width="192" height="28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_OpstellenNotaBesluitvormingConcerndirecteur_di" bpmnElement="Task_OpstellenNotaBesluitvormingConcerndirecteur">
+        <dc:Bounds x="1900" y="580" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_OpstellenNotaBesluitvormingAo_di" bpmnElement="Task_OpstellenNotaBesluitvormingAo">
+        <dc:Bounds x="1900" y="670" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_VaststellenNotaBesluitvormingConcerndirecteur_di" bpmnElement="Task_VaststellenNotaBesluitvormingConcerndirecteur">
+        <dc:Bounds x="2060" y="780" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_VaststellenNotaBesluitvormingAo_di" bpmnElement="Task_VaststellenNotaBesluitvormingAo">
+        <dc:Bounds x="2060" y="1020" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_NotaJoin_di" bpmnElement="Gateway_NotaJoin" isMarkerVisible="true">
+        <dc:Bounds x="2220" y="595" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_VerwerkenProjectramingAanbesteding_di" bpmnElement="Task_VerwerkenProjectramingAanbesteding">
+        <dc:Bounds x="2300" y="900" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_InformerenInkoopadviseur_di" bpmnElement="Task_InformerenInkoopadviseur">
+        <dc:Bounds x="2460" y="1140" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_AfrondenInkoopprocedure_di" bpmnElement="Task_AfrondenInkoopprocedure">
+        <dc:Bounds x="2620" y="380" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_Inkoopprocedure_di" bpmnElement="EndEvent_Inkoopprocedure">
+        <dc:Bounds x="2780" y="402" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2582" y="443" width="432" height="28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Annotation_IN1_Inkoopproces_di" bpmnElement="Annotation_IN1_Inkoopproces">
+        <dc:Bounds x="400" y="620" width="260" height="45" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Annotation_KV2_Infranotas_di" bpmnElement="Annotation_KV2_Infranotas">
+        <dc:Bounds x="2160" y="1240" width="200" height="45" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_StartEvent_R41_Task_VerzoekenTotAanbesteden_di" bpmnElement="Flow_StartEvent_R41_Task_VerzoekenTotAanbesteden">
+        <di:waypoint x="268" y="230" />
+        <di:waypoint x="300" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_VerzoekenTotAanbesteden_Task_ControlerenAanbestedingsdocumenten_di" bpmnElement="Flow_Task_VerzoekenTotAanbesteden_Task_ControlerenAanbestedingsdocumenten">
+        <di:waypoint x="400" y="230" />
+        <di:waypoint x="430" y="230" />
+        <di:waypoint x="430" y="420" />
+        <di:waypoint x="460" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_ControlerenAanbestedingsdocumenten_Gateway_DossierVolledig_di" bpmnElement="Flow_Task_ControlerenAanbestedingsdocumenten_Gateway_DossierVolledig">
+        <di:waypoint x="560" y="420" />
+        <di:waypoint x="620" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_DossierVolledig_Task_HerstellenDossier_di" bpmnElement="Flow_Gateway_DossierVolledig_Task_HerstellenDossier">
+        <di:waypoint x="670" y="420" />
+        <di:waypoint x="685" y="420" />
+        <di:waypoint x="685" y="230" />
+        <di:waypoint x="700" y="230" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="676" y="400" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_DossierVolledig_Task_ActualiserenProjectraming_di" bpmnElement="Flow_Gateway_DossierVolledig_Task_ActualiserenProjectraming">
+        <di:waypoint x="670" y="420" />
+        <di:waypoint x="765" y="420" />
+        <di:waypoint x="765" y="230" />
+        <di:waypoint x="860" y="230" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="676" y="400" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_HerstellenDossier_Task_ControlerenAanbestedingsdocumenten_di" bpmnElement="Flow_Task_HerstellenDossier_Task_ControlerenAanbestedingsdocumenten">
+        <di:waypoint x="750" y="270" />
+        <di:waypoint x="750" y="352" />
+        <di:waypoint x="510" y="352" />
+        <di:waypoint x="510" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_ActualiserenProjectraming_Task_ControlerenWijzigingenNotaVanInlichtingen_di" bpmnElement="Flow_Task_ActualiserenProjectraming_Task_ControlerenWijzigingenNotaVanInlichtingen">
+        <di:waypoint x="960" y="230" />
+        <di:waypoint x="1020" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_ControlerenWijzigingenNotaVanInlichtingen_Gateway_Onregelmatigheid1_di" bpmnElement="Flow_Task_ControlerenWijzigingenNotaVanInlichtingen_Gateway_Onregelmatigheid1">
+        <di:waypoint x="1120" y="230" />
+        <di:waypoint x="1180" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_Onregelmatigheid1_Task_TerzijdeLeggenOnrechtmatigeInschrijving_di" bpmnElement="Flow_Gateway_Onregelmatigheid1_Task_TerzijdeLeggenOnrechtmatigeInschrijving">
+        <di:waypoint x="1230" y="230" />
+        <di:waypoint x="1245" y="230" />
+        <di:waypoint x="1245" y="140" />
+        <di:waypoint x="1260" y="140" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1236" y="210" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_Onregelmatigheid1_Task_ControlerenEenheidsprijzen_di" bpmnElement="Flow_Gateway_Onregelmatigheid1_Task_ControlerenEenheidsprijzen">
+        <di:waypoint x="1230" y="230" />
+        <di:waypoint x="1260" y="230" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1236" y="210" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_TerzijdeLeggenOnrechtmatigeInschrijving_Task_AfwijzenInschrijving_di" bpmnElement="Flow_Task_TerzijdeLeggenOnrechtmatigeInschrijving_Task_AfwijzenInschrijving">
+        <di:waypoint x="1360" y="140" />
+        <di:waypoint x="1390" y="140" />
+        <di:waypoint x="1390" y="420" />
+        <di:waypoint x="1420" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_AfwijzenInschrijving_EndEvent_InschrijvingAfgewezen_di" bpmnElement="Flow_Task_AfwijzenInschrijving_EndEvent_InschrijvingAfgewezen">
+        <di:waypoint x="1520" y="420" />
+        <di:waypoint x="1580" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_ControlerenEenheidsprijzen_Gateway_Onregelmatigheid2_di" bpmnElement="Flow_Task_ControlerenEenheidsprijzen_Gateway_Onregelmatigheid2">
+        <di:waypoint x="1360" y="230" />
+        <di:waypoint x="1420" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_Onregelmatigheid2_Task_OpvragenVerduidelijkingInschrijving_di" bpmnElement="Flow_Gateway_Onregelmatigheid2_Task_OpvragenVerduidelijkingInschrijving">
+        <di:waypoint x="1470" y="230" />
+        <di:waypoint x="1485" y="230" />
+        <di:waypoint x="1485" y="310" />
+        <di:waypoint x="1500" y="310" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1476" y="210" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_Onregelmatigheid2_Task_OpstellenVoornemenTotGunnen_di" bpmnElement="Flow_Gateway_Onregelmatigheid2_Task_OpstellenVoornemenTotGunnen">
+        <di:waypoint x="1470" y="230" />
+        <di:waypoint x="1565" y="230" />
+        <di:waypoint x="1565" y="420" />
+        <di:waypoint x="1660" y="420" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1476" y="210" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_OpvragenVerduidelijkingInschrijving_Task_ControlerenEenheidsprijzen_di" bpmnElement="Flow_Task_OpvragenVerduidelijkingInschrijving_Task_ControlerenEenheidsprijzen">
+        <di:waypoint x="1550" y="350" />
+        <di:waypoint x="1550" y="352" />
+        <di:waypoint x="1310" y="352" />
+        <di:waypoint x="1310" y="270" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_OpstellenVoornemenTotGunnen_Gateway_Dekkingsbron_di" bpmnElement="Flow_Task_OpstellenVoornemenTotGunnen_Gateway_Dekkingsbron">
+        <di:waypoint x="1760" y="420" />
+        <di:waypoint x="1790" y="420" />
+        <di:waypoint x="1790" y="620" />
+        <di:waypoint x="1820" y="620" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_Dekkingsbron_Task_OpstellenNotaBesluitvormingConcerndirecteur_di" bpmnElement="Flow_Gateway_Dekkingsbron_Task_OpstellenNotaBesluitvormingConcerndirecteur">
+        <di:waypoint x="1870" y="620" />
+        <di:waypoint x="1900" y="620" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1876" y="600" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_Dekkingsbron_Task_OpstellenNotaBesluitvormingAo_di" bpmnElement="Flow_Gateway_Dekkingsbron_Task_OpstellenNotaBesluitvormingAo">
+        <di:waypoint x="1870" y="620" />
+        <di:waypoint x="1885" y="620" />
+        <di:waypoint x="1885" y="710" />
+        <di:waypoint x="1900" y="710" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1876" y="600" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_OpstellenNotaBesluitvormingConcerndirecteur_Task_VaststellenNotaBesluitvormingConcerndirecteur_di" bpmnElement="Flow_Task_OpstellenNotaBesluitvormingConcerndirecteur_Task_VaststellenNotaBesluitvormingConcerndirecteur">
+        <di:waypoint x="2000" y="620" />
+        <di:waypoint x="2030" y="620" />
+        <di:waypoint x="2030" y="820" />
+        <di:waypoint x="2060" y="820" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_OpstellenNotaBesluitvormingAo_Task_VaststellenNotaBesluitvormingAo_di" bpmnElement="Flow_Task_OpstellenNotaBesluitvormingAo_Task_VaststellenNotaBesluitvormingAo">
+        <di:waypoint x="2000" y="710" />
+        <di:waypoint x="2030" y="710" />
+        <di:waypoint x="2030" y="1060" />
+        <di:waypoint x="2060" y="1060" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_VaststellenNotaBesluitvormingConcerndirecteur_Gateway_NotaJoin_di" bpmnElement="Flow_Task_VaststellenNotaBesluitvormingConcerndirecteur_Gateway_NotaJoin">
+        <di:waypoint x="2160" y="820" />
+        <di:waypoint x="2190" y="820" />
+        <di:waypoint x="2190" y="620" />
+        <di:waypoint x="2220" y="620" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_VaststellenNotaBesluitvormingAo_Gateway_NotaJoin_di" bpmnElement="Flow_Task_VaststellenNotaBesluitvormingAo_Gateway_NotaJoin">
+        <di:waypoint x="2160" y="1060" />
+        <di:waypoint x="2190" y="1060" />
+        <di:waypoint x="2190" y="620" />
+        <di:waypoint x="2220" y="620" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_NotaJoin_Task_VerwerkenProjectramingAanbesteding_di" bpmnElement="Flow_Gateway_NotaJoin_Task_VerwerkenProjectramingAanbesteding">
+        <di:waypoint x="2270" y="620" />
+        <di:waypoint x="2285" y="620" />
+        <di:waypoint x="2285" y="940" />
+        <di:waypoint x="2300" y="940" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_VerwerkenProjectramingAanbesteding_Task_InformerenInkoopadviseur_di" bpmnElement="Flow_Task_VerwerkenProjectramingAanbesteding_Task_InformerenInkoopadviseur">
+        <di:waypoint x="2400" y="940" />
+        <di:waypoint x="2430" y="940" />
+        <di:waypoint x="2430" y="1180" />
+        <di:waypoint x="2460" y="1180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_InformerenInkoopadviseur_Task_AfrondenInkoopprocedure_di" bpmnElement="Flow_Task_InformerenInkoopadviseur_Task_AfrondenInkoopprocedure">
+        <di:waypoint x="2560" y="1180" />
+        <di:waypoint x="2590" y="1180" />
+        <di:waypoint x="2590" y="420" />
+        <di:waypoint x="2620" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_AfrondenInkoopprocedure_EndEvent_Inkoopprocedure_di" bpmnElement="Flow_Task_AfrondenInkoopprocedure_EndEvent_Inkoopprocedure">
+        <di:waypoint x="2720" y="420" />
+        <di:waypoint x="2780" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Assoc_Annotation_IN1_Inkoopproces_di" bpmnElement="Assoc_Annotation_IN1_Inkoopproces">
+        <di:waypoint x="510" y="380" />
+        <di:waypoint x="530" y="665" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Assoc_Annotation_KV2_Infranotas_di" bpmnElement="Assoc_Annotation_KV2_Infranotas">
+        <di:waypoint x="2245" y="595" />
+        <di:waypoint x="2260" y="1285" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/examples/organizations/flevoland/rip-phase-41/rip-aanbestedingsdossier.document
+++ b/examples/organizations/flevoland/rip-phase-41/rip-aanbestedingsdossier.document
@@ -1,0 +1,225 @@
+{
+  "id": "rip-aanbestedingsdossier",
+  "name": "RIP — Tender Dossier (Aanbestedingsdossier)",
+  "description": "The tender dossier checked for completeness before upload to the procurement procedure.",
+  "processKey": "RipR41Process",
+  "serviceId": "RipR41",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{aanbestedingsdossierReferentie}}",
+      "variableKey": "aanbestedingsdossierReferentie",
+      "source": "process",
+      "label": "Tender dossier reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{dossierGecontroleerdOp}}",
+      "variableKey": "dossierGecontroleerdOp",
+      "source": "process",
+      "label": "Checked on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{dossierVolledig}}",
+      "variableKey": "dossierVolledig",
+      "source": "process",
+      "label": "Complete"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{dossierOntbrekendeStukken}}",
+      "variableKey": "dossierOntbrekendeStukken",
+      "source": "process",
+      "label": "Missing parts"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{aanbestedingsverzoekReferentie}}",
+      "variableKey": "aanbestedingsverzoekReferentie",
+      "source": "process",
+      "label": "Tender request reference"
+    },
+    {
+      "id": "b8",
+      "placeholder": "{{contractdocumentenReferentie}}",
+      "variableKey": "contractdocumentenReferentie",
+      "source": "process",
+      "label": "Contract document set reference"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Tender dossier {{aanbestedingsdossierReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Tender dossier",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Tender dossier"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Tender dossier {{aanbestedingsdossierReferentie}} for project {{projectNumber}} — {{projectName}} was checked on {{dossierGecontroleerdOp}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Complete: {{dossierVolledig}}. {{dossierOntbrekendeStukken}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "It follows tender request {{aanbestedingsverzoekReferentie}} and the contract document set {{contractdocumentenReferentie}} adopted in R3.2."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Checked by the procurement adviser"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-41/rip-actualiseren-projectraming.form
+++ b/examples/organizations/flevoland/rip-phase-41/rip-actualiseren-projectraming.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-actualiseren-projectraming",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Update the project estimate"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Update the project estimate for the tender, producing the projectraming na aanbesteding."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Updated project estimate reference",
+      "key": "projectramingNaAanbestedingReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bedrag",
+      "type": "number",
+      "label": "Updated project estimate (EUR)",
+      "key": "projectramingNaAanbestedingBedrag",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Updated on",
+      "key": "projectramingGeactualiseerdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-41/rip-afronden-inkoopprocedure.form
+++ b/examples/organizations/flevoland/rip-phase-41/rip-afronden-inkoopprocedure.form
@@ -1,0 +1,43 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-afronden-inkoopprocedure",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Close the procurement procedure"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Close the procurement procedure so the intention to award can be published on TenderNed."
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Closed on",
+      "key": "inkoopprocedureAfgerondOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Notes",
+      "key": "inkoopprocedureOpmerkingen"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-41/rip-afwijzen-inschrijving.form
+++ b/examples/organizations/flevoland/rip-phase-41/rip-afwijzen-inschrijving.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-afwijzen-inschrijving",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Reject the tender"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Record the rejection of the tender that was set aside."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Rejection reference",
+      "key": "afwijzingReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Motivering",
+      "type": "textarea",
+      "label": "Reasons given to the tenderer",
+      "key": "afwijzingMotivering",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Rejected on",
+      "key": "inschrijvingAfgewezenOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-41/rip-controleren-aanbestedingsdocumenten.form
+++ b/examples/organizations/flevoland/rip-phase-41/rip-controleren-aanbestedingsdocumenten.form
@@ -1,0 +1,71 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-controleren-aanbestedingsdocumenten",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Check the tender documents are ready for upload"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The procurement adviser checks the aanbestedingsdossier is complete before it goes to the procurement procedure."
+    },
+    {
+      "id": "F_Dossier",
+      "type": "textfield",
+      "label": "Tender dossier reference",
+      "key": "aanbestedingsdossierReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Volledig",
+      "type": "select",
+      "label": "Dossier complete",
+      "key": "dossierVolledig",
+      "values": [
+        {
+          "label": "Yes",
+          "value": "ja"
+        },
+        {
+          "label": "No",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Ontbreekt",
+      "type": "textarea",
+      "label": "What is missing, if anything",
+      "key": "dossierOntbrekendeStukken"
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Checked on",
+      "key": "dossierGecontroleerdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-41/rip-controleren-eenheidsprijzen.form
+++ b/examples/organizations/flevoland/rip-phase-41/rip-controleren-eenheidsprijzen.form
@@ -1,0 +1,83 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-controleren-eenheidsprijzen",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Check the unit prices in the tender schedule"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Check the unit prices in the inschrijfstaat against the contractor offer and the updated project estimate, and decide whether an irregularity was found."
+    },
+    {
+      "id": "F_Pv",
+      "type": "textfield",
+      "label": "Proces verbaal reference",
+      "key": "procesVerbaalReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Aanbieding",
+      "type": "textfield",
+      "label": "Contractor offer reference",
+      "key": "aanbiedingAannemerReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bevindingen",
+      "type": "textarea",
+      "label": "Findings on the unit prices",
+      "key": "eenheidsprijzenBevindingen",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Onregelmatig",
+      "type": "select",
+      "label": "Irregularity found",
+      "key": "onregelmatigheidEenheidsprijzen",
+      "values": [
+        {
+          "label": "Yes",
+          "value": "ja"
+        },
+        {
+          "label": "No",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Checked on",
+      "key": "eenheidsprijzenGecontroleerdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-41/rip-controleren-nota-van-inlichtingen.form
+++ b/examples/organizations/flevoland/rip-phase-41/rip-controleren-nota-van-inlichtingen.form
@@ -1,0 +1,74 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-controleren-nota-van-inlichtingen",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Check the changes in the note of information"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Check the changes recorded in the Nota van inlichtingen and decide whether an irregularity was found."
+    },
+    {
+      "id": "F_Nota",
+      "type": "textfield",
+      "label": "Nota van inlichtingen reference",
+      "key": "notaVanInlichtingenReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Wijzigingen",
+      "type": "textarea",
+      "label": "Changes checked",
+      "key": "notaWijzigingen",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Onregelmatig",
+      "type": "select",
+      "label": "Irregularity found",
+      "key": "onregelmatigheidNotaInlichtingen",
+      "values": [
+        {
+          "label": "Yes",
+          "value": "ja"
+        },
+        {
+          "label": "No",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Checked on",
+      "key": "notaGecontroleerdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-41/rip-gunningsvoornemen.document
+++ b/examples/organizations/flevoland/rip-phase-41/rip-gunningsvoornemen.document
@@ -1,0 +1,234 @@
+{
+  "id": "rip-gunningsvoornemen",
+  "name": "RIP — Intention to Award (Gunningsvoornemen)",
+  "description": "The intention to award, with the BPKV substantiation annex where that applies.",
+  "processKey": "RipR41Process",
+  "serviceId": "RipR41",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{gunningsvoornemenReferentie}}",
+      "variableKey": "gunningsvoornemenReferentie",
+      "source": "process",
+      "label": "Gunningsvoornemen reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{gunningsvoornemenOp}}",
+      "variableKey": "gunningsvoornemenOp",
+      "source": "process",
+      "label": "Drawn up on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{voorgenomenAannemer}}",
+      "variableKey": "voorgenomenAannemer",
+      "source": "process",
+      "label": "Proposed contractor"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{gunningBedrag}}",
+      "variableKey": "gunningBedrag",
+      "source": "process",
+      "label": "Award amount"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{bpkvVanToepassing}}",
+      "variableKey": "bpkvVanToepassing",
+      "source": "process",
+      "label": "BPKV applies"
+    },
+    {
+      "id": "b8",
+      "placeholder": "{{gunningMotivering}}",
+      "variableKey": "gunningMotivering",
+      "source": "process",
+      "label": "Substantiation"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Gunningsvoornemen {{gunningsvoornemenReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Intention to award",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Intention to award"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Gunningsvoornemen {{gunningsvoornemenReferentie}} for project {{projectNumber}} — {{projectName}} was drawn up on {{gunningsvoornemenOp}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Proposed contractor: {{voorgenomenAannemer}}, award amount EUR {{gunningBedrag}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "BPKV applies: {{bpkvVanToepassing}}. Substantiation: {{gunningMotivering}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Once the decision note is adopted, the intention is published on TenderNed under IIN1.2.x."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up by the procurement adviser"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-41/rip-herstellen-dossier.form
+++ b/examples/organizations/flevoland/rip-phase-41/rip-herstellen-dossier.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-herstellen-dossier",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Repair the tender dossier"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Complete the missing parts of the tender dossier and resubmit it for checking."
+    },
+    {
+      "id": "F_Hersteld",
+      "type": "textarea",
+      "label": "What was added or corrected",
+      "key": "dossierHerstelToelichting",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Repaired on",
+      "key": "dossierHersteldOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-41/rip-informeren-inkoopadviseur.form
+++ b/examples/organizations/flevoland/rip-phase-41/rip-informeren-inkoopadviseur.form
@@ -1,0 +1,43 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-informeren-inkoopadviseur",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Inform the procurement adviser"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Inform the procurement adviser that the decision note is adopted, so the procurement procedure can be closed."
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Informed on",
+      "key": "inkoopadviseurGeinformeerdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Message",
+      "key": "inkoopadviseurBericht"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-41/rip-nota-besluitvorming-ao.document
+++ b/examples/organizations/flevoland/rip-phase-41/rip-nota-besluitvorming-ao.document
@@ -1,0 +1,225 @@
+{
+  "id": "rip-nota-besluitvorming-ao",
+  "name": "RIP — Decision Note, AO (Nota besluitvorming)",
+  "description": "Sjabloon nota besluitvorming for the AO, used when the award stays within the funding source.",
+  "processKey": "RipR41Process",
+  "serviceId": "RipR41",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{notaAoReferentie}}",
+      "variableKey": "notaAoReferentie",
+      "source": "process",
+      "label": "Decision note reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{notaAoToelichting}}",
+      "variableKey": "notaAoToelichting",
+      "source": "process",
+      "label": "Substantiation"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{notaAoVastgesteld}}",
+      "variableKey": "notaAoVastgesteld",
+      "source": "process",
+      "label": "Adopted"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{notaAoVastgesteldDoor}}",
+      "variableKey": "notaAoVastgesteldDoor",
+      "source": "process",
+      "label": "Adopted by"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{notaAoVastgesteldOp}}",
+      "variableKey": "notaAoVastgesteldOp",
+      "source": "process",
+      "label": "Adopted on"
+    },
+    {
+      "id": "b8",
+      "placeholder": "{{notaAoOpmerkingen}}",
+      "variableKey": "notaAoOpmerkingen",
+      "source": "process",
+      "label": "Comments"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Nota {{notaAoReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Decision note — AO",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Decision note — AO"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The award for project {{projectNumber}} — {{projectName}} stays within the funding source, so the decision goes to the AO."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Substantiation: {{notaAoToelichting}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Adopted: {{notaAoVastgesteld}}, by {{notaAoVastgesteldDoor}} on {{notaAoVastgesteldOp}}. {{notaAoOpmerkingen}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Adopted by the AO"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-41/rip-nota-besluitvorming-ao.form
+++ b/examples/organizations/flevoland/rip-phase-41/rip-nota-besluitvorming-ao.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-nota-besluitvorming-ao",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Draw up the decision note (AO template)"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The award stays within the funding source, so the decision note goes to the AO for adoption."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Decision note reference",
+      "key": "notaAoReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Toel",
+      "type": "textarea",
+      "label": "Substantiation",
+      "key": "notaAoToelichting",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Drawn up on",
+      "key": "notaAoOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-41/rip-nota-besluitvorming-concerndirecteur.document
+++ b/examples/organizations/flevoland/rip-phase-41/rip-nota-besluitvorming-concerndirecteur.document
@@ -1,0 +1,232 @@
+{
+  "id": "rip-nota-besluitvorming-concerndirecteur",
+  "name": "RIP — Decision Note, Concerndirecteur (Nota besluitvorming)",
+  "description": "Sjabloon nota besluitvorming for the concern director, used when the award deviates from the funding source.",
+  "processKey": "RipR41Process",
+  "serviceId": "RipR41",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{notaConcerndirecteurReferentie}}",
+      "variableKey": "notaConcerndirecteurReferentie",
+      "source": "process",
+      "label": "Decision note reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{afwijkingDekkingsbron}}",
+      "variableKey": "afwijkingDekkingsbron",
+      "source": "process",
+      "label": "Deviation"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{notaConcerndirecteurToelichting}}",
+      "variableKey": "notaConcerndirecteurToelichting",
+      "source": "process",
+      "label": "Substantiation"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{notaConcerndirecteurVastgesteld}}",
+      "variableKey": "notaConcerndirecteurVastgesteld",
+      "source": "process",
+      "label": "Adopted"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{notaConcerndirecteurVastgesteldDoor}}",
+      "variableKey": "notaConcerndirecteurVastgesteldDoor",
+      "source": "process",
+      "label": "Adopted by"
+    },
+    {
+      "id": "b8",
+      "placeholder": "{{notaConcerndirecteurVastgesteldOp}}",
+      "variableKey": "notaConcerndirecteurVastgesteldOp",
+      "source": "process",
+      "label": "Adopted on"
+    },
+    {
+      "id": "b9",
+      "placeholder": "{{notaConcerndirecteurOpmerkingen}}",
+      "variableKey": "notaConcerndirecteurOpmerkingen",
+      "source": "process",
+      "label": "Comments"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Nota {{notaConcerndirecteurReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Decision note — concern director",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Decision note — concern director"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The award for project {{projectNumber}} — {{projectName}} deviates from the funding source by EUR {{afwijkingDekkingsbron}}, so the decision goes to the concern director."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Substantiation: {{notaConcerndirecteurToelichting}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Adopted: {{notaConcerndirecteurVastgesteld}}, by {{notaConcerndirecteurVastgesteldDoor}} on {{notaConcerndirecteurVastgesteldOp}}. {{notaConcerndirecteurOpmerkingen}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Adopted by the concern director"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-41/rip-nota-besluitvorming-concerndirecteur.form
+++ b/examples/organizations/flevoland/rip-phase-41/rip-nota-besluitvorming-concerndirecteur.form
@@ -1,0 +1,64 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-nota-besluitvorming-concerndirecteur",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Draw up the decision note (Concerndirecteur template)"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The award over- or undershoots the funding source, so the decision note goes to the concern director for adoption."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Decision note reference",
+      "key": "notaConcerndirecteurReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Afwijking",
+      "type": "number",
+      "label": "Deviation against the funding source (EUR)",
+      "key": "afwijkingDekkingsbron",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Toel",
+      "type": "textarea",
+      "label": "Substantiation",
+      "key": "notaConcerndirecteurToelichting",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Drawn up on",
+      "key": "notaConcerndirecteurOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-41/rip-nota-van-inlichtingen.document
+++ b/examples/organizations/flevoland/rip-phase-41/rip-nota-van-inlichtingen.document
@@ -1,0 +1,211 @@
+{
+  "id": "rip-nota-van-inlichtingen",
+  "name": "RIP — Note of Information (Nota van inlichtingen)",
+  "description": "The note of information issued during the tender, and the check on the changes it records.",
+  "processKey": "RipR41Process",
+  "serviceId": "RipR41",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{notaVanInlichtingenReferentie}}",
+      "variableKey": "notaVanInlichtingenReferentie",
+      "source": "process",
+      "label": "Nota reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{notaGecontroleerdOp}}",
+      "variableKey": "notaGecontroleerdOp",
+      "source": "process",
+      "label": "Checked on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{notaWijzigingen}}",
+      "variableKey": "notaWijzigingen",
+      "source": "process",
+      "label": "Changes checked"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{onregelmatigheidNotaInlichtingen}}",
+      "variableKey": "onregelmatigheidNotaInlichtingen",
+      "source": "process",
+      "label": "Irregularity found"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Nota {{notaVanInlichtingenReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Note of information",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Note of information"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Nota van inlichtingen {{notaVanInlichtingenReferentie}} for project {{projectNumber}} — {{projectName}} was checked on {{notaGecontroleerdOp}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Changes checked: {{notaWijzigingen}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Irregularity found: {{onregelmatigheidNotaInlichtingen}}."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Checked by the cost and contract specialist"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-41/rip-opstellen-voornemen-tot-gunnen.form
+++ b/examples/organizations/flevoland/rip-phase-41/rip-opstellen-voornemen-tot-gunnen.form
@@ -1,0 +1,108 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-opstellen-voornemen-tot-gunnen",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Draw up the intention to award"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Draw up the gunningsvoornemen. Under BPKV an annex substantiating the award is included. Drafted by the procurement adviser."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Intention to award reference",
+      "key": "gunningsvoornemenReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Aannemer",
+      "type": "textfield",
+      "label": "Proposed contractor",
+      "key": "voorgenomenAannemer",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bedrag",
+      "type": "number",
+      "label": "Award amount (EUR)",
+      "key": "gunningBedrag",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bpkv",
+      "type": "select",
+      "label": "BPKV applies (annex required)",
+      "key": "bpkvVanToepassing",
+      "values": [
+        {
+          "label": "Yes",
+          "value": "ja"
+        },
+        {
+          "label": "No",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Motivering",
+      "type": "textarea",
+      "label": "Substantiation of the award",
+      "key": "gunningMotivering"
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Drawn up on",
+      "key": "gunningsvoornemenOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Dekkingsbron",
+      "type": "select",
+      "label": "Award over- or undershoots the funding source",
+      "key": "dekkingsbronAfwijking",
+      "values": [
+        {
+          "label": "Yes",
+          "value": "ja"
+        },
+        {
+          "label": "No",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-41/rip-opvragen-verduidelijking-inschrijving.form
+++ b/examples/organizations/flevoland/rip-phase-41/rip-opvragen-verduidelijking-inschrijving.form
@@ -1,0 +1,52 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-opvragen-verduidelijking-inschrijving",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Request clarification of the tender"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Ask the tenderer to clarify the tender, then check the unit prices again."
+    },
+    {
+      "id": "F_Vraag",
+      "type": "textarea",
+      "label": "Clarification requested",
+      "key": "verduidelijkingVraag",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Antwoord",
+      "type": "textarea",
+      "label": "Clarification received",
+      "key": "verduidelijkingAntwoord"
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Requested on",
+      "key": "verduidelijkingOpgevraagdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-41/rip-proces-verbaal-aanbesteding.document
+++ b/examples/organizations/flevoland/rip-phase-41/rip-proces-verbaal-aanbesteding.document
@@ -1,0 +1,218 @@
+{
+  "id": "rip-proces-verbaal-aanbesteding",
+  "name": "RIP — Tender Record (Proces verbaal)",
+  "description": "Sjabloon Proces verbaal. Records the unit-price check on the tender schedule and the contractor offer.",
+  "processKey": "RipR41Process",
+  "serviceId": "RipR41",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{procesVerbaalReferentie}}",
+      "variableKey": "procesVerbaalReferentie",
+      "source": "process",
+      "label": "Proces verbaal reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{eenheidsprijzenGecontroleerdOp}}",
+      "variableKey": "eenheidsprijzenGecontroleerdOp",
+      "source": "process",
+      "label": "Checked on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{aanbiedingAannemerReferentie}}",
+      "variableKey": "aanbiedingAannemerReferentie",
+      "source": "process",
+      "label": "Contractor offer reference"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{eenheidsprijzenBevindingen}}",
+      "variableKey": "eenheidsprijzenBevindingen",
+      "source": "process",
+      "label": "Findings"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{onregelmatigheidEenheidsprijzen}}",
+      "variableKey": "onregelmatigheidEenheidsprijzen",
+      "source": "process",
+      "label": "Irregularity found"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Proces verbaal {{procesVerbaalReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Tender record",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Tender record"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Proces verbaal {{procesVerbaalReferentie}} for project {{projectNumber}} — {{projectName}} records the unit-price check carried out on {{eenheidsprijzenGecontroleerdOp}} against contractor offer {{aanbiedingAannemerReferentie}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Findings: {{eenheidsprijzenBevindingen}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Irregularity found: {{onregelmatigheidEenheidsprijzen}}."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Recorded by the cost and contract specialist"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-41/rip-projectraming-na-aanbesteding.document
+++ b/examples/organizations/flevoland/rip-phase-41/rip-projectraming-na-aanbesteding.document
@@ -1,0 +1,186 @@
+{
+  "id": "rip-projectraming-na-aanbesteding",
+  "name": "RIP — Post-Tender Project Estimate (Projectraming na aanbesteding)",
+  "description": "The project estimate updated for the tender.",
+  "processKey": "RipR41Process",
+  "serviceId": "RipR41",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-01T00:00:00.000Z",
+  "updatedAt": "2026-09-01T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{projectramingNaAanbestedingReferentie}}",
+      "variableKey": "projectramingNaAanbestedingReferentie",
+      "source": "process",
+      "label": "Project estimate reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{projectramingNaAanbestedingBedrag}}",
+      "variableKey": "projectramingNaAanbestedingBedrag",
+      "source": "process",
+      "label": "Project estimate"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{projectramingGeactualiseerdOp}}",
+      "variableKey": "projectramingGeactualiseerdOp",
+      "source": "process",
+      "label": "Updated on"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project estimate {{projectramingNaAanbestedingReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Post-tender project estimate",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Post-tender project estimate"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project estimate {{projectramingNaAanbestedingReferentie}} for project {{projectNumber}} — {{projectName}} amounts to EUR {{projectramingNaAanbestedingBedrag}}, updated on {{projectramingGeactualiseerdOp}}."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up by the cost and contract specialist"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-41/rip-terzijde-leggen-inschrijving.form
+++ b/examples/organizations/flevoland/rip-phase-41/rip-terzijde-leggen-inschrijving.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-terzijde-leggen-inschrijving",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Set the tender aside as unlawful"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Set the tender aside because of an unlawful submission, so it can be rejected."
+    },
+    {
+      "id": "F_Inschrijver",
+      "type": "textfield",
+      "label": "Tenderer",
+      "key": "inschrijverNaam",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Grond",
+      "type": "textarea",
+      "label": "Grounds for setting aside",
+      "key": "terzijdeLeggenGrond",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Set aside on",
+      "key": "terzijdeGelegdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-41/rip-vaststellen-nota-ao.form
+++ b/examples/organizations/flevoland/rip-phase-41/rip-vaststellen-nota-ao.form
@@ -1,0 +1,71 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-vaststellen-nota-ao",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Adopt the decision note (AO)"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The AO adopts the decision note."
+    },
+    {
+      "id": "F_Vastgesteld",
+      "type": "select",
+      "label": "Decision note adopted",
+      "key": "notaAoVastgesteld",
+      "values": [
+        {
+          "label": "Yes",
+          "value": "ja"
+        },
+        {
+          "label": "No",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Door",
+      "type": "textfield",
+      "label": "Adopted by",
+      "key": "notaAoVastgesteldDoor",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Adopted on",
+      "key": "notaAoVastgesteldOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Comments",
+      "key": "notaAoOpmerkingen"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-41/rip-vaststellen-nota-concerndirecteur.form
+++ b/examples/organizations/flevoland/rip-phase-41/rip-vaststellen-nota-concerndirecteur.form
@@ -1,0 +1,71 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-vaststellen-nota-concerndirecteur",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Adopt the decision note (Concerndirecteur)"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The concern director adopts the decision note."
+    },
+    {
+      "id": "F_Vastgesteld",
+      "type": "select",
+      "label": "Decision note adopted",
+      "key": "notaConcerndirecteurVastgesteld",
+      "values": [
+        {
+          "label": "Yes",
+          "value": "ja"
+        },
+        {
+          "label": "No",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Door",
+      "type": "textfield",
+      "label": "Adopted by",
+      "key": "notaConcerndirecteurVastgesteldDoor",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Adopted on",
+      "key": "notaConcerndirecteurVastgesteldOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Comments",
+      "key": "notaConcerndirecteurOpmerkingen"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-41/rip-verwerken-projectraming-aanbesteding.form
+++ b/examples/organizations/flevoland/rip-phase-41/rip-verwerken-projectraming-aanbesteding.form
@@ -1,0 +1,52 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-verwerken-projectraming-aanbesteding",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Process the project estimate and Infra framework credit"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Record the post-tender project estimate and the adopted decision note in the Infra framework credit administration."
+    },
+    {
+      "id": "F_Bedrag",
+      "type": "number",
+      "label": "Amount processed (EUR)",
+      "key": "verwerktBedragAanbesteding",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Admin",
+      "type": "textfield",
+      "label": "Administration reference",
+      "key": "administratieReferentieAanbesteding"
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Processed on",
+      "key": "verwerktOpAanbesteding",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-41/rip-verzoeken-tot-aanbesteden.form
+++ b/examples/organizations/flevoland/rip-phase-41/rip-verzoeken-tot-aanbesteden.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-verzoeken-tot-aanbesteden",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Request the tender"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Request the tender against the contract and tender documents adopted at the close of R3.2."
+    },
+    {
+      "id": "F_Set",
+      "type": "textfield",
+      "label": "Contract document set reference (from R3.2)",
+      "key": "contractdocumentenReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Verzoek",
+      "type": "textfield",
+      "label": "Tender request reference",
+      "key": "aanbestedingsverzoekReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Requested on",
+      "key": "aanbestedingVerzochtOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}


### PR DESCRIPTION
> **Stacked on #57 (R3.2) → #56 (R3.1) → #54 (R2.4) → #53 (R2.3) → `acc`.** Shows only R4.1's 25 files.

Models **R4.1 (Aanbestedingsproces)** from `rip-phases-left/R4. Aanbesteding/R4.1 Aanbestedingsproces.pdf` (sheet dated 17-7-2025). `R4_ Aanbesteding.pdf` is a five-line stage cover sheet with no process content and is not modelled.

`RipR41Process` — 25 flow nodes, 27 sequence flows, 7 lanes, 17 forms, 7 document templates.

## Flow

```
Start (from R3.2)
 └─ Verzoeken tot aanbesteden              (Kosten- en contractdeskundige)
 └─ Controleren aanbestedingsdocumenten klaar voor upload  (Inkoopadviseur)
 └─ XOR Dossier volledig?
      ├─ nee → Herstellen dossier ⟲ back to the check
      └─ ja  ↓
 └─ Actualiseren projectraming
 └─ Controleren wijzigingen Nota van inlichtingen
 └─ XOR Onregelmatigheid gevonden?
      ├─ ja  → Terzijde leggen i.v.m. onrechtmatige inschrijving
      │         └─ Afwijzen inschrijving  (Inkoopadviseur)
      │              └─ ■ end: Inschrijving afgewezen
      └─ nee ↓
 └─ Controleren eenheidsprijzen inschrijfstaat
 └─ XOR Onregelmatigheid gevonden?
      ├─ ja  → Opvragen verduidelijking inschrijving ⟲ back to the check
      └─ nee ↓
 └─ Opstellen voornemen tot gunnen         (Inkoopadviseur)
 └─ XOR Over- of onderschrijding dekkingsbron?   (Projectleider)
      ├─ ja  → nota besluitvorming (Concerndirecteur) → Vaststellen (Concerndirecteur)
      └─ nee → nota besluitvorming (AO)             → Vaststellen (AO)
 └─ Verwerken projectraming en raamkrediet Infra  (Financiën)
 └─ Informeren Inkoopadviseur                     (Projectondersteuner)
 └─ Afronden inkoopprocedure                      (Inkoopadviseur)
 └─ → IIN1.2.x Publiceren voornemen tot gunnen (TenderNed)
```

**First phase with a terminating branch that isn't the phase handover.** The two irregularity checks have different remedies: an unlawful tender is set aside and rejected, ending the instance on its own end event; an unclear tender prompts a clarification request that loops back into the unit-price check.

## A defect the checker caught before commit

`dekkingsbronAfwijking` gated the funding-source branch but **no form set it** — a started instance would have stopped at that gateway with no outgoing flow selectable. Same class of defect the RBA session flagged on R2.3's `mbviMoment`, caught locally this time. Fixed by recording the assessment on the gunningsvoornemen form, where the award amount is known and where the sheet places no intervening task.

## Faseladder contract

| | Item | State |
|---|---|---|
| 1 | Key | `RipR41Process` |
| 2 | Tenant `flevoland` | at deploy |
| 3 | `municipality` untouched; no form sets a board-supplied variable | verified |
| 4 | `businessKey` | 0 |
| 5 | External-task topics | **none** |
| 6 | `formRefBinding="deployment"` | all 17 |

## Candidate groups — one to decide later

Three new: `rip-concerndirecteur`, `rip-inkoopadviseur`, `rip-projectondersteuner`.

**`rip-inkoopadviseur` sits alongside R3.1's `rip-inkoopadviseur-werken`.** The sheets label the lane differently — "Inkoopadviseur" here, "Inkoopadviseur werken" in R3.1 — and each sheet's own label governs its phase, but these may well be the same role and worth merging when the Keycloak group list is settled.

`Opstellen voornemen tot gunnen` carries **both** `rip-inkoopadviseur` and `rip-kosten-contractdeskundige`: the sheet places the box in the cost and contract specialist's band but annotates it *"opstellen door ink.adv"*.

Ladder total: **27 groups**, all `rip-[\w-]+` → `infra-board`.

## Verification

```
R2.1  bpmn: OK   bundle: OK      R3.1  bpmn: OK   bundle: OK
R2.2  bpmn: OK   bundle: OK      R3.2  bpmn: OK   bundle: OK
R2.3  bpmn: OK   bundle: OK      R4.1  bpmn: OK   bundle: OK
R2.4  bpmn: OK   bundle: OK

id collisions across all seven: none
```
