### PR TITLE
feat(rip): add R5.1 Voorbereiding op uitvoering bundle for Flevoland

### DIFF
--- a/examples/organizations/flevoland/rip-phase-51/RipR51Process.bpmn
+++ b/examples/organizations/flevoland/rip-phase-51/RipR51Process.bpmn
@@ -1,0 +1,534 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:ronl="http://ronl.nl/schema/1.0" id="Definitions_RipR51Process" targetNamespace="http://example.com/rip-phase-51" exporter="Camunda Modeler" exporterVersion="5.45.0">
+  <bpmn:collaboration id="Collaboration_RipR51Process">
+    <bpmn:participant id="Participant_RipR51Process" name="R5.1 - Voorbereiding op uitvoering" processRef="RipR51Process" />
+  </bpmn:collaboration>
+  <bpmn:process id="RipR51Process" name="R5.1 - Voorbereiding op uitvoering" isExecutable="true" camunda:historyTimeToLive="180">
+    <bpmn:laneSet id="LaneSet_RipR51Process">
+      <bpmn:lane id="Lane_KostenContractdeskundige" name="Kosten- en contractdeskundige">
+        <bpmn:flowNodeRef>StartEvent_R51</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_OpstellenWerkbestek</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_InrichtenVisi</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_InrichtenBetterPerformance</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_UitgangspuntenOverleg" name="RIP-team, Omgevingsmanager, Toezichthouder, Communicatieadviseur">
+        <bpmn:flowNodeRef>Task_HoudenOverlegUitgangspunten</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_ManagerPB" name="Manager Projectbeheersing">
+        <bpmn:flowNodeRef>Task_UpdatenRisicodossier</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_ToezichtsplanOverleg" name="Directievoerder, Toezichthouder, Vestigingsmanager">
+        <bpmn:flowNodeRef>Task_BesprekenToezichtsplan</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_Directievoerder" name="Directievoerder">
+        <bpmn:flowNodeRef>Gateway_VoorbereidingSplit</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_VersturenVerzoekVisi</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_VersturenVerzoekBetterPerformance</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_UpdatenToezichtsplan</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_VersturenToezichtsplan</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_InrichtenBesteksadministratie</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_VoorbereidingJoin</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_TechnischeInstallaties</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_CommunicerenOverdrachtInstallatiedeel</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_ControlerenDocumentenON</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_VersturenDocumentVG</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_AkkoordDocumenten</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_LatenAanpassenDocumentenON</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_Projectleider" name="Projectleider">
+        <bpmn:flowNodeRef>Task_InitierenStartoverleg</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_HoudenOverlegVgCoordinator</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndEvent_StartWerkBuiten</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_Startoverleg" name="Directievoerder, Toezichthouder, Projectleider, Omgevingsmanager, Technisch administratief medewerker, ON">
+        <bpmn:flowNodeRef>Task_HoudenStartoverleg</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_AdviseurVG" name="Adviseur B&amp;O Infra Veiligheid en gezondheid">
+        <bpmn:flowNodeRef>Task_BeoordelenDocumentVG</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+
+    <bpmn:startEvent id="StartEvent_R51" name="Start R5.1 - Voorbereiding op uitvoering&#10;(vanuit R4.1 / IN1. Inkoopprocedure)">
+      <bpmn:outgoing>Flow_StartEvent_R51_Task_OpstellenWerkbestek</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:userTask id="Task_OpstellenWerkbestek" name="Opstellen&#10;werkbestek" camunda:formRef="rip-opstellen-werkbestek" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-kosten-contractdeskundige" ronl:documentRef="rip-werkbestek">
+      <bpmn:incoming>Flow_StartEvent_R51_Task_OpstellenWerkbestek</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_OpstellenWerkbestek_Task_HoudenOverlegUitgangspunten</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_HoudenOverlegUitgangspunten" name="Houden overleg uitgangspunten&#10;uitvoeringsfase" camunda:formRef="rip-overleg-uitgangspunten-uitvoering" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-team,rip-omgevingsmanager,rip-toezichthouder,rip-communicatieadviseur" ronl:documentRef="rip-uitgangspunten-uitvoering">
+      <bpmn:incoming>Flow_Task_OpstellenWerkbestek_Task_HoudenOverlegUitgangspunten</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_HoudenOverlegUitgangspunten_Task_UpdatenRisicodossier</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_UpdatenRisicodossier" name="Updaten risicodossier&#10;(t.b.v. contractbeheersing)" camunda:formRef="rip-updaten-risicodossier-uitvoering" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-manager-pb" ronl:documentRef="rip-risicodossier-contractbeheersing">
+      <bpmn:incoming>Flow_Task_HoudenOverlegUitgangspunten_Task_UpdatenRisicodossier</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_UpdatenRisicodossier_Gateway_VoorbereidingSplit</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:parallelGateway id="Gateway_VoorbereidingSplit">
+      <bpmn:incoming>Flow_Task_UpdatenRisicodossier_Gateway_VoorbereidingSplit</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_VoorbereidingSplit_Task_VersturenVerzoekVisi</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_VoorbereidingSplit_Task_VersturenVerzoekBetterPerformance</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_VoorbereidingSplit_Task_UpdatenToezichtsplan</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_VoorbereidingSplit_Task_InrichtenBesteksadministratie</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_VoorbereidingSplit_Task_InitierenStartoverleg</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:userTask id="Task_VersturenVerzoekVisi" name="Versturen verzoek&#10;inrichten VISI" camunda:formRef="rip-verzoek-inrichten-visi" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-directievoerder" ronl:documentRef="rip-aanmeldformulier-visi">
+      <bpmn:incoming>Flow_Gateway_VoorbereidingSplit_Task_VersturenVerzoekVisi</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_VersturenVerzoekVisi_Task_InrichtenVisi</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_InrichtenVisi" name="Inrichten&#10;VISI" camunda:formRef="rip-inrichten-visi" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-kosten-contractdeskundige">
+      <bpmn:incoming>Flow_Task_VersturenVerzoekVisi_Task_InrichtenVisi</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_InrichtenVisi_Gateway_VoorbereidingJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_VersturenVerzoekBetterPerformance" name="Versturen verzoek inrichten&#10;Better performance" camunda:formRef="rip-verzoek-inrichten-better-performance" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-directievoerder">
+      <bpmn:incoming>Flow_Gateway_VoorbereidingSplit_Task_VersturenVerzoekBetterPerformance</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_VersturenVerzoekBetterPerformance_Task_InrichtenBetterPerformance</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_InrichtenBetterPerformance" name="Inrichten&#10;Better performance" camunda:formRef="rip-inrichten-better-performance" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-kosten-contractdeskundige">
+      <bpmn:incoming>Flow_Task_VersturenVerzoekBetterPerformance_Task_InrichtenBetterPerformance</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_InrichtenBetterPerformance_Gateway_VoorbereidingJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_UpdatenToezichtsplan" name="Updaten&#10;toezichtsplan" camunda:formRef="rip-updaten-toezichtsplan" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-directievoerder" ronl:documentRef="rip-definitief-toezichtsplan">
+      <bpmn:incoming>Flow_Gateway_VoorbereidingSplit_Task_UpdatenToezichtsplan</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_UpdatenToezichtsplan_Task_VersturenToezichtsplan</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_VersturenToezichtsplan" name="Versturen toezichtsplan&#10;aan VM en TZH" camunda:formRef="rip-versturen-toezichtsplan" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-directievoerder">
+      <bpmn:incoming>Flow_Task_UpdatenToezichtsplan_Task_VersturenToezichtsplan</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_VersturenToezichtsplan_Task_BesprekenToezichtsplan</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_BesprekenToezichtsplan" name="Bespreken&#10;toezichtsplan" camunda:formRef="rip-bespreken-toezichtsplan" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-directievoerder,rip-toezichthouder,rip-vestigingsmanager" ronl:documentRef="rip-vastgesteld-toezichtsplan">
+      <bpmn:incoming>Flow_Task_VersturenToezichtsplan_Task_BesprekenToezichtsplan</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_BesprekenToezichtsplan_Gateway_VoorbereidingJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_InrichtenBesteksadministratie" name="Inrichten&#10;besteksadministratie" camunda:formRef="rip-inrichten-besteksadministratie" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-directievoerder">
+      <bpmn:incoming>Flow_Gateway_VoorbereidingSplit_Task_InrichtenBesteksadministratie</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_InrichtenBesteksadministratie_Gateway_VoorbereidingJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_InitierenStartoverleg" name="Initiëren&#10;startoverleg" camunda:formRef="rip-initieren-startoverleg" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-agenda-startoverleg">
+      <bpmn:incoming>Flow_Gateway_VoorbereidingSplit_Task_InitierenStartoverleg</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_InitierenStartoverleg_Task_HoudenStartoverleg</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_HoudenStartoverleg" name="Houden&#10;startoverleg" camunda:formRef="rip-houden-startoverleg" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-directievoerder,rip-toezichthouder,rip-projectleider,rip-omgevingsmanager,rip-technisch-administratief-medewerker,rip-opdrachtnemer" ronl:documentRef="rip-verslag-startoverleg">
+      <bpmn:incoming>Flow_Task_InitierenStartoverleg_Task_HoudenStartoverleg</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_HoudenStartoverleg_Gateway_VoorbereidingJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:parallelGateway id="Gateway_VoorbereidingJoin">
+      <bpmn:incoming>Flow_Task_InrichtenVisi_Gateway_VoorbereidingJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_InrichtenBetterPerformance_Gateway_VoorbereidingJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_BesprekenToezichtsplan_Gateway_VoorbereidingJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_InrichtenBesteksadministratie_Gateway_VoorbereidingJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_HoudenStartoverleg_Gateway_VoorbereidingJoin</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_VoorbereidingJoin_Gateway_TechnischeInstallaties</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:exclusiveGateway id="Gateway_TechnischeInstallaties" name="Zijn er technische&#10;installatie(s) in project?">
+      <bpmn:incoming>Flow_Gateway_VoorbereidingJoin_Gateway_TechnischeInstallaties</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_TechnischeInstallaties_Task_CommunicerenOverdrachtInstallatiedeel</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_TechnischeInstallaties_Task_ControlerenDocumentenON</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_CommunicerenOverdrachtInstallatiedeel" name="Communiceren overdracht&#10;installatiedeel aan OvD en DV" camunda:formRef="rip-communiceren-overdracht-installatiedeel" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-directievoerder">
+      <bpmn:incoming>Flow_Gateway_TechnischeInstallaties_Task_CommunicerenOverdrachtInstallatiedeel</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_CommunicerenOverdrachtInstallatiedeel_Task_ControlerenDocumentenON</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_ControlerenDocumentenON" name="Controleren&#10;documenten ON" camunda:formRef="rip-controleren-documenten-on" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-directievoerder">
+      <bpmn:incoming>Flow_Gateway_TechnischeInstallaties_Task_ControlerenDocumentenON</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_CommunicerenOverdrachtInstallatiedeel_Task_ControlerenDocumentenON</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_LatenAanpassenDocumentenON_Task_ControlerenDocumentenON</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_ControlerenDocumentenON_Task_VersturenDocumentVG</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_VersturenDocumentVG" name="Versturen document&#10;V&amp;G (ON) ter controle" camunda:formRef="rip-versturen-document-vg" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-directievoerder">
+      <bpmn:incoming>Flow_Task_ControlerenDocumentenON_Task_VersturenDocumentVG</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_VersturenDocumentVG_Task_BeoordelenDocumentVG</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_BeoordelenDocumentVG" name="Beoordelen&#10;document V&amp;G (ON)" camunda:formRef="rip-beoordelen-document-vg" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-adviseur-veiligheid-gezondheid" ronl:documentRef="rip-vg-plan-beoordeling">
+      <bpmn:incoming>Flow_Task_VersturenDocumentVG_Task_BeoordelenDocumentVG</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_BeoordelenDocumentVG_Gateway_AkkoordDocumenten</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_AkkoordDocumenten" name="Akkoord alle&#10;documenten?">
+      <bpmn:incoming>Flow_Task_BeoordelenDocumentVG_Gateway_AkkoordDocumenten</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_AkkoordDocumenten_Task_LatenAanpassenDocumentenON</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_AkkoordDocumenten_Task_HoudenOverlegVgCoordinator</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_LatenAanpassenDocumentenON" name="Laten aanpassen&#10;documenten door ON" camunda:formRef="rip-laten-aanpassen-documenten-on" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-directievoerder">
+      <bpmn:incoming>Flow_Gateway_AkkoordDocumenten_Task_LatenAanpassenDocumentenON</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_LatenAanpassenDocumentenON_Task_ControlerenDocumentenON</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_HoudenOverlegVgCoordinator" name="Houden overleg met V&amp;G-coördinator&#10;uitvoering (ON)" camunda:formRef="rip-overleg-vg-coordinator" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-vg-uitvoeringsafspraken">
+      <bpmn:incoming>Flow_Gateway_AkkoordDocumenten_Task_HoudenOverlegVgCoordinator</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_HoudenOverlegVgCoordinator_EndEvent_StartWerkBuiten</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_StartWerkBuiten" name="Start werk &quot;buiten&quot;&#10;→ R5.2 Directievoering en toezicht UAV">
+      <bpmn:incoming>Flow_Task_HoudenOverlegVgCoordinator_EndEvent_StartWerkBuiten</bpmn:incoming>
+    </bpmn:endEvent>
+
+    <bpmn:sequenceFlow id="Flow_StartEvent_R51_Task_OpstellenWerkbestek" sourceRef="StartEvent_R51" targetRef="Task_OpstellenWerkbestek" />
+    <bpmn:sequenceFlow id="Flow_Task_OpstellenWerkbestek_Task_HoudenOverlegUitgangspunten" sourceRef="Task_OpstellenWerkbestek" targetRef="Task_HoudenOverlegUitgangspunten" />
+    <bpmn:sequenceFlow id="Flow_Task_HoudenOverlegUitgangspunten_Task_UpdatenRisicodossier" sourceRef="Task_HoudenOverlegUitgangspunten" targetRef="Task_UpdatenRisicodossier" />
+    <bpmn:sequenceFlow id="Flow_Task_UpdatenRisicodossier_Gateway_VoorbereidingSplit" sourceRef="Task_UpdatenRisicodossier" targetRef="Gateway_VoorbereidingSplit" />
+    <bpmn:sequenceFlow id="Flow_Gateway_VoorbereidingSplit_Task_VersturenVerzoekVisi" sourceRef="Gateway_VoorbereidingSplit" targetRef="Task_VersturenVerzoekVisi" />
+    <bpmn:sequenceFlow id="Flow_Task_VersturenVerzoekVisi_Task_InrichtenVisi" sourceRef="Task_VersturenVerzoekVisi" targetRef="Task_InrichtenVisi" />
+    <bpmn:sequenceFlow id="Flow_Task_InrichtenVisi_Gateway_VoorbereidingJoin" sourceRef="Task_InrichtenVisi" targetRef="Gateway_VoorbereidingJoin" />
+    <bpmn:sequenceFlow id="Flow_Gateway_VoorbereidingSplit_Task_VersturenVerzoekBetterPerformance" sourceRef="Gateway_VoorbereidingSplit" targetRef="Task_VersturenVerzoekBetterPerformance" />
+    <bpmn:sequenceFlow id="Flow_Task_VersturenVerzoekBetterPerformance_Task_InrichtenBetterPerformance" sourceRef="Task_VersturenVerzoekBetterPerformance" targetRef="Task_InrichtenBetterPerformance" />
+    <bpmn:sequenceFlow id="Flow_Task_InrichtenBetterPerformance_Gateway_VoorbereidingJoin" sourceRef="Task_InrichtenBetterPerformance" targetRef="Gateway_VoorbereidingJoin" />
+    <bpmn:sequenceFlow id="Flow_Gateway_VoorbereidingSplit_Task_UpdatenToezichtsplan" sourceRef="Gateway_VoorbereidingSplit" targetRef="Task_UpdatenToezichtsplan" />
+    <bpmn:sequenceFlow id="Flow_Task_UpdatenToezichtsplan_Task_VersturenToezichtsplan" sourceRef="Task_UpdatenToezichtsplan" targetRef="Task_VersturenToezichtsplan" />
+    <bpmn:sequenceFlow id="Flow_Task_VersturenToezichtsplan_Task_BesprekenToezichtsplan" sourceRef="Task_VersturenToezichtsplan" targetRef="Task_BesprekenToezichtsplan" />
+    <bpmn:sequenceFlow id="Flow_Task_BesprekenToezichtsplan_Gateway_VoorbereidingJoin" sourceRef="Task_BesprekenToezichtsplan" targetRef="Gateway_VoorbereidingJoin" />
+    <bpmn:sequenceFlow id="Flow_Gateway_VoorbereidingSplit_Task_InrichtenBesteksadministratie" sourceRef="Gateway_VoorbereidingSplit" targetRef="Task_InrichtenBesteksadministratie" />
+    <bpmn:sequenceFlow id="Flow_Task_InrichtenBesteksadministratie_Gateway_VoorbereidingJoin" sourceRef="Task_InrichtenBesteksadministratie" targetRef="Gateway_VoorbereidingJoin" />
+    <bpmn:sequenceFlow id="Flow_Gateway_VoorbereidingSplit_Task_InitierenStartoverleg" sourceRef="Gateway_VoorbereidingSplit" targetRef="Task_InitierenStartoverleg" />
+    <bpmn:sequenceFlow id="Flow_Task_InitierenStartoverleg_Task_HoudenStartoverleg" sourceRef="Task_InitierenStartoverleg" targetRef="Task_HoudenStartoverleg" />
+    <bpmn:sequenceFlow id="Flow_Task_HoudenStartoverleg_Gateway_VoorbereidingJoin" sourceRef="Task_HoudenStartoverleg" targetRef="Gateway_VoorbereidingJoin" />
+    <bpmn:sequenceFlow id="Flow_Gateway_VoorbereidingJoin_Gateway_TechnischeInstallaties" sourceRef="Gateway_VoorbereidingJoin" targetRef="Gateway_TechnischeInstallaties" />
+    <bpmn:sequenceFlow id="Flow_Gateway_TechnischeInstallaties_Task_CommunicerenOverdrachtInstallatiedeel" name="ja" sourceRef="Gateway_TechnischeInstallaties" targetRef="Task_CommunicerenOverdrachtInstallatiedeel">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${technischeInstallaties == "ja"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_TechnischeInstallaties_Task_ControlerenDocumentenON" name="nee" sourceRef="Gateway_TechnischeInstallaties" targetRef="Task_ControlerenDocumentenON">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${technischeInstallaties == "nee"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Task_CommunicerenOverdrachtInstallatiedeel_Task_ControlerenDocumentenON" sourceRef="Task_CommunicerenOverdrachtInstallatiedeel" targetRef="Task_ControlerenDocumentenON" />
+    <bpmn:sequenceFlow id="Flow_Task_ControlerenDocumentenON_Task_VersturenDocumentVG" sourceRef="Task_ControlerenDocumentenON" targetRef="Task_VersturenDocumentVG" />
+    <bpmn:sequenceFlow id="Flow_Task_VersturenDocumentVG_Task_BeoordelenDocumentVG" sourceRef="Task_VersturenDocumentVG" targetRef="Task_BeoordelenDocumentVG" />
+    <bpmn:sequenceFlow id="Flow_Task_BeoordelenDocumentVG_Gateway_AkkoordDocumenten" sourceRef="Task_BeoordelenDocumentVG" targetRef="Gateway_AkkoordDocumenten" />
+    <bpmn:sequenceFlow id="Flow_Gateway_AkkoordDocumenten_Task_LatenAanpassenDocumentenON" name="nee" sourceRef="Gateway_AkkoordDocumenten" targetRef="Task_LatenAanpassenDocumentenON">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${documentenAkkoord == "nee"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_AkkoordDocumenten_Task_HoudenOverlegVgCoordinator" name="ja" sourceRef="Gateway_AkkoordDocumenten" targetRef="Task_HoudenOverlegVgCoordinator">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${documentenAkkoord == "ja"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Task_LatenAanpassenDocumentenON_Task_ControlerenDocumentenON" sourceRef="Task_LatenAanpassenDocumentenON" targetRef="Task_ControlerenDocumentenON" />
+    <bpmn:sequenceFlow id="Flow_Task_HoudenOverlegVgCoordinator_EndEvent_StartWerkBuiten" sourceRef="Task_HoudenOverlegVgCoordinator" targetRef="EndEvent_StartWerkBuiten" />
+
+    <bpmn:textAnnotation id="Annotation_IN1_Inkoopprocedure">
+      <bpmn:text>IN1. Uitvoeren inkoopprocedure</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Assoc_Annotation_IN1_Inkoopprocedure" sourceRef="Task_OpstellenWerkbestek" targetRef="Annotation_IN1_Inkoopprocedure" />
+    <bpmn:textAnnotation id="Annotation_BO13_Overdracht">
+      <bpmn:text>BO13.1 Start overdracht — het installatiedeel gaat over naar Beheer &amp; Onderhoud, dat de overdracht terugkoppelt aan de OvD en de directievoerder</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Assoc_Annotation_BO13_Overdracht" sourceRef="Task_CommunicerenOverdrachtInstallatiedeel" targetRef="Annotation_BO13_Overdracht" />
+    <bpmn:textAnnotation id="Annotation_R52_StartWerk">
+      <bpmn:text>R5.2 Directievoering en toezicht UAV</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Assoc_Annotation_R52_StartWerk" sourceRef="Task_HoudenOverlegVgCoordinator" targetRef="Annotation_R52_StartWerk" />
+  </bpmn:process>
+
+  <bpmndi:BPMNDiagram id="BPMNDiagram_RipR51Process">
+    <bpmndi:BPMNPlane id="BPMNPlane_RipR51Process" bpmnElement="Collaboration_RipR51Process">
+      <bpmndi:BPMNShape id="Participant_RipR51Process_di" bpmnElement="Participant_RipR51Process" isHorizontal="true">
+        <dc:Bounds x="160" y="80" width="2346" height="1380" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_KostenContractdeskundige_di" bpmnElement="Lane_KostenContractdeskundige" isHorizontal="true">
+        <dc:Bounds x="190" y="80" width="2316" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_UitgangspuntenOverleg_di" bpmnElement="Lane_UitgangspuntenOverleg" isHorizontal="true">
+        <dc:Bounds x="190" y="280" width="2316" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_ManagerPB_di" bpmnElement="Lane_ManagerPB" isHorizontal="true">
+        <dc:Bounds x="190" y="400" width="2316" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_ToezichtsplanOverleg_di" bpmnElement="Lane_ToezichtsplanOverleg" isHorizontal="true">
+        <dc:Bounds x="190" y="520" width="2316" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Directievoerder_di" bpmnElement="Lane_Directievoerder" isHorizontal="true">
+        <dc:Bounds x="190" y="640" width="2316" height="380" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Projectleider_di" bpmnElement="Lane_Projectleider" isHorizontal="true">
+        <dc:Bounds x="190" y="1020" width="2316" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Startoverleg_di" bpmnElement="Lane_Startoverleg" isHorizontal="true">
+        <dc:Bounds x="190" y="1220" width="2316" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_AdviseurVG_di" bpmnElement="Lane_AdviseurVG" isHorizontal="true">
+        <dc:Bounds x="190" y="1340" width="2316" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_R51_di" bpmnElement="StartEvent_R51">
+        <dc:Bounds x="240" y="122" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="98" y="163" width="320" height="28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_OpstellenWerkbestek_di" bpmnElement="Task_OpstellenWerkbestek">
+        <dc:Bounds x="300" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_HoudenOverlegUitgangspunten_di" bpmnElement="Task_HoudenOverlegUitgangspunten">
+        <dc:Bounds x="460" y="300" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_UpdatenRisicodossier_di" bpmnElement="Task_UpdatenRisicodossier">
+        <dc:Bounds x="620" y="420" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_VoorbereidingSplit_di" bpmnElement="Gateway_VoorbereidingSplit">
+        <dc:Bounds x="780" y="765" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_VersturenVerzoekVisi_di" bpmnElement="Task_VersturenVerzoekVisi">
+        <dc:Bounds x="860" y="660" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_InrichtenVisi_di" bpmnElement="Task_InrichtenVisi">
+        <dc:Bounds x="1020" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_VersturenVerzoekBetterPerformance_di" bpmnElement="Task_VersturenVerzoekBetterPerformance">
+        <dc:Bounds x="860" y="750" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_InrichtenBetterPerformance_di" bpmnElement="Task_InrichtenBetterPerformance">
+        <dc:Bounds x="1020" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_UpdatenToezichtsplan_di" bpmnElement="Task_UpdatenToezichtsplan">
+        <dc:Bounds x="860" y="840" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_VersturenToezichtsplan_di" bpmnElement="Task_VersturenToezichtsplan">
+        <dc:Bounds x="1020" y="840" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_BesprekenToezichtsplan_di" bpmnElement="Task_BesprekenToezichtsplan">
+        <dc:Bounds x="1180" y="540" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_InrichtenBesteksadministratie_di" bpmnElement="Task_InrichtenBesteksadministratie">
+        <dc:Bounds x="860" y="930" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_InitierenStartoverleg_di" bpmnElement="Task_InitierenStartoverleg">
+        <dc:Bounds x="860" y="1040" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_HoudenStartoverleg_di" bpmnElement="Task_HoudenStartoverleg">
+        <dc:Bounds x="1020" y="1240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_VoorbereidingJoin_di" bpmnElement="Gateway_VoorbereidingJoin">
+        <dc:Bounds x="1360" y="765" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_TechnischeInstallaties_di" bpmnElement="Gateway_TechnischeInstallaties" isMarkerVisible="true">
+        <dc:Bounds x="1440" y="765" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1361" y="820" width="208" height="28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_CommunicerenOverdrachtInstallatiedeel_di" bpmnElement="Task_CommunicerenOverdrachtInstallatiedeel">
+        <dc:Bounds x="1520" y="660" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_ControlerenDocumentenON_di" bpmnElement="Task_ControlerenDocumentenON">
+        <dc:Bounds x="1680" y="750" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_VersturenDocumentVG_di" bpmnElement="Task_VersturenDocumentVG">
+        <dc:Bounds x="1840" y="840" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_BeoordelenDocumentVG_di" bpmnElement="Task_BeoordelenDocumentVG">
+        <dc:Bounds x="2000" y="1360" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_AkkoordDocumenten_di" bpmnElement="Gateway_AkkoordDocumenten" isMarkerVisible="true">
+        <dc:Bounds x="2160" y="765" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2137" y="820" width="96" height="28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_LatenAanpassenDocumentenON_di" bpmnElement="Task_LatenAanpassenDocumentenON">
+        <dc:Bounds x="2240" y="660" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_HoudenOverlegVgCoordinator_di" bpmnElement="Task_HoudenOverlegVgCoordinator">
+        <dc:Bounds x="2240" y="1130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_StartWerkBuiten_di" bpmnElement="EndEvent_StartWerkBuiten">
+        <dc:Bounds x="2400" y="1152" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2266" y="1193" width="304" height="28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Annotation_IN1_Inkoopprocedure_di" bpmnElement="Annotation_IN1_Inkoopprocedure">
+        <dc:Bounds x="480" y="100" width="240" height="45" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Annotation_BO13_Overdracht_di" bpmnElement="Annotation_BO13_Overdracht">
+        <dc:Bounds x="1500" y="540" width="300" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Annotation_R52_StartWerk_di" bpmnElement="Annotation_R52_StartWerk">
+        <dc:Bounds x="2200" y="1240" width="260" height="45" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_StartEvent_R51_Task_OpstellenWerkbestek_di" bpmnElement="Flow_StartEvent_R51_Task_OpstellenWerkbestek">
+        <di:waypoint x="276" y="140" />
+        <di:waypoint x="300" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_OpstellenWerkbestek_Task_HoudenOverlegUitgangspunten_di" bpmnElement="Flow_Task_OpstellenWerkbestek_Task_HoudenOverlegUitgangspunten">
+        <di:waypoint x="400" y="140" />
+        <di:waypoint x="430" y="140" />
+        <di:waypoint x="430" y="340" />
+        <di:waypoint x="460" y="340" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_HoudenOverlegUitgangspunten_Task_UpdatenRisicodossier_di" bpmnElement="Flow_Task_HoudenOverlegUitgangspunten_Task_UpdatenRisicodossier">
+        <di:waypoint x="560" y="340" />
+        <di:waypoint x="590" y="340" />
+        <di:waypoint x="590" y="460" />
+        <di:waypoint x="620" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_UpdatenRisicodossier_Gateway_VoorbereidingSplit_di" bpmnElement="Flow_Task_UpdatenRisicodossier_Gateway_VoorbereidingSplit">
+        <di:waypoint x="720" y="460" />
+        <di:waypoint x="750" y="460" />
+        <di:waypoint x="750" y="790" />
+        <di:waypoint x="780" y="790" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_VoorbereidingSplit_Task_VersturenVerzoekVisi_di" bpmnElement="Flow_Gateway_VoorbereidingSplit_Task_VersturenVerzoekVisi">
+        <di:waypoint x="830" y="790" />
+        <di:waypoint x="845" y="790" />
+        <di:waypoint x="845" y="700" />
+        <di:waypoint x="860" y="700" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_VersturenVerzoekVisi_Task_InrichtenVisi_di" bpmnElement="Flow_Task_VersturenVerzoekVisi_Task_InrichtenVisi">
+        <di:waypoint x="960" y="700" />
+        <di:waypoint x="990" y="700" />
+        <di:waypoint x="990" y="140" />
+        <di:waypoint x="1020" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_InrichtenVisi_Gateway_VoorbereidingJoin_di" bpmnElement="Flow_Task_InrichtenVisi_Gateway_VoorbereidingJoin">
+        <di:waypoint x="1120" y="140" />
+        <di:waypoint x="1240" y="140" />
+        <di:waypoint x="1240" y="790" />
+        <di:waypoint x="1360" y="790" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_VoorbereidingSplit_Task_VersturenVerzoekBetterPerformance_di" bpmnElement="Flow_Gateway_VoorbereidingSplit_Task_VersturenVerzoekBetterPerformance">
+        <di:waypoint x="830" y="790" />
+        <di:waypoint x="860" y="790" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_VersturenVerzoekBetterPerformance_Task_InrichtenBetterPerformance_di" bpmnElement="Flow_Task_VersturenVerzoekBetterPerformance_Task_InrichtenBetterPerformance">
+        <di:waypoint x="960" y="790" />
+        <di:waypoint x="990" y="790" />
+        <di:waypoint x="990" y="230" />
+        <di:waypoint x="1020" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_InrichtenBetterPerformance_Gateway_VoorbereidingJoin_di" bpmnElement="Flow_Task_InrichtenBetterPerformance_Gateway_VoorbereidingJoin">
+        <di:waypoint x="1120" y="230" />
+        <di:waypoint x="1240" y="230" />
+        <di:waypoint x="1240" y="790" />
+        <di:waypoint x="1360" y="790" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_VoorbereidingSplit_Task_UpdatenToezichtsplan_di" bpmnElement="Flow_Gateway_VoorbereidingSplit_Task_UpdatenToezichtsplan">
+        <di:waypoint x="830" y="790" />
+        <di:waypoint x="845" y="790" />
+        <di:waypoint x="845" y="880" />
+        <di:waypoint x="860" y="880" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_UpdatenToezichtsplan_Task_VersturenToezichtsplan_di" bpmnElement="Flow_Task_UpdatenToezichtsplan_Task_VersturenToezichtsplan">
+        <di:waypoint x="960" y="880" />
+        <di:waypoint x="1020" y="880" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_VersturenToezichtsplan_Task_BesprekenToezichtsplan_di" bpmnElement="Flow_Task_VersturenToezichtsplan_Task_BesprekenToezichtsplan">
+        <di:waypoint x="1120" y="880" />
+        <di:waypoint x="1150" y="880" />
+        <di:waypoint x="1150" y="580" />
+        <di:waypoint x="1180" y="580" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_BesprekenToezichtsplan_Gateway_VoorbereidingJoin_di" bpmnElement="Flow_Task_BesprekenToezichtsplan_Gateway_VoorbereidingJoin">
+        <di:waypoint x="1280" y="580" />
+        <di:waypoint x="1320" y="580" />
+        <di:waypoint x="1320" y="790" />
+        <di:waypoint x="1360" y="790" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_VoorbereidingSplit_Task_InrichtenBesteksadministratie_di" bpmnElement="Flow_Gateway_VoorbereidingSplit_Task_InrichtenBesteksadministratie">
+        <di:waypoint x="830" y="790" />
+        <di:waypoint x="845" y="790" />
+        <di:waypoint x="845" y="970" />
+        <di:waypoint x="860" y="970" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_InrichtenBesteksadministratie_Gateway_VoorbereidingJoin_di" bpmnElement="Flow_Task_InrichtenBesteksadministratie_Gateway_VoorbereidingJoin">
+        <di:waypoint x="960" y="970" />
+        <di:waypoint x="1160" y="970" />
+        <di:waypoint x="1160" y="790" />
+        <di:waypoint x="1360" y="790" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_VoorbereidingSplit_Task_InitierenStartoverleg_di" bpmnElement="Flow_Gateway_VoorbereidingSplit_Task_InitierenStartoverleg">
+        <di:waypoint x="830" y="790" />
+        <di:waypoint x="845" y="790" />
+        <di:waypoint x="845" y="1080" />
+        <di:waypoint x="860" y="1080" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_InitierenStartoverleg_Task_HoudenStartoverleg_di" bpmnElement="Flow_Task_InitierenStartoverleg_Task_HoudenStartoverleg">
+        <di:waypoint x="960" y="1080" />
+        <di:waypoint x="990" y="1080" />
+        <di:waypoint x="990" y="1280" />
+        <di:waypoint x="1020" y="1280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_HoudenStartoverleg_Gateway_VoorbereidingJoin_di" bpmnElement="Flow_Task_HoudenStartoverleg_Gateway_VoorbereidingJoin">
+        <di:waypoint x="1120" y="1280" />
+        <di:waypoint x="1240" y="1280" />
+        <di:waypoint x="1240" y="790" />
+        <di:waypoint x="1360" y="790" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_VoorbereidingJoin_Gateway_TechnischeInstallaties_di" bpmnElement="Flow_Gateway_VoorbereidingJoin_Gateway_TechnischeInstallaties">
+        <di:waypoint x="1410" y="790" />
+        <di:waypoint x="1440" y="790" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_TechnischeInstallaties_Task_CommunicerenOverdrachtInstallatiedeel_di" bpmnElement="Flow_Gateway_TechnischeInstallaties_Task_CommunicerenOverdrachtInstallatiedeel">
+        <di:waypoint x="1490" y="790" />
+        <di:waypoint x="1505" y="790" />
+        <di:waypoint x="1505" y="700" />
+        <di:waypoint x="1520" y="700" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1496" y="770" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_TechnischeInstallaties_Task_ControlerenDocumentenON_di" bpmnElement="Flow_Gateway_TechnischeInstallaties_Task_ControlerenDocumentenON">
+        <di:waypoint x="1490" y="790" />
+        <di:waypoint x="1680" y="790" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1496" y="770" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_CommunicerenOverdrachtInstallatiedeel_Task_ControlerenDocumentenON_di" bpmnElement="Flow_Task_CommunicerenOverdrachtInstallatiedeel_Task_ControlerenDocumentenON">
+        <di:waypoint x="1620" y="700" />
+        <di:waypoint x="1650" y="700" />
+        <di:waypoint x="1650" y="790" />
+        <di:waypoint x="1680" y="790" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_ControlerenDocumentenON_Task_VersturenDocumentVG_di" bpmnElement="Flow_Task_ControlerenDocumentenON_Task_VersturenDocumentVG">
+        <di:waypoint x="1780" y="790" />
+        <di:waypoint x="1810" y="790" />
+        <di:waypoint x="1810" y="880" />
+        <di:waypoint x="1840" y="880" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_VersturenDocumentVG_Task_BeoordelenDocumentVG_di" bpmnElement="Flow_Task_VersturenDocumentVG_Task_BeoordelenDocumentVG">
+        <di:waypoint x="1940" y="880" />
+        <di:waypoint x="1970" y="880" />
+        <di:waypoint x="1970" y="1400" />
+        <di:waypoint x="2000" y="1400" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_BeoordelenDocumentVG_Gateway_AkkoordDocumenten_di" bpmnElement="Flow_Task_BeoordelenDocumentVG_Gateway_AkkoordDocumenten">
+        <di:waypoint x="2100" y="1400" />
+        <di:waypoint x="2130" y="1400" />
+        <di:waypoint x="2130" y="790" />
+        <di:waypoint x="2160" y="790" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_AkkoordDocumenten_Task_LatenAanpassenDocumentenON_di" bpmnElement="Flow_Gateway_AkkoordDocumenten_Task_LatenAanpassenDocumentenON">
+        <di:waypoint x="2210" y="790" />
+        <di:waypoint x="2225" y="790" />
+        <di:waypoint x="2225" y="700" />
+        <di:waypoint x="2240" y="700" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2216" y="770" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_AkkoordDocumenten_Task_HoudenOverlegVgCoordinator_di" bpmnElement="Flow_Gateway_AkkoordDocumenten_Task_HoudenOverlegVgCoordinator">
+        <di:waypoint x="2210" y="790" />
+        <di:waypoint x="2225" y="790" />
+        <di:waypoint x="2225" y="1170" />
+        <di:waypoint x="2240" y="1170" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2216" y="770" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_LatenAanpassenDocumentenON_Task_ControlerenDocumentenON_di" bpmnElement="Flow_Task_LatenAanpassenDocumentenON_Task_ControlerenDocumentenON">
+        <di:waypoint x="2290" y="740" />
+        <di:waypoint x="2290" y="1010" />
+        <di:waypoint x="1730" y="1010" />
+        <di:waypoint x="1730" y="830" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_HoudenOverlegVgCoordinator_EndEvent_StartWerkBuiten_di" bpmnElement="Flow_Task_HoudenOverlegVgCoordinator_EndEvent_StartWerkBuiten">
+        <di:waypoint x="2340" y="1170" />
+        <di:waypoint x="2400" y="1170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Assoc_Annotation_IN1_Inkoopprocedure_di" bpmnElement="Assoc_Annotation_IN1_Inkoopprocedure">
+        <di:waypoint x="350" y="100" />
+        <di:waypoint x="600" y="145" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Assoc_Annotation_BO13_Overdracht_di" bpmnElement="Assoc_Annotation_BO13_Overdracht">
+        <di:waypoint x="1570" y="660" />
+        <di:waypoint x="1650" y="620" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Assoc_Annotation_R52_StartWerk_di" bpmnElement="Assoc_Annotation_R52_StartWerk">
+        <di:waypoint x="2290" y="1130" />
+        <di:waypoint x="2330" y="1285" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/examples/organizations/flevoland/rip-phase-51/rip-aanmeldformulier-visi.document
+++ b/examples/organizations/flevoland/rip-phase-51/rip-aanmeldformulier-visi.document
@@ -1,0 +1,186 @@
+{
+  "id": "rip-aanmeldformulier-visi",
+  "name": "RIP — VISI Registration Form (Aanmeldformulier VISI)",
+  "description": "The registration form submitted to have the VISI environment set up for the project.",
+  "processKey": "RipR51Process",
+  "serviceId": "RipR51",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-02T00:00:00.000Z",
+  "updatedAt": "2026-09-02T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{visiAanmeldformulierReferentie}}",
+      "variableKey": "visiAanmeldformulierReferentie",
+      "source": "process",
+      "label": "Registration form reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{visiVerzoekVerstuurdOp}}",
+      "variableKey": "visiVerzoekVerstuurdOp",
+      "source": "process",
+      "label": "Request sent on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{visiProjectcode}}",
+      "variableKey": "visiProjectcode",
+      "source": "process",
+      "label": "VISI project code"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Aanmeldformulier {{visiAanmeldformulierReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "VISI registration",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "VISI registration"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Registration form {{visiAanmeldformulierReferentie}} was submitted on {{visiVerzoekVerstuurdOp}} to set up VISI for project {{projectNumber}} — {{projectName}} under project code {{visiProjectcode}}."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Submitted by the directievoerder"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-agenda-startoverleg.document
+++ b/examples/organizations/flevoland/rip-phase-51/rip-agenda-startoverleg.document
@@ -1,0 +1,195 @@
+{
+  "id": "rip-agenda-startoverleg",
+  "name": "RIP — Kick-off Meeting Agenda (Agenda startoverleg)",
+  "description": "The agenda for the kick-off meeting with the project team and the contractor.",
+  "processKey": "RipR51Process",
+  "serviceId": "RipR51",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-02T00:00:00.000Z",
+  "updatedAt": "2026-09-02T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{agendaStartoverlegReferentie}}",
+      "variableKey": "agendaStartoverlegReferentie",
+      "source": "process",
+      "label": "Agenda reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{startoverlegDatum}}",
+      "variableKey": "startoverlegDatum",
+      "source": "process",
+      "label": "Meeting date"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{startoverlegGenodigden}}",
+      "variableKey": "startoverlegGenodigden",
+      "source": "process",
+      "label": "Invited"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Agenda {{agendaStartoverlegReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Kick-off meeting agenda",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Kick-off meeting agenda"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Agenda {{agendaStartoverlegReferentie}} covers the startoverleg for project {{projectNumber}} — {{projectName}}, to be held on {{startoverlegDatum}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Invited: {{startoverlegGenodigden}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up by the projectleider"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-beoordelen-document-vg.form
+++ b/examples/organizations/flevoland/rip-phase-51/rip-beoordelen-document-vg.form
@@ -1,0 +1,74 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-beoordelen-document-vg",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Assess the contractor health and safety plan"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The B&O Infra health and safety adviser assesses the contractor health and safety plan and gives the verdict on the contractor documents as a whole."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Assessment reference",
+      "key": "vgBeoordelingReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bevindingen",
+      "type": "textarea",
+      "label": "Assessment findings",
+      "key": "vgBeoordelingBevindingen",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Akkoord",
+      "type": "select",
+      "label": "All contractor documents approved",
+      "key": "documentenAkkoord",
+      "values": [
+        {
+          "label": "Yes",
+          "value": "ja"
+        },
+        {
+          "label": "No",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Assessed on",
+      "key": "vgBeoordeeldOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-bespreken-toezichtsplan.form
+++ b/examples/organizations/flevoland/rip-phase-51/rip-bespreken-toezichtsplan.form
@@ -1,0 +1,71 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-bespreken-toezichtsplan",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Discuss and adopt the supervision plan"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The directievoerder, toezichthouder and vestigingsmanager discuss the final supervision plan and adopt it."
+    },
+    {
+      "id": "F_Vastgesteld",
+      "type": "select",
+      "label": "Supervision plan adopted",
+      "key": "toezichtsplanVastgesteld",
+      "values": [
+        {
+          "label": "Yes",
+          "value": "ja"
+        },
+        {
+          "label": "No",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Door",
+      "type": "textfield",
+      "label": "Adopted by",
+      "key": "toezichtsplanVastgesteldDoor",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Adopted on",
+      "key": "toezichtsplanVastgesteldOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Comments",
+      "key": "toezichtsplanOpmerkingen"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-communiceren-overdracht-installatiedeel.form
+++ b/examples/organizations/flevoland/rip-phase-51/rip-communiceren-overdracht-installatiedeel.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-communiceren-overdracht-installatiedeel",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Communicate the handover of the installation part"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The project contains technical installations, so the installation part is handed to Beheer & Onderhoud under BO13.1. Communicate that handover to the OvD and the directievoerder; preparation of the execution then continues."
+    },
+    {
+      "id": "F_Ontvangers",
+      "type": "textfield",
+      "label": "Communicated to",
+      "key": "overdrachtOntvangers",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Toel",
+      "type": "textarea",
+      "label": "Scope of the installation part",
+      "key": "overdrachtInstallatiedeelToelichting",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Communicated on",
+      "key": "overdrachtGecommuniceerdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-controleren-documenten-on.form
+++ b/examples/organizations/flevoland/rip-phase-51/rip-controleren-documenten-on.form
@@ -1,0 +1,73 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-controleren-documenten-on",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Check the contractor documents"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Check the documents submitted by the contractor: the execution planning, the health and safety plan and the work plans."
+    },
+    {
+      "id": "F_Planning",
+      "type": "textfield",
+      "label": "Execution planning reference",
+      "key": "uitvoeringsplanningReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Vg",
+      "type": "textfield",
+      "label": "Health and safety plan reference",
+      "key": "vgPlanReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Werkplannen",
+      "type": "textfield",
+      "label": "Work plans reference",
+      "key": "werkplannenReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bevindingen",
+      "type": "textarea",
+      "label": "Findings",
+      "key": "documentenBevindingen",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Checked on",
+      "key": "documentenGecontroleerdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-definitief-toezichtsplan.document
+++ b/examples/organizations/flevoland/rip-phase-51/rip-definitief-toezichtsplan.document
@@ -1,0 +1,202 @@
+{
+  "id": "rip-definitief-toezichtsplan",
+  "name": "RIP — Final Supervision Plan (Definitief toezichtsplan)",
+  "description": "The draft supervision plan worked up into its final form, ahead of adoption.",
+  "processKey": "RipR51Process",
+  "serviceId": "RipR51",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-02T00:00:00.000Z",
+  "updatedAt": "2026-09-02T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{definitiefToezichtsplanReferentie}}",
+      "variableKey": "definitiefToezichtsplanReferentie",
+      "source": "process",
+      "label": "Final supervision plan reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{toezichtsplanBijgewerktOp}}",
+      "variableKey": "toezichtsplanBijgewerktOp",
+      "source": "process",
+      "label": "Finalised on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{conceptToezichtsplanReferentie}}",
+      "variableKey": "conceptToezichtsplanReferentie",
+      "source": "process",
+      "label": "Draft supervision plan reference"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{toezichtsplanWijzigingen}}",
+      "variableKey": "toezichtsplanWijzigingen",
+      "source": "process",
+      "label": "What was changed"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Toezichtsplan {{definitiefToezichtsplanReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Final supervision plan",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Final supervision plan"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Supervision plan {{definitiefToezichtsplanReferentie}} for project {{projectNumber}} — {{projectName}} was finalised on {{toezichtsplanBijgewerktOp}}, from draft {{conceptToezichtsplanReferentie}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "What was changed: {{toezichtsplanWijzigingen}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up by the directievoerder"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-houden-startoverleg.form
+++ b/examples/organizations/flevoland/rip-phase-51/rip-houden-startoverleg.form
@@ -1,0 +1,73 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-houden-startoverleg",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Hold the kick-off meeting"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Hold the startoverleg with the project team and the contractor, and record the agreements and the overview of documents the contractor is to submit."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Meeting report reference",
+      "key": "verslagStartoverlegReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Aanwezig",
+      "type": "textarea",
+      "label": "Attendees",
+      "key": "startoverlegAanwezigen",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Afspraken",
+      "type": "textarea",
+      "label": "Agreements made",
+      "key": "startoverlegAfspraken",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Stukken",
+      "type": "textarea",
+      "label": "Overview of documents to be submitted by the contractor",
+      "key": "inTeDienenStukkenON",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Held on",
+      "key": "startoverlegGehoudenOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-initieren-startoverleg.form
+++ b/examples/organizations/flevoland/rip-phase-51/rip-initieren-startoverleg.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-initieren-startoverleg",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Initiate the kick-off meeting"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Draw up the agenda for the startoverleg and invite the participants, including the contractor."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Agenda reference",
+      "key": "agendaStartoverlegReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Datum",
+      "type": "datetime",
+      "label": "Meeting date",
+      "key": "startoverlegDatum",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Genodigden",
+      "type": "textarea",
+      "label": "Invited",
+      "key": "startoverlegGenodigden",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-inrichten-besteksadministratie.form
+++ b/examples/organizations/flevoland/rip-phase-51/rip-inrichten-besteksadministratie.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-inrichten-besteksadministratie",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Set up the specification administration"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Set up the besteksadministratie for the work specification, so payments and changes can be recorded against it during execution."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Specification administration reference",
+      "key": "besteksadministratieReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Set up on",
+      "key": "besteksadministratieIngerichtOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-inrichten-better-performance.form
+++ b/examples/organizations/flevoland/rip-phase-51/rip-inrichten-better-performance.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-inrichten-better-performance",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Set up Better Performance"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Set up the Better Performance environment for the project."
+    },
+    {
+      "id": "F_Url",
+      "type": "textfield",
+      "label": "Better Performance environment",
+      "key": "betterPerformanceOmgevingUrl",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Set up on",
+      "key": "betterPerformanceIngerichtOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-inrichten-visi.form
+++ b/examples/organizations/flevoland/rip-phase-51/rip-inrichten-visi.form
@@ -1,0 +1,65 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-inrichten-visi",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Set up VISI"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Set up the VISI environment for the project and assign the roles."
+    },
+    {
+      "id": "F_Url",
+      "type": "textfield",
+      "label": "VISI environment",
+      "key": "visiOmgevingUrl",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Rollen",
+      "type": "select",
+      "label": "Roles assigned",
+      "key": "visiRollenIngericht",
+      "values": [
+        {
+          "label": "Yes",
+          "value": "ja"
+        },
+        {
+          "label": "No",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Set up on",
+      "key": "visiIngerichtOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-laten-aanpassen-documenten-on.form
+++ b/examples/organizations/flevoland/rip-phase-51/rip-laten-aanpassen-documenten-on.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-laten-aanpassen-documenten-on",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Have the contractor amend the documents"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Return the documents to the contractor for amendment, after which they are checked again."
+    },
+    {
+      "id": "F_Verzoek",
+      "type": "textarea",
+      "label": "Amendments requested",
+      "key": "aanpassingVerzoek",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Requested on",
+      "key": "aanpassingVerzochtOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-opstellen-werkbestek.form
+++ b/examples/organizations/flevoland/rip-phase-51/rip-opstellen-werkbestek.form
@@ -1,0 +1,61 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-opstellen-werkbestek",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Draw up the work specification"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Draw up the werkbestek from the contract specification and drawings adopted in R3.2 and the note of information issued during the tender."
+    },
+    {
+      "id": "F_Werkbestek",
+      "type": "textfield",
+      "label": "Work specification reference",
+      "key": "werkbestekReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bestek",
+      "type": "textfield",
+      "label": "Contract specification and drawings reference (from R3.2)",
+      "key": "bestekReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Nota",
+      "type": "textfield",
+      "label": "Nota van inlichtingen reference",
+      "key": "notaVanInlichtingenReferentie"
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Drawn up on",
+      "key": "werkbestekOpgesteldOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-overleg-uitgangspunten-uitvoering.form
+++ b/examples/organizations/flevoland/rip-phase-51/rip-overleg-uitgangspunten-uitvoering.form
@@ -1,0 +1,83 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-overleg-uitgangspunten-uitvoering",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Hold the execution ground-rules meeting"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The RIP team, environment manager, supervisor and communications adviser agree the uitgangspunten for the execution phase. Whether the project contains technical installations is settled here, because it decides later whether the installation part is handed to Beheer & Onderhoud under BO13.1."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Execution ground rules reference",
+      "key": "uitgangspuntenReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Deelnemers",
+      "type": "textfield",
+      "label": "Attendees",
+      "key": "uitgangspuntenDeelnemers",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Afspraken",
+      "type": "textarea",
+      "label": "Ground rules agreed",
+      "key": "uitgangspuntenAfspraken",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Installaties",
+      "type": "select",
+      "label": "Project contains technical installation(s)",
+      "key": "technischeInstallaties",
+      "values": [
+        {
+          "label": "Yes",
+          "value": "ja"
+        },
+        {
+          "label": "No",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Agreed on",
+      "key": "uitgangspuntenVastgesteldOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-overleg-vg-coordinator.form
+++ b/examples/organizations/flevoland/rip-phase-51/rip-overleg-vg-coordinator.form
@@ -1,0 +1,73 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-overleg-vg-coordinator",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Hold the meeting with the contractor health and safety coordinator"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The projectleider meets the contractor health and safety coordinator for the execution phase, covering the written agreement under the Arbobesluit vergewisplicht, the client design plan and the contractor execution plan. Once this is done the work can start on site and R5.2 begins."
+    },
+    {
+      "id": "F_Naam",
+      "type": "textfield",
+      "label": "Health and safety coordinator (contractor)",
+      "key": "vgCoordinatorNaam",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Ovk",
+      "type": "textfield",
+      "label": "Written agreement, Arbobesluit vergewisplicht",
+      "key": "schriftelijkeOvkVergewisplicht",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Ontwerpplan",
+      "type": "textfield",
+      "label": "Health and safety design plan (client) reference",
+      "key": "vgOntwerpplanReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Uitvoerplan",
+      "type": "textfield",
+      "label": "Health and safety execution plan (contractor) reference",
+      "key": "vgUitvoerplanReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Held on",
+      "key": "vgOverlegGehoudenOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-risicodossier-contractbeheersing.document
+++ b/examples/organizations/flevoland/rip-phase-51/rip-risicodossier-contractbeheersing.document
@@ -1,0 +1,218 @@
+{
+  "id": "rip-risicodossier-contractbeheersing",
+  "name": "RIP — Risk Dossier for Contract Management (Risicodossier)",
+  "description": "The risk dossier updated for contract management at the start of the execution phase.",
+  "processKey": "RipR51Process",
+  "serviceId": "RipR51",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-02T00:00:00.000Z",
+  "updatedAt": "2026-09-02T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{risicodossierReferentie}}",
+      "variableKey": "risicodossierReferentie",
+      "source": "process",
+      "label": "Risk dossier reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{risicodossierBijgewerktOp}}",
+      "variableKey": "risicodossierBijgewerktOp",
+      "source": "process",
+      "label": "Updated on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{risicodossierWijzigingen}}",
+      "variableKey": "risicodossierWijzigingen",
+      "source": "process",
+      "label": "Risks added or changed"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{aanbiedingAannemerReferentie}}",
+      "variableKey": "aanbiedingAannemerReferentie",
+      "source": "process",
+      "label": "Contractor offer reference"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{werkbestekReferentie}}",
+      "variableKey": "werkbestekReferentie",
+      "source": "process",
+      "label": "Work specification reference"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Risicodossier {{risicodossierReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Risk dossier",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Risk dossier"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Risicodossier {{risicodossierReferentie}} for project {{projectNumber}} — {{projectName}} was updated for contract management on {{risicodossierBijgewerktOp}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Risks added or changed: {{risicodossierWijzigingen}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The update draws on the execution ground rules, contractor offer {{aanbiedingAannemerReferentie}} and work specification {{werkbestekReferentie}}."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Updated by the manager projectbeheersing"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-uitgangspunten-uitvoering.document
+++ b/examples/organizations/flevoland/rip-phase-51/rip-uitgangspunten-uitvoering.document
@@ -1,0 +1,218 @@
+{
+  "id": "rip-uitgangspunten-uitvoering",
+  "name": "RIP — Execution Ground Rules (Uitgangspunten uitvoering)",
+  "description": "The ground rules agreed for the execution phase, including whether the project contains technical installations.",
+  "processKey": "RipR51Process",
+  "serviceId": "RipR51",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-02T00:00:00.000Z",
+  "updatedAt": "2026-09-02T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{uitgangspuntenReferentie}}",
+      "variableKey": "uitgangspuntenReferentie",
+      "source": "process",
+      "label": "Ground rules reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{uitgangspuntenVastgesteldOp}}",
+      "variableKey": "uitgangspuntenVastgesteldOp",
+      "source": "process",
+      "label": "Agreed on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{uitgangspuntenDeelnemers}}",
+      "variableKey": "uitgangspuntenDeelnemers",
+      "source": "process",
+      "label": "Attendees"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{uitgangspuntenAfspraken}}",
+      "variableKey": "uitgangspuntenAfspraken",
+      "source": "process",
+      "label": "Ground rules agreed"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{technischeInstallaties}}",
+      "variableKey": "technischeInstallaties",
+      "source": "process",
+      "label": "Technical installations present"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Uitgangspunten {{uitgangspuntenReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Execution ground rules",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Execution ground rules"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The ground rules {{uitgangspuntenReferentie}} for the execution phase of project {{projectNumber}} — {{projectName}} were agreed on {{uitgangspuntenVastgesteldOp}} with {{uitgangspuntenDeelnemers}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Agreed: {{uitgangspuntenAfspraken}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The project contains technical installation(s): {{technischeInstallaties}}. Where it does, the installation part is handed to Beheer & Onderhoud under BO13.1."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Agreed by the RIP team, environment manager, supervisor and communications adviser"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-updaten-risicodossier-uitvoering.form
+++ b/examples/organizations/flevoland/rip-phase-51/rip-updaten-risicodossier-uitvoering.form
@@ -1,0 +1,64 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-updaten-risicodossier-uitvoering",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Update the risk dossier for contract management"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Update the risicodossier for contract management, using the execution ground rules, the contractor offer and the work specification."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Risk dossier reference",
+      "key": "risicodossierReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Aanbieding",
+      "type": "textfield",
+      "label": "Contractor offer reference",
+      "key": "aanbiedingAannemerReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Wijzigingen",
+      "type": "textarea",
+      "label": "Risks added or changed",
+      "key": "risicodossierWijzigingen",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Updated on",
+      "key": "risicodossierBijgewerktOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-updaten-toezichtsplan.form
+++ b/examples/organizations/flevoland/rip-phase-51/rip-updaten-toezichtsplan.form
@@ -1,0 +1,64 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-updaten-toezichtsplan",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Update the supervision plan"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Work the draft supervision plan up into the definitieve toezichtsplan, using the contractor offer, the risk dossier and the work specification."
+    },
+    {
+      "id": "F_Concept",
+      "type": "textfield",
+      "label": "Draft supervision plan reference",
+      "key": "conceptToezichtsplanReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Definitief",
+      "type": "textfield",
+      "label": "Final supervision plan reference",
+      "key": "definitiefToezichtsplanReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Wijzigingen",
+      "type": "textarea",
+      "label": "What was changed",
+      "key": "toezichtsplanWijzigingen",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Updated on",
+      "key": "toezichtsplanBijgewerktOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-vastgesteld-toezichtsplan.document
+++ b/examples/organizations/flevoland/rip-phase-51/rip-vastgesteld-toezichtsplan.document
@@ -1,0 +1,232 @@
+{
+  "id": "rip-vastgesteld-toezichtsplan",
+  "name": "RIP — Adopted Supervision Plan (Vastgesteld toezichtsplan)",
+  "description": "The supervision plan as adopted by the directievoerder, toezichthouder and vestigingsmanager.",
+  "processKey": "RipR51Process",
+  "serviceId": "RipR51",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-02T00:00:00.000Z",
+  "updatedAt": "2026-09-02T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{definitiefToezichtsplanReferentie}}",
+      "variableKey": "definitiefToezichtsplanReferentie",
+      "source": "process",
+      "label": "Supervision plan reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{toezichtsplanOntvangers}}",
+      "variableKey": "toezichtsplanOntvangers",
+      "source": "process",
+      "label": "Sent to"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{toezichtsplanVerstuurdOp}}",
+      "variableKey": "toezichtsplanVerstuurdOp",
+      "source": "process",
+      "label": "Sent on"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{toezichtsplanVastgesteld}}",
+      "variableKey": "toezichtsplanVastgesteld",
+      "source": "process",
+      "label": "Adopted"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{toezichtsplanVastgesteldDoor}}",
+      "variableKey": "toezichtsplanVastgesteldDoor",
+      "source": "process",
+      "label": "Adopted by"
+    },
+    {
+      "id": "b8",
+      "placeholder": "{{toezichtsplanVastgesteldOp}}",
+      "variableKey": "toezichtsplanVastgesteldOp",
+      "source": "process",
+      "label": "Adopted on"
+    },
+    {
+      "id": "b9",
+      "placeholder": "{{toezichtsplanOpmerkingen}}",
+      "variableKey": "toezichtsplanOpmerkingen",
+      "source": "process",
+      "label": "Comments"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Toezichtsplan {{definitiefToezichtsplanReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Adopted supervision plan",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Adopted supervision plan"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Supervision plan {{definitiefToezichtsplanReferentie}} for project {{projectNumber}} — {{projectName}} was sent to {{toezichtsplanOntvangers}} on {{toezichtsplanVerstuurdOp}} and discussed thereafter."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Adopted: {{toezichtsplanVastgesteld}}, by {{toezichtsplanVastgesteldDoor}} on {{toezichtsplanVastgesteldOp}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "{{toezichtsplanOpmerkingen}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Adopted by the directievoerder, toezichthouder and vestigingsmanager"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-verslag-startoverleg.document
+++ b/examples/organizations/flevoland/rip-phase-51/rip-verslag-startoverleg.document
@@ -1,0 +1,227 @@
+{
+  "id": "rip-verslag-startoverleg",
+  "name": "RIP — Kick-off Meeting Report (Verslag startoverleg)",
+  "description": "The report of the kick-off meeting, including the overview of documents the contractor is to submit.",
+  "processKey": "RipR51Process",
+  "serviceId": "RipR51",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-02T00:00:00.000Z",
+  "updatedAt": "2026-09-02T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{verslagStartoverlegReferentie}}",
+      "variableKey": "verslagStartoverlegReferentie",
+      "source": "process",
+      "label": "Meeting report reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{startoverlegGehoudenOp}}",
+      "variableKey": "startoverlegGehoudenOp",
+      "source": "process",
+      "label": "Held on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{startoverlegAanwezigen}}",
+      "variableKey": "startoverlegAanwezigen",
+      "source": "process",
+      "label": "Attendees"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{startoverlegAfspraken}}",
+      "variableKey": "startoverlegAfspraken",
+      "source": "process",
+      "label": "Agreements"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{inTeDienenStukkenON}}",
+      "variableKey": "inTeDienenStukkenON",
+      "source": "process",
+      "label": "Documents to be submitted by the contractor"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Verslag {{verslagStartoverlegReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Kick-off meeting report",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Kick-off meeting report"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The startoverleg for project {{projectNumber}} — {{projectName}} was held on {{startoverlegGehoudenOp}}, recorded in {{verslagStartoverlegReferentie}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Attendees: {{startoverlegAanwezigen}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Agreements: {{startoverlegAfspraken}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Documents to be submitted by the contractor: {{inTeDienenStukkenON}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Recorded by the technisch administratief medewerker"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-versturen-document-vg.form
+++ b/examples/organizations/flevoland/rip-phase-51/rip-versturen-document-vg.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-versturen-document-vg",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Send the health and safety document for assessment"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Send the contractor health and safety plan to the B&O Infra health and safety adviser for assessment."
+    },
+    {
+      "id": "F_Aan",
+      "type": "textfield",
+      "label": "Sent to",
+      "key": "vgDocumentVerstuurdAan",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Sent on",
+      "key": "vgDocumentVerstuurdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-versturen-toezichtsplan.form
+++ b/examples/organizations/flevoland/rip-phase-51/rip-versturen-toezichtsplan.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-versturen-toezichtsplan",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Send the supervision plan to VM and TZH"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Send the final supervision plan to the vestigingsmanager and the toezichthouder ahead of the meeting at which it is adopted."
+    },
+    {
+      "id": "F_Ontvangers",
+      "type": "textfield",
+      "label": "Sent to",
+      "key": "toezichtsplanOntvangers",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Sent on",
+      "key": "toezichtsplanVerstuurdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-verzoek-inrichten-better-performance.form
+++ b/examples/organizations/flevoland/rip-phase-51/rip-verzoek-inrichten-better-performance.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-verzoek-inrichten-better-performance",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Send the request to set up Better Performance"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Request the Better Performance environment for the project."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Request reference",
+      "key": "betterPerformanceVerzoekReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Request sent on",
+      "key": "betterPerformanceVerzoekVerstuurdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-verzoek-inrichten-visi.form
+++ b/examples/organizations/flevoland/rip-phase-51/rip-verzoek-inrichten-visi.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-verzoek-inrichten-visi",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Send the request to set up VISI"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Submit the VISI registration form so the VISI environment can be set up for the project."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "VISI registration form reference",
+      "key": "visiAanmeldformulierReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Code",
+      "type": "textfield",
+      "label": "VISI project code",
+      "key": "visiProjectcode",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Request sent on",
+      "key": "visiVerzoekVerstuurdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-vg-plan-beoordeling.document
+++ b/examples/organizations/flevoland/rip-phase-51/rip-vg-plan-beoordeling.document
@@ -1,0 +1,218 @@
+{
+  "id": "rip-vg-plan-beoordeling",
+  "name": "RIP — Health and Safety Plan Assessment (Beoordeling V&G-plan)",
+  "description": "The B&O Infra health and safety adviser assessment of the contractor health and safety plan, and the verdict on the contractor documents as a whole.",
+  "processKey": "RipR51Process",
+  "serviceId": "RipR51",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-02T00:00:00.000Z",
+  "updatedAt": "2026-09-02T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{vgBeoordelingReferentie}}",
+      "variableKey": "vgBeoordelingReferentie",
+      "source": "process",
+      "label": "Assessment reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{vgBeoordeeldOp}}",
+      "variableKey": "vgBeoordeeldOp",
+      "source": "process",
+      "label": "Assessed on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{vgPlanReferentie}}",
+      "variableKey": "vgPlanReferentie",
+      "source": "process",
+      "label": "Health and safety plan reference"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{vgBeoordelingBevindingen}}",
+      "variableKey": "vgBeoordelingBevindingen",
+      "source": "process",
+      "label": "Findings"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{documentenAkkoord}}",
+      "variableKey": "documentenAkkoord",
+      "source": "process",
+      "label": "All documents approved"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Beoordeling {{vgBeoordelingReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Health and safety plan assessment",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Health and safety plan assessment"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Health and safety plan {{vgPlanReferentie}} for project {{projectNumber}} — {{projectName}} was assessed on {{vgBeoordeeldOp}}, recorded in {{vgBeoordelingReferentie}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Findings: {{vgBeoordelingBevindingen}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "All contractor documents approved: {{documentenAkkoord}}. Where they are not, the documents go back to the contractor for amendment and are checked again."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Assessed by the B&O Infra health and safety adviser"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-vg-uitvoeringsafspraken.document
+++ b/examples/organizations/flevoland/rip-phase-51/rip-vg-uitvoeringsafspraken.document
@@ -1,0 +1,227 @@
+{
+  "id": "rip-vg-uitvoeringsafspraken",
+  "name": "RIP — Health and Safety Execution Agreements (V&G-afspraken uitvoering)",
+  "description": "The agreements made with the contractor health and safety coordinator before the work starts on site.",
+  "processKey": "RipR51Process",
+  "serviceId": "RipR51",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-02T00:00:00.000Z",
+  "updatedAt": "2026-09-02T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{vgCoordinatorNaam}}",
+      "variableKey": "vgCoordinatorNaam",
+      "source": "process",
+      "label": "Health and safety coordinator"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{vgOverlegGehoudenOp}}",
+      "variableKey": "vgOverlegGehoudenOp",
+      "source": "process",
+      "label": "Held on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{schriftelijkeOvkVergewisplicht}}",
+      "variableKey": "schriftelijkeOvkVergewisplicht",
+      "source": "process",
+      "label": "Written agreement"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{vgOntwerpplanReferentie}}",
+      "variableKey": "vgOntwerpplanReferentie",
+      "source": "process",
+      "label": "Design plan reference"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{vgUitvoerplanReferentie}}",
+      "variableKey": "vgUitvoerplanReferentie",
+      "source": "process",
+      "label": "Execution plan reference"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "V&G-afspraken · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Health and safety execution agreements",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Health and safety execution agreements"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The meeting with contractor health and safety coordinator {{vgCoordinatorNaam}} for project {{projectNumber}} — {{projectName}} was held on {{vgOverlegGehoudenOp}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Written agreement under the Arbobesluit vergewisplicht: {{schriftelijkeOvkVergewisplicht}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Health and safety design plan (client): {{vgOntwerpplanReferentie}}. Health and safety execution plan (contractor): {{vgUitvoerplanReferentie}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "With these agreements in place the work can start on site and R5.2 Directievoering en toezicht UAV begins."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Agreed by the projectleider and the contractor health and safety coordinator"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-51/rip-werkbestek.document
+++ b/examples/organizations/flevoland/rip-phase-51/rip-werkbestek.document
@@ -1,0 +1,202 @@
+{
+  "id": "rip-werkbestek",
+  "name": "RIP — Work Specification (Werkbestek)",
+  "description": "The work specification drawn up from the R3.2 contract documents and the note of information.",
+  "processKey": "RipR51Process",
+  "serviceId": "RipR51",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-02T00:00:00.000Z",
+  "updatedAt": "2026-09-02T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{werkbestekReferentie}}",
+      "variableKey": "werkbestekReferentie",
+      "source": "process",
+      "label": "Work specification reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{werkbestekOpgesteldOp}}",
+      "variableKey": "werkbestekOpgesteldOp",
+      "source": "process",
+      "label": "Drawn up on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{bestekReferentie}}",
+      "variableKey": "bestekReferentie",
+      "source": "process",
+      "label": "Contract specification reference"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{notaVanInlichtingenReferentie}}",
+      "variableKey": "notaVanInlichtingenReferentie",
+      "source": "process",
+      "label": "Nota van inlichtingen reference"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Werkbestek {{werkbestekReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Work specification",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Work specification"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Werkbestek {{werkbestekReferentie}} for project {{projectNumber}} — {{projectName}} was drawn up on {{werkbestekOpgesteldOp}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "It is based on contract specification and drawings {{bestekReferentie}} adopted in R3.2 and on Nota van inlichtingen {{notaVanInlichtingenReferentie}}."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up by the cost and contract specialist"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}


### PR DESCRIPTION
First of four stacked PRs completing the RIP phase ladder. **Merge order: this one, then #R5.2 → #R5.4 → #R6.1.**

Models `R5_1 Voorbereiding op uitvoering 2007 DEF.pdf` (sheet dated 28-4-2026) as `RipR51Process`.

| | |
|---|---|
| Files | 30 (1 BPMN, 19 forms, 10 documents) |
| Nodes / flows / lanes | 25 / 30 / 8 |

## Three readings the drawing does not force on its own

**The five preparation streams are parallel.** VISI, Better Performance, the toezichtsplan, the besteksadministratie and the startoverleg fan out of the risk-dossier update and collect again before the installation question. They share no data and the sheet draws no order between them, so a parallel split/join is more honest than picking an arbitrary sequence.

**The V&G assessment is in sequence, not a second parallel block.** "Akkoord alle documenten?" consumes the adviser's verdict and no path to that decision skips the assessment, so a fork would add a gateway pair that can never interleave.

**BO13.1 is a round trip, not an exit.** On *ja* the installation part is handed to Beheer & Onderhoud, and the sheet's second BO13.1 marker points back into R5.1 — that is the handover being communicated to the OvD and the directievoerder. The *ja* leg therefore rejoins the document check and the phase keeps its single R5.2 exit.

## Gateway variables

`technischeInstallaties` is set in the uitgangspunten meeting, which is where that kind of execution ground rule is settled and which always precedes its gateway. `documentenAkkoord` is set by the V&G assessment, the last form before its own.

## Roles

Four are new to the ladder: `rip-communicatieadviseur`, `rip-technisch-administratief-medewerker`, `rip-opdrachtnemer`, `rip-adviseur-veiligheid-gezondheid`. **R5.1 is the first phase in which the contractor sits in a lane rather than outside the process.**

## Verification

Faseladder contract holds — key `RipR51Process`, `formRefBinding="deployment"` throughout with no `"latest"`, no `businessKey`, no `municipality` variable, no external-task topics, no `boardOwner` in the bundle (deploy-injected).

Both validators pass: structure (ids, reference resolution, reachability, one lane per node, deterministic exclusive gateways, balanced parallel gateways, DI integrity) and bundle (formRef/documentRef resolution, placeholder-to-binding agreement, every gateway variable produced by some form).