### PR TITLE
fix(types): clear the type errors in test files and gate on tsc

### DIFF
--- a/.github/workflows/azure-backend-acc.yml
+++ b/.github/workflows/azure-backend-acc.yml
@@ -50,6 +50,10 @@ jobs:
         working-directory: packages/backend
         run: npm run lint
 
+      - name: Typecheck
+        working-directory: packages/backend
+        run: npm run typecheck
+
       - name: Unit tests
         working-directory: packages/backend
         run: npm test

--- a/.github/workflows/azure-backend-production.yml
+++ b/.github/workflows/azure-backend-production.yml
@@ -48,6 +48,10 @@ jobs:
         working-directory: packages/backend
         run: npm run lint
 
+      - name: Typecheck
+        working-directory: packages/backend
+        run: npm run typecheck
+
       - name: Unit tests
         working-directory: packages/backend
         run: npm test

--- a/.github/workflows/azure-frontend-acc.yml
+++ b/.github/workflows/azure-frontend-acc.yml
@@ -54,6 +54,8 @@ jobs:
         run: npm ci
       - name: Run linter
         run: npm run lint --workspace=packages/frontend
+      - name: Typecheck
+        run: npm run typecheck --workspace=packages/frontend
       - name: Unit tests
         run: npm test --workspace=packages/frontend
       - name: Build And Deploy

--- a/.github/workflows/azure-frontend-production.yml
+++ b/.github/workflows/azure-frontend-production.yml
@@ -52,6 +52,8 @@ jobs:
         run: npm ci
       - name: Run linter
         run: npm run lint --workspace=packages/frontend
+      - name: Typecheck
+        run: npm run typecheck --workspace=packages/frontend
       - name: Unit tests
         run: npm test --workspace=packages/frontend
       - name: Build And Deploy

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "preview": "npm run preview --workspace=@linked-data-explorer/frontend",
     "lint": "npm run lint --workspaces --if-present",
     "lint:fix": "npm run lint:fix --workspaces --if-present",
+    "typecheck": "npm run typecheck --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
     "format": "npm run format --workspaces --if-present",
     "check-format": "npm run check-format --workspaces --if-present",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -12,6 +12,7 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"src/**/*.ts\"",
     "check-format": "prettier --check \"src/**/*.ts\"",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -10,6 +10,7 @@
     "build:prod": "vite build --mode production",
     "preview": "vite preview",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "lint:fix": "eslint . --fix",
     "test": "vitest run --coverage",
     "test:watch": "vitest",

--- a/packages/frontend/src/components/ChainBuilder/ChainResults.test.tsx
+++ b/packages/frontend/src/components/ChainBuilder/ChainResults.test.tsx
@@ -56,7 +56,16 @@ describe('ChainResults', () => {
     render(
       <ChainResults
         result={result({
-          steps: [{ dmnId: 'age-check', duration: 10, outputs: { eligible: true } }],
+          steps: [
+            {
+              dmnId: 'age-check',
+              dmnTitle: 'Age check',
+              startTime: 1_700_000_000_000,
+              inputs: { age: 42 },
+              duration: 10,
+              outputs: { eligible: true },
+            },
+          ],
         })}
       />
     );
@@ -71,7 +80,16 @@ describe('ChainResults', () => {
     render(
       <ChainResults
         result={result({
-          steps: [{ dmnId: 'age-check', duration: 10, error: 'Missing variable' }],
+          steps: [
+            {
+              dmnId: 'age-check',
+              dmnTitle: 'Age check',
+              startTime: 1_700_000_000_000,
+              inputs: { age: 42 },
+              duration: 10,
+              error: 'Missing variable',
+            },
+          ],
         })}
       />
     );

--- a/packages/frontend/src/components/DocumentComposer/DocumentComposer.test.tsx
+++ b/packages/frontend/src/components/DocumentComposer/DocumentComposer.test.tsx
@@ -15,12 +15,16 @@ const deleteTemplate = vi.fn((id: string) => {
   store = store.filter((t) => t.id !== id);
 });
 
+// Forwarded with each mock's own signature rather than (...args: unknown[]).
+// The mocks are typed by their implementations, so spreading an unknown[] into
+// them is not assignable — the indirection is only here because vi.mock is
+// hoisted above the const declarations and must reference them lazily.
 vi.mock('../../services/documentService', () => ({
   DocumentService: {
-    getTemplates: (...args: unknown[]) => getTemplates(...args),
-    saveTemplate: (...args: unknown[]) => saveTemplate(...args),
-    getTemplate: (...args: unknown[]) => getTemplate(...args),
-    deleteTemplate: (...args: unknown[]) => deleteTemplate(...args),
+    getTemplates: () => getTemplates(),
+    saveTemplate: (t: { id: string }) => saveTemplate(t),
+    getTemplate: (id: string) => getTemplate(id),
+    deleteTemplate: (id: string) => deleteTemplate(id),
   },
 }));
 

--- a/packages/frontend/src/services/userTemplateStorage.test.ts
+++ b/packages/frontend/src/services/userTemplateStorage.test.ts
@@ -15,12 +15,21 @@ import {
 
 const ENDPOINT = 'https://api.open-regels.triply.cc/datasets/x/facts/sparql';
 
+/** Endpoint deliberately unlike ENDPOINT — see the note on `endpoint` below. */
+const IGNORED_ENDPOINT = 'https://ignored.example.com/sparql';
+
 function baseTemplate() {
   return {
     name: 'My chain',
+    description: 'A chain saved from the builder',
+    dmnIds: ['age-check', 'income-check'],
+    // saveUserTemplate spreads the payload and then overwrites endpoint from
+    // its own argument, so whatever is passed here is discarded. Passing a
+    // different value keeps `expect(saved.endpoint).toBe(ENDPOINT)` honest.
+    endpoint: IGNORED_ENDPOINT,
     type: 'sequential' as const,
     category: 'custom' as const,
-    tags: [],
+    tags: [] as string[],
     complexity: 'simple' as const,
     estimatedTime: 5,
     isPublic: false,


### PR DESCRIPTION
Independent of the RIP stack and of #52 — branched off `acc`, touches neither `examples/` nor any file #52 changes.

`tsc --noEmit` reported **15 errors across three test files, and nothing ran `tsc`**:

| script | what it actually does |
|---|---|
| `build` | `vite build` — esbuild, strips types **without checking them** |
| `lint` | `eslint` |
| `test` | `vitest` |

So the errors were invisible to every gate and had accumulated unnoticed. **None affected runtime.**

## Correction to my earlier count

I previously reported *"8 introduced by #52, 11 pre-existing"*. That was wrong — I attributed `DocumentComposer.test.tsx` to #52 because #52 adds lines to that file, without checking whether the *errors* were new. They weren't. Verified against `acc`:

- **15 pre-existing on `acc`** — `userTemplateStorage.test.ts` (9), `DocumentComposer.test.tsx` (4), `ChainResults.test.tsx` (2). All fixed here.
- **4 introduced by #52** — `ChainComposer.test.tsx` only. Still open on that branch; the gate below will catch them there.

## The fixes

All three were incomplete or mistyped fixtures. Each is fixed by making the fixture honest, not by widening a type.

**`userTemplateStorage.test.ts` (9)** — `baseTemplate()` omitted `description`, `dmnIds` and `endpoint`, all required by `Omit<UserTemplate, 'id' | 'createdAt' | 'updatedAt' | 'isUserTemplate'>`.

`endpoint` is now supplied **deliberately wrong**. `saveUserTemplate` spreads the payload then overwrites `endpoint` from its own argument, so passing a value the caller doesn't expect turns the existing `expect(saved.endpoint).toBe(ENDPOINT)` into a real assertion that the parameter wins — previously it would have passed either way.

**`ChainResults.test.tsx` (2)** — two `ExecutionStep` fixtures omitted `dmnTitle`, `startTime` and `inputs`.

**`DocumentComposer.test.tsx` (4)** — the `vi.mock` factory forwarded through `(...args: unknown[])`, but the mocks are typed by their implementations, so spreading an `unknown[]` into them isn't assignable. Each now forwards with its own signature. The indirection stays, because `vi.mock` is hoisted above the `const` declarations and must reference them lazily.

## The gate

- `"typecheck": "tsc --noEmit"` in both workspaces, plus a workspace-wide one at the root
- a **Typecheck** step beside the existing linter step in all four Azure deploy workflows — frontend and backend, acceptance and production

Without it the next such error lands just as quietly as these did.

## Left alone deliberately

`saveUserTemplate` requiring `endpoint` in a payload it overwrites is a real wart, and `updateUserTemplate` already omits it — the two are inconsistent. But changing a production signature doesn't belong in a PR that fixes test types. Worth a follow-up.

## Verification

```
tsc --noEmit    clean in both workspaces
eslint          clean
prettier        clean
frontend        578 tests pass
backend         1134 tests pass
```
