### PR TITLE
fix(bpmn): keep the deploy modal's actions reachable for large bundles

### DIFF
--- a/packages/frontend/src/components/BpmnModeler/BpmnCanvas.test.tsx
+++ b/packages/frontend/src/components/BpmnModeler/BpmnCanvas.test.tsx
@@ -902,3 +902,109 @@ describe('BpmnCanvas — deploy request', () => {
     expect((await screen.findAllByText(/Deployment failed/)).length).toBeGreaterThan(0);
   });
 });
+
+describe('BpmnCanvas — deploy modal layout', () => {
+  // A RIP phase bundles 19-28 resources. Before the dialog was height-capped it
+  // grew with that list until Deploy/Cancel sat below the fold, unreachable
+  // without zooming the browser out.
+  const NS =
+    'xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" ' +
+    'xmlns:camunda="http://camunda.org/schema/1.0/bpmn" ' +
+    'xmlns:ronl="https://regels.overheid.nl/schema"';
+
+  /** A bundle referencing `count` distinct forms, to grow the resource list. */
+  function bulkXml(count: number) {
+    const tasks = Array.from(
+      { length: count },
+      (_, i) =>
+        `<bpmn:userTask id="t${i}" camunda:candidateGroups="rip-projectleider" ` +
+        `camunda:formRef="form-${i}" />`
+    ).join('');
+    return (
+      `<bpmn:definitions ${NS}><bpmn:process id="BulkProcess" ` +
+      `ronl:organization="flevoland">${tasks}</bpmn:process></bpmn:definitions>`
+    );
+  }
+
+  async function openModal(count: number) {
+    const forms = Array.from({ length: count }, (_, i) => ({
+      id: `f${i}`,
+      schema: { id: `form-${i}` },
+    }));
+    await renderCanvas({ xml: bulkXml(count), forms });
+    await userEvent.click(screen.getByText('Deploy'));
+    await screen.findByText('Deploy to Operaton');
+  }
+
+  test('the dialog is capped to the viewport so it cannot outgrow the screen', async () => {
+    await openModal(26);
+
+    const dialog = screen.getByTestId('deploy-modal');
+    expect(dialog.className).toContain('max-h-full');
+    expect(dialog.className).toContain('flex-col');
+    // The overlay keeps the dialog off the viewport edges.
+    const overlay = screen.getByTestId('deploy-modal').parentElement as HTMLElement;
+    expect(overlay.className).toContain('fixed');
+    expect(overlay.className).toContain('p-4');
+  });
+
+  test('only the middle section scrolls, and it can actually shrink', async () => {
+    await openModal(26);
+
+    const body = screen.getByTestId('deploy-modal-body');
+    expect(body.className).toContain('overflow-y-auto');
+    expect(body.className).toContain('flex-1');
+    // Without min-h-0 a flex child defaults to min-height:auto and refuses to
+    // shrink, so the overflow rule would never take effect.
+    expect(body.className).toContain('min-h-0');
+  });
+
+  test('Deploy and Cancel sit outside the scrolling body, however long the list', async () => {
+    await openModal(26);
+
+    const body = screen.getByTestId('deploy-modal-body');
+    const deploy = screen.getAllByRole('button', { name: /^Deploy$/ })[1];
+    const cancel = screen.getByRole('button', { name: 'Cancel' });
+
+    expect(body.contains(deploy)).toBe(false);
+    expect(body.contains(cancel)).toBe(false);
+  });
+
+  test('the resource list itself stays inside the scrolling body', async () => {
+    await openModal(26);
+
+    const body = screen.getByTestId('deploy-modal-body');
+    expect(body.textContent).toContain('Resources to deploy');
+    expect(body.textContent).toContain('form-25.form');
+    // 26 forms plus the process itself.
+    expect(body.textContent).toContain('27 resource(s)');
+  });
+
+  test('the result banner rides with the buttons, not with the scrolling list', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        json: async () => ({ success: true, data: { deploymentId: 'dep-77' } }),
+      }))
+    );
+    await openModal(3);
+
+    await userEvent.click(screen.getAllByRole('button', { name: /^Deploy$/ })[1]);
+    // The id also appears in the toolbar badge behind the dialog; take the one
+    // inside the dialog.
+    const banner = (await screen.findAllByText(/Deployment ID: dep-77/)).find((el) =>
+      screen.getByTestId('deploy-modal').contains(el)
+    ) as HTMLElement;
+
+    expect(banner).toBeTruthy();
+    expect(screen.getByTestId('deploy-modal-body').contains(banner)).toBe(false);
+    vi.unstubAllGlobals();
+  });
+
+  test('a short bundle still renders the whole dialog', async () => {
+    await openModal(2);
+
+    expect(screen.getByTestId('deploy-modal-body').textContent).toContain('3 resource(s)');
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy();
+  });
+});

--- a/packages/frontend/src/components/BpmnModeler/BpmnCanvas.tsx
+++ b/packages/frontend/src/components/BpmnModeler/BpmnCanvas.tsx
@@ -794,10 +794,21 @@ const BpmnCanvas: React.FC<BpmnCanvasProps> = ({
       </div>
 
       {showDeployModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4 shadow-xl">
-            {/* Header */}
-            <div className="flex items-center justify-between mb-4">
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+          {/*
+            The resource list grows with the bundle — a RIP phase deploys 19-28
+            files — so the dialog is capped at the viewport and split into three:
+            a pinned header, a scrolling body, and a pinned footer. Without the
+            cap the dialog grew past the screen and pushed Deploy/Cancel out of
+            reach. min-h-0 is what actually lets the middle shrink; a flex child
+            defaults to min-height:auto and would refuse to scroll without it.
+          */}
+          <div
+            data-testid="deploy-modal"
+            className="bg-white rounded-lg max-w-md w-full shadow-xl flex flex-col max-h-full"
+          >
+            {/* Header — pinned */}
+            <div className="flex items-center justify-between px-6 pt-6 pb-4 flex-shrink-0">
               <h3 className="text-lg font-semibold">Deploy to Operaton</h3>
               <button
                 onClick={() => {
@@ -810,252 +821,261 @@ const BpmnCanvas: React.FC<BpmnCanvasProps> = ({
               </button>
             </div>
 
-            {/* Board ownership — deploy-time boardOwner tag */}
-            <div className="mb-4 p-3 rounded-lg border-2 bg-slate-50 border-slate-200">
-              <div className="flex items-center justify-between mb-2">
-                <div className="font-semibold text-sm text-slate-800">🏷️ Board ownership</div>
-                {boardAuto ? (
-                  <span className="text-xs text-slate-500">
-                    auto-detected: <span className="font-mono text-slate-700">{boardAuto}</span>
-                  </span>
-                ) : (
-                  <span className="text-xs text-slate-400">no board auto-detected</span>
-                )}
-              </div>
-              <div className="flex flex-wrap gap-2">
-                {(
-                  [
-                    { id: 'auto', label: boardAuto ? `Auto (${boardAuto})` : 'Auto (none)' },
-                    { id: 'infra-board', label: 'Infra-board' },
-                    { id: 'caseworker', label: 'Caseworker' },
-                  ] as { id: BoardChoice; label: string }[]
-                ).map((opt) => {
-                  const active = boardChoice === opt.id;
-                  return (
-                    <button
-                      key={opt.id}
-                      type="button"
-                      onClick={() => setBoardChoice(opt.id)}
-                      disabled={isDeploying || deployResult?.success === true}
-                      className={`px-3 py-1.5 rounded-md text-xs font-medium border transition-colors disabled:opacity-50 ${
-                        active
-                          ? 'bg-blue-600 text-white border-blue-600'
-                          : 'bg-white text-slate-700 border-slate-300 hover:bg-slate-100'
-                      }`}
-                    >
-                      {opt.label}
-                    </button>
-                  );
-                })}
-              </div>
-              <div className="mt-2 text-xs text-slate-500">
-                {boardChoice === 'auto' ? (
-                  boardAuto ? (
-                    <>
-                      Auto-detected <span className="font-mono">{boardAuto}</span> from the
-                      candidate groups.
-                    </>
+            {/* Body — the only part that scrolls */}
+            <div data-testid="deploy-modal-body" className="flex-1 min-h-0 overflow-y-auto px-6">
+              {/* Board ownership — deploy-time boardOwner tag */}
+              <div className="mb-4 p-3 rounded-lg border-2 bg-slate-50 border-slate-200">
+                <div className="flex items-center justify-between mb-2">
+                  <div className="font-semibold text-sm text-slate-800">🏷️ Board ownership</div>
+                  {boardAuto ? (
+                    <span className="text-xs text-slate-500">
+                      auto-detected: <span className="font-mono text-slate-700">{boardAuto}</span>
+                    </span>
                   ) : (
-                    'No board could be auto-detected — pick one to continue.'
-                  )
-                ) : (
-                  <>
-                    Tagging as <span className="font-mono">{boardChoice}</span> — overrides
-                    auto-detection.
-                  </>
-                )}
-              </div>
-              {!resolvedBoard && (
-                <div className="mt-2 p-2 rounded-md bg-amber-50 border border-amber-200 text-xs text-amber-800">
-                  ⚠️ A board owner is required. Select{' '}
-                  <span className="font-mono">Infra-board</span> or{' '}
-                  <span className="font-mono">Caseworker</span> before deploying.
+                    <span className="text-xs text-slate-400">no board auto-detected</span>
+                  )}
                 </div>
-              )}
-            </div>
-
-            {/* Organization — deploy-time tenant-id tag */}
-            <div className="mb-4 p-3 rounded-lg border-2 bg-slate-50 border-slate-200">
-              <div className="flex items-center justify-between mb-2">
-                <div className="font-semibold text-sm text-slate-800">🏢 Organization</div>
-                {deployOrganization ? (
-                  <span className="text-xs font-mono text-slate-700">{deployOrganization}</span>
-                ) : (
-                  <span className="text-xs text-slate-400">not set</span>
-                )}
-              </div>
-              {!deployOrganization && (
-                <div className="mt-2 p-2 rounded-md bg-amber-50 border border-amber-200 text-xs text-amber-800">
-                  ⚠️ An organization is required. Set one in the sidebar&apos;s Organization field
-                  before deploying.
+                <div className="flex flex-wrap gap-2">
+                  {(
+                    [
+                      { id: 'auto', label: boardAuto ? `Auto (${boardAuto})` : 'Auto (none)' },
+                      { id: 'infra-board', label: 'Infra-board' },
+                      { id: 'caseworker', label: 'Caseworker' },
+                    ] as { id: BoardChoice; label: string }[]
+                  ).map((opt) => {
+                    const active = boardChoice === opt.id;
+                    return (
+                      <button
+                        key={opt.id}
+                        type="button"
+                        onClick={() => setBoardChoice(opt.id)}
+                        disabled={isDeploying || deployResult?.success === true}
+                        className={`px-3 py-1.5 rounded-md text-xs font-medium border transition-colors disabled:opacity-50 ${
+                          active
+                            ? 'bg-blue-600 text-white border-blue-600'
+                            : 'bg-white text-slate-700 border-slate-300 hover:bg-slate-100'
+                        }`}
+                      >
+                        {opt.label}
+                      </button>
+                    );
+                  })}
                 </div>
-              )}
-            </div>
-
-            {/* Resources preview */}
-            <div className="mb-4 p-3 rounded-lg border-2 bg-blue-50 border-blue-200">
-              <div className="font-semibold text-sm text-blue-800 mb-2">🚀 Resources to deploy</div>
-              <ul className="space-y-1">
-                {deployResources.bpmnFiles.map((f) => (
-                  <li key={f} className="flex items-center gap-2 text-sm text-slate-700">
-                    <span className="text-blue-500">📄</span> {f}
-                  </li>
-                ))}
-                {deployResources.formFiles.map((f) => (
-                  <li key={f} className="flex items-center gap-2 text-sm text-slate-700">
-                    <span className="text-green-500">📝</span> {f}
-                  </li>
-                ))}
-                {deployResources.documentFiles.map((f) => (
-                  <li key={f} className="flex items-center gap-2 text-sm text-slate-700">
-                    <span className="text-purple-500">📄</span> {f}
-                  </li>
-                ))}
-              </ul>
-              {(deployResources.unmatchedForms.length > 0 ||
-                deployResources.unmatchedDocuments.length > 0) && (
-                <div className="mb-3 mt-3 p-3 rounded-lg bg-red-50 border border-red-300 text-xs text-red-800">
-                  <div className="font-semibold mb-1">
-                    ⛔ Referenced resources are missing from local storage
+                <div className="mt-2 text-xs text-slate-500">
+                  {boardChoice === 'auto' ? (
+                    boardAuto ? (
+                      <>
+                        Auto-detected <span className="font-mono">{boardAuto}</span> from the
+                        candidate groups.
+                      </>
+                    ) : (
+                      'No board could be auto-detected — pick one to continue.'
+                    )
+                  ) : (
+                    <>
+                      Tagging as <span className="font-mono">{boardChoice}</span> — overrides
+                      auto-detection.
+                    </>
+                  )}
+                </div>
+                {!resolvedBoard && (
+                  <div className="mt-2 p-2 rounded-md bg-amber-50 border border-amber-200 text-xs text-amber-800">
+                    ⚠️ A board owner is required. Select{' '}
+                    <span className="font-mono">Infra-board</span> or{' '}
+                    <span className="font-mono">Caseworker</span> before deploying.
                   </div>
-                  <ul className="mb-2 space-y-0.5">
-                    {deployResources.unmatchedForms.map((ref) => (
-                      <li key={`uf-${ref}`} className="font-mono">
-                        {ref}.form
-                      </li>
-                    ))}
-                    {deployResources.unmatchedDocuments.map((ref) => (
-                      <li key={`ud-${ref}`} className="font-mono">
-                        {ref}.document
-                      </li>
-                    ))}
-                  </ul>
-                  Deploying without them produces a bundle the engine cannot resolve at runtime.
-                  Import them in the Form editor or Document composer first.
-                </div>
-              )}
-              {(deployResources as any).ropaRefMissing && (
-                <div className="mb-3 p-3 rounded-lg bg-amber-50 border border-amber-200 text-xs text-amber-800">
-                  ⚠️ No <code className="font-mono">ronl:ropaRef</code> found on the process
-                  element. Link a RoPA record in the BPMN properties panel before deploying to
-                  production.
-                </div>
-              )}
-              {(deployResources as any).languageMismatch && (
-                <div className="mb-3 p-3 rounded-lg bg-amber-50 border border-amber-200 text-xs text-amber-800">
-                  ⚠️ Bundle mixes languages:{' '}
-                  <span className="font-mono">
-                    {((deployResources as any).languageList as string[]).join(', ')}
-                  </span>
-                  . A deployed bundle should be a single language. Untag or retag the mismatched
-                  artefact(s) before deploying.
-                </div>
-              )}
-              <div className="mt-2 text-xs text-slate-500">
-                {deployResources.bpmnFiles.length +
-                  deployResources.formFiles.length +
-                  deployResources.documentFiles.length}{' '}
-                resource(s) · process key:{' '}
-                <span className="font-mono">{deployResources.processKey}</span>
+                )}
               </div>
-            </div>
 
-            {/* Operaton REST endpoint */}
-            <div className="mb-4">
-              <label className="block text-xs font-medium text-slate-700 mb-1">
-                Operaton REST endpoint
-              </label>
-              <input
-                type="text"
-                value={operatonUrl}
-                onChange={(e) => setOperatonUrl(e.target.value)}
-                disabled={isDeploying || deployResult?.success === true}
-                className="w-full px-3 py-2 border border-slate-300 rounded-md text-sm font-mono focus:ring-2 focus:ring-blue-500 focus:outline-none disabled:bg-slate-50 disabled:text-slate-400"
-                placeholder="https://operaton.open-regels.nl/engine-rest"
-              />
-            </div>
+              {/* Organization — deploy-time tenant-id tag */}
+              <div className="mb-4 p-3 rounded-lg border-2 bg-slate-50 border-slate-200">
+                <div className="flex items-center justify-between mb-2">
+                  <div className="font-semibold text-sm text-slate-800">🏢 Organization</div>
+                  {deployOrganization ? (
+                    <span className="text-xs font-mono text-slate-700">{deployOrganization}</span>
+                  ) : (
+                    <span className="text-xs text-slate-400">not set</span>
+                  )}
+                </div>
+                {!deployOrganization && (
+                  <div className="mt-2 p-2 rounded-md bg-amber-50 border border-amber-200 text-xs text-amber-800">
+                    ⚠️ An organization is required. Set one in the sidebar&apos;s Organization field
+                    before deploying.
+                  </div>
+                )}
+              </div>
 
-            {/* Operaton REST endpoint - Username & Password */}
-            <div className="grid grid-cols-2 gap-2 mb-4">
-              <div>
+              {/* Resources preview */}
+              <div className="mb-4 p-3 rounded-lg border-2 bg-blue-50 border-blue-200">
+                <div className="font-semibold text-sm text-blue-800 mb-2">
+                  🚀 Resources to deploy
+                </div>
+                <ul className="space-y-1">
+                  {deployResources.bpmnFiles.map((f) => (
+                    <li key={f} className="flex items-center gap-2 text-sm text-slate-700">
+                      <span className="text-blue-500">📄</span> {f}
+                    </li>
+                  ))}
+                  {deployResources.formFiles.map((f) => (
+                    <li key={f} className="flex items-center gap-2 text-sm text-slate-700">
+                      <span className="text-green-500">📝</span> {f}
+                    </li>
+                  ))}
+                  {deployResources.documentFiles.map((f) => (
+                    <li key={f} className="flex items-center gap-2 text-sm text-slate-700">
+                      <span className="text-purple-500">📄</span> {f}
+                    </li>
+                  ))}
+                </ul>
+                {(deployResources.unmatchedForms.length > 0 ||
+                  deployResources.unmatchedDocuments.length > 0) && (
+                  <div className="mb-3 mt-3 p-3 rounded-lg bg-red-50 border border-red-300 text-xs text-red-800">
+                    <div className="font-semibold mb-1">
+                      ⛔ Referenced resources are missing from local storage
+                    </div>
+                    <ul className="mb-2 space-y-0.5">
+                      {deployResources.unmatchedForms.map((ref) => (
+                        <li key={`uf-${ref}`} className="font-mono">
+                          {ref}.form
+                        </li>
+                      ))}
+                      {deployResources.unmatchedDocuments.map((ref) => (
+                        <li key={`ud-${ref}`} className="font-mono">
+                          {ref}.document
+                        </li>
+                      ))}
+                    </ul>
+                    Deploying without them produces a bundle the engine cannot resolve at runtime.
+                    Import them in the Form editor or Document composer first.
+                  </div>
+                )}
+                {(deployResources as any).ropaRefMissing && (
+                  <div className="mb-3 p-3 rounded-lg bg-amber-50 border border-amber-200 text-xs text-amber-800">
+                    ⚠️ No <code className="font-mono">ronl:ropaRef</code> found on the process
+                    element. Link a RoPA record in the BPMN properties panel before deploying to
+                    production.
+                  </div>
+                )}
+                {(deployResources as any).languageMismatch && (
+                  <div className="mb-3 p-3 rounded-lg bg-amber-50 border border-amber-200 text-xs text-amber-800">
+                    ⚠️ Bundle mixes languages:{' '}
+                    <span className="font-mono">
+                      {((deployResources as any).languageList as string[]).join(', ')}
+                    </span>
+                    . A deployed bundle should be a single language. Untag or retag the mismatched
+                    artefact(s) before deploying.
+                  </div>
+                )}
+                <div className="mt-2 text-xs text-slate-500">
+                  {deployResources.bpmnFiles.length +
+                    deployResources.formFiles.length +
+                    deployResources.documentFiles.length}{' '}
+                  resource(s) · process key:{' '}
+                  <span className="font-mono">{deployResources.processKey}</span>
+                </div>
+              </div>
+
+              {/* Operaton REST endpoint */}
+              <div className="mb-4">
                 <label className="block text-xs font-medium text-slate-700 mb-1">
-                  Username <span className="text-slate-400 font-normal">(optional)</span>
+                  Operaton REST endpoint
                 </label>
                 <input
                   type="text"
-                  value={operatonUsername}
-                  onChange={(e) => setOperatonUsername(e.target.value)}
+                  value={operatonUrl}
+                  onChange={(e) => setOperatonUrl(e.target.value)}
                   disabled={isDeploying || deployResult?.success === true}
-                  className="w-full px-3 py-2 border border-slate-300 rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:outline-none disabled:bg-slate-50 disabled:text-slate-400"
-                  placeholder="demo"
-                  autoComplete="username"
+                  className="w-full px-3 py-2 border border-slate-300 rounded-md text-sm font-mono focus:ring-2 focus:ring-blue-500 focus:outline-none disabled:bg-slate-50 disabled:text-slate-400"
+                  placeholder="https://operaton.open-regels.nl/engine-rest"
                 />
               </div>
-              <div>
-                <label className="block text-xs font-medium text-slate-700 mb-1">
-                  Password <span className="text-slate-400 font-normal">(optional)</span>
-                </label>
-                <input
-                  type="password"
-                  value={operatonPassword}
-                  onChange={(e) => setOperatonPassword(e.target.value)}
-                  disabled={isDeploying || deployResult?.success === true}
-                  className="w-full px-3 py-2 border border-slate-300 rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:outline-none disabled:bg-slate-50 disabled:text-slate-400"
-                  placeholder="••••••••"
-                  autoComplete="current-password"
-                />
+
+              {/* Operaton REST endpoint - Username & Password */}
+              <div className="grid grid-cols-2 gap-2 mb-4">
+                <div>
+                  <label className="block text-xs font-medium text-slate-700 mb-1">
+                    Username <span className="text-slate-400 font-normal">(optional)</span>
+                  </label>
+                  <input
+                    type="text"
+                    value={operatonUsername}
+                    onChange={(e) => setOperatonUsername(e.target.value)}
+                    disabled={isDeploying || deployResult?.success === true}
+                    className="w-full px-3 py-2 border border-slate-300 rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:outline-none disabled:bg-slate-50 disabled:text-slate-400"
+                    placeholder="demo"
+                    autoComplete="username"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs font-medium text-slate-700 mb-1">
+                    Password <span className="text-slate-400 font-normal">(optional)</span>
+                  </label>
+                  <input
+                    type="password"
+                    value={operatonPassword}
+                    onChange={(e) => setOperatonPassword(e.target.value)}
+                    disabled={isDeploying || deployResult?.success === true}
+                    className="w-full px-3 py-2 border border-slate-300 rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:outline-none disabled:bg-slate-50 disabled:text-slate-400"
+                    placeholder="••••••••"
+                    autoComplete="current-password"
+                  />
+                </div>
               </div>
             </div>
 
-            {/* Result banner */}
-            {deployResult && (
-              <div
-                className={`mb-4 p-3 rounded-lg text-sm ${
-                  deployResult.success
-                    ? 'bg-green-50 text-green-700 border border-green-200'
-                    : 'bg-red-50 text-red-700 border border-red-200'
-                }`}
-              >
-                {deployResult.success ? '✓ ' : '✗ '}
-                {deployResult.message}
-              </div>
-            )}
+            {/* Footer — pinned. The result banner rides with the buttons so the
+                deployment id stays readable next to Close. */}
+            <div className="flex-shrink-0 px-6 pb-6 pt-4 border-t border-slate-200">
+              {/* Result banner */}
+              {deployResult && (
+                <div
+                  className={`mb-4 p-3 rounded-lg text-sm ${
+                    deployResult.success
+                      ? 'bg-green-50 text-green-700 border border-green-200'
+                      : 'bg-red-50 text-red-700 border border-red-200'
+                  }`}
+                >
+                  {deployResult.success ? '✓ ' : '✗ '}
+                  {deployResult.message}
+                </div>
+              )}
 
-            {/* Actions */}
-            <div className="flex gap-2">
-              <button
-                onClick={handleDeploy}
-                disabled={
-                  isDeploying ||
-                  deployResult?.success === true ||
-                  !resolvedBoard ||
-                  !deployOrganization ||
-                  deployResources.unmatchedForms.length > 0 ||
-                  deployResources.unmatchedDocuments.length > 0
-                }
-                className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors font-medium"
-              >
-                {isDeploying ? (
-                  <>
-                    <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
-                    Deploying…
-                  </>
-                ) : (
-                  <>
-                    <Rocket size={16} />
-                    {deployResult?.success ? 'Deployed' : 'Deploy'}
-                  </>
-                )}
-              </button>
-              <button
-                onClick={() => {
-                  setShowDeployModal(false);
-                  setDeployResult(null);
-                }}
-                className="px-4 py-2 border border-slate-300 text-slate-700 rounded-lg hover:bg-slate-50 transition-colors"
-              >
-                {deployResult?.success ? 'Close' : 'Cancel'}
-              </button>
+              {/* Actions */}
+              <div className="flex gap-2">
+                <button
+                  onClick={handleDeploy}
+                  disabled={
+                    isDeploying ||
+                    deployResult?.success === true ||
+                    !resolvedBoard ||
+                    !deployOrganization ||
+                    deployResources.unmatchedForms.length > 0 ||
+                    deployResources.unmatchedDocuments.length > 0
+                  }
+                  className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors font-medium"
+                >
+                  {isDeploying ? (
+                    <>
+                      <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                      Deploying…
+                    </>
+                  ) : (
+                    <>
+                      <Rocket size={16} />
+                      {deployResult?.success ? 'Deployed' : 'Deploy'}
+                    </>
+                  )}
+                </button>
+                <button
+                  onClick={() => {
+                    setShowDeployModal(false);
+                    setDeployResult(null);
+                  }}
+                  className="px-4 py-2 border border-slate-300 text-slate-700 rounded-lg hover:bg-slate-50 transition-colors"
+                >
+                  {deployResult?.success ? 'Close' : 'Cancel'}
+                </button>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
> **Stacked on #52.** Base is `chore/test-coverage-80` so this shows only the modal change. #52 rewrites `BpmnCanvas.test.tsx` heavily, so branching off `acc` would have guaranteed a conflict there. Retarget to `acc` if you'd rather merge this first.

The deploy dialog was a single flat container with **no height constraint**, so it grew with the resource list. A RIP phase bundles 19–28 files, and at that size the dialog outgrew the viewport and pushed **Deploy/Cancel below the fold** — reachable only by zooming the browser out. Reported against a 26-resource R3.2 deployment.

## Before / after

```
before                             after
┌──────────────────────┐           ┌──────────────────────┐
│ Deploy to Operaton   │           │ Deploy to Operaton  ×│ ← pinned
│ Board ownership      │           ├──────────────────────┤
│ Organization         │           │ Board ownership    ▲ │
│ Resources (26)       │           │ Organization       ║ │ ← scrolls
│   …                  │           │ Resources (26)     ║ │
│   …                  │           │   …                ▼ │
│ Endpoint             │           ├──────────────────────┤
│ Username  Password   │           │ ✓ Deployment ID: …   │ ← pinned
│ ✓ Deployment ID: …   │           │ [ Deploy ] [ Close ] │
│ [ Deploy ] [ Close ] │ ← off     └──────────────────────┘
└──────────────────────┘   screen
```

## Three details that matter

**`min-h-0` on the scrolling body.** A flex child defaults to `min-height:auto` and refuses to shrink below its content, so `overflow-y-auto` alone would never have taken effect. This is the part that's easy to get wrong and looks fine until the list is long.

**The result banner moved into the footer.** It used to sit at the end of the body, so the deployment ID would scroll away at exactly the moment you want it. It now rides with the buttons.

**`p-4` on the overlay**, so a tall dialog stops short of the viewport edges instead of butting against them.

## Scope

Layout only — same fields, same guards, same deploy payload. Plus a `data-testid` on the dialog and on its scrolling body, because several inner boxes share `.rounded-lg` and asserting structure through shared utility classes is how you get a test that passes for the wrong reason.

## Tests

Six, driven by a synthetic 26-form bundle:

- the dialog is capped (`max-h-full`) and column-flexed, overlay has `p-4`
- the body scrolls (`overflow-y-auto`, `flex-1`) **and can shrink** (`min-h-0`)
- **Deploy and Cancel are outside the scrolling element** — the actual regression guard
- the resource list *is* inside it, including the 27th entry and the footer count
- the result banner is in the footer, not the body
- a two-resource bundle still renders in full

**1020 frontend tests pass, eslint clean, prettier clean.**

## Unrelated finding, not fixed here

`tsc --noEmit` reports **19 type errors in test files**, and **no script runs `tsc`** — `build` is `vite build` (esbuild strips types without checking), `lint` is eslint, `test` is vitest. So these are invisible to CI, which is why #52 went green.

- **8 introduced by #52**: `ChainComposer.test.tsx` (4), `DocumentComposer.test.tsx` (4) — mine, from the coverage work
- **11 pre-existing on `acc`**: `userTemplateStorage.test.ts` (9), `ChainResults.test.tsx` (2)

None affect runtime or the build. Left alone to keep this PR to one change; worth a follow-up that fixes all 19 and adds a `typecheck` script so CI catches the next one.
