### PR TITLE
feat(rip): add R5.2 Directievoering en toezicht UAV bundle for Flevoland

### DIFF
--- a/examples/organizations/flevoland/rip-phase-52/RipR52Process.bpmn
+++ b/examples/organizations/flevoland/rip-phase-52/RipR52Process.bpmn
@@ -1,0 +1,1105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:ronl="http://ronl.nl/schema/1.0" id="Definitions_RipR52Process" targetNamespace="http://example.com/rip-phase-52" exporter="Camunda Modeler" exporterVersion="5.45.0">
+  <bpmn:collaboration id="Collaboration_RipR52Process">
+    <bpmn:participant id="Participant_RipR52Process" name="R5.2 - Directievoering en toezicht UAV" processRef="RipR52Process" />
+  </bpmn:collaboration>
+  <bpmn:process id="RipR52Process" name="R5.2 - Directievoering en toezicht UAV" isExecutable="true" camunda:historyTimeToLive="180">
+    <bpmn:laneSet id="LaneSet_RipR52Process">
+      <bpmn:lane id="Lane_Ondersteuner" name="Ondersteuner">
+        <bpmn:flowNodeRef>Task_OpstellenBriefAkkoordAfwijzing</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_InvullenWebformulierAtb</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_AO" name="AO">
+        <bpmn:flowNodeRef>Task_AccorderenFactuur</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_BeoordelenVerzoekOpleveringAo</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_IndienenBriefBijBesluitvorming</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_Projectleider" name="Projectleider">
+        <bpmn:flowNodeRef>Task_AccorderenFactuurDoorsturenAo</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_VerzoekSplit</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_SturenVerzoekOpleveringEnBeoordeling</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_BeoordelenVerzoekOpleveringPl</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_BinnenBuitenKrediet</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_MakenNotaConcerndirecteur</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_Waarde</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_MakenNotaAo</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_LatenInvullenWebformulierAtb</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_NotaJoin</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_VerzoekJoin</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_Aannemer" name="Aannemer">
+        <bpmn:flowNodeRef>StartEvent_R52</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_UitvoeringSplit</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_WeekStart</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_WeekAfwSplit</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_OpstellenWeekstaat</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_VersturenWeekstaat</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_WeekstaatBeoordelingSplit</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_WeekstaatBeoordelingJoin</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_WeekstaatAkkoord</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_AanpassenWeekstaat</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_MeldenAfwijking</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_AanpassenAfwijkingenrapport</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_WeekAfwJoin</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_SturenFactuurAanOg</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_AanvragenTotOpneming</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_VerzoekenTotUitstelOpleveren</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_UitvoeringJoin</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndEvent_R53</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_Toezichthouder" name="Toezichthouder">
+        <bpmn:flowNodeRef>Task_UitvoerenWerkzaamhedenToezichtsplan</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_BeoordelenEnSturenBeoordelingWeekstaat</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_InvoerenAantallenWeekstaat</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_Directievoerder" name="Directievoerder">
+        <bpmn:flowNodeRef>Task_BeoordelenWeekstaat</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_AfstemmenAfwijking</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_AfwijkingAkkoord</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_Directievoering</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_TermijnenContract</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_DoorsturenGeaccordeerdeTermijn</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_SturenOverzichtAwr</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_OnderhandelenPrijzen</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_SturenAangepastOverzichtAwr</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_AwrJoin</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_VersturenOverzichtAwrDv</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_WerkGereed</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_BeoordelenVerzoekOpleverenDv</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_SturenAdviesVerzoekOpleveren</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_PlaatsenBriefInVisi</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_KostenContractdeskundige" name="Kosten- en contractdeskundige">
+        <bpmn:flowNodeRef>Task_BeoordelenOverzichtAwr</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_AwrAkkoord</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_RetourSturenOverzichtAwr</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_VersturenOverzichtAwrKc</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+
+    <bpmn:startEvent id="StartEvent_R52" name="Start werk &quot;buiten&quot;&#10;(vanuit R5.1)">
+      <bpmn:outgoing>Flow_StartEvent_R52_Gateway_UitvoeringSplit</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:parallelGateway id="Gateway_UitvoeringSplit">
+      <bpmn:incoming>Flow_StartEvent_R52_Gateway_UitvoeringSplit</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_UitvoeringSplit_Gateway_WeekStart</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_UitvoeringSplit_Task_SturenFactuurAanOg</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_UitvoeringSplit_Task_AanvragenTotOpneming</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:exclusiveGateway id="Gateway_WeekStart" name="Volgende week">
+      <bpmn:incoming>Flow_Gateway_UitvoeringSplit_Gateway_WeekStart</bpmn:incoming>
+      <bpmn:incoming>Flow_Gateway_WerkGereed_Gateway_WeekStart</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_WeekStart_Gateway_WeekAfwSplit</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:parallelGateway id="Gateway_WeekAfwSplit">
+      <bpmn:incoming>Flow_Gateway_WeekStart_Gateway_WeekAfwSplit</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_WeekAfwSplit_Task_UitvoerenWerkzaamhedenToezichtsplan</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_WeekAfwSplit_Task_MeldenAfwijking</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:userTask id="Task_UitvoerenWerkzaamhedenToezichtsplan" name="Uitvoeren werkzaamheden&#10;conform toezichtsplan" camunda:formRef="rip-uitvoeren-toezichtsplan" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-toezichthouder">
+      <bpmn:incoming>Flow_Gateway_WeekAfwSplit_Task_UitvoerenWerkzaamhedenToezichtsplan</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_UitvoerenWerkzaamhedenToezichtsplan_Task_OpstellenWeekstaat</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_OpstellenWeekstaat" name="Opstellen&#10;weekstaat" camunda:formRef="rip-opstellen-weekstaat" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-opdrachtnemer" ronl:documentRef="rip-weekstaat">
+      <bpmn:incoming>Flow_Task_UitvoerenWerkzaamhedenToezichtsplan_Task_OpstellenWeekstaat</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_OpstellenWeekstaat_Task_VersturenWeekstaat</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_VersturenWeekstaat" name="Versturen weekstaat&#10;aan DV en TZH" camunda:formRef="rip-versturen-weekstaat" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-opdrachtnemer">
+      <bpmn:incoming>Flow_Task_OpstellenWeekstaat_Task_VersturenWeekstaat</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_AanpassenWeekstaat_Task_VersturenWeekstaat</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_VersturenWeekstaat_Gateway_WeekstaatBeoordelingSplit</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:parallelGateway id="Gateway_WeekstaatBeoordelingSplit">
+      <bpmn:incoming>Flow_Task_VersturenWeekstaat_Gateway_WeekstaatBeoordelingSplit</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_WeekstaatBeoordelingSplit_Task_BeoordelenEnSturenBeoordelingWeekstaat</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_WeekstaatBeoordelingSplit_Task_BeoordelenWeekstaat</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:userTask id="Task_BeoordelenEnSturenBeoordelingWeekstaat" name="Beoordelen en sturen&#10;beoordeling weekstaat" camunda:formRef="rip-beoordelen-sturen-weekstaat" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-toezichthouder">
+      <bpmn:incoming>Flow_Gateway_WeekstaatBeoordelingSplit_Task_BeoordelenEnSturenBeoordelingWeekstaat</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_BeoordelenEnSturenBeoordelingWeekstaat_Gateway_WeekstaatBeoordelingJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_BeoordelenWeekstaat" name="Beoordelen&#10;weekstaat" camunda:formRef="rip-beoordelen-weekstaat" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-directievoerder">
+      <bpmn:incoming>Flow_Gateway_WeekstaatBeoordelingSplit_Task_BeoordelenWeekstaat</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_BeoordelenWeekstaat_Gateway_WeekstaatBeoordelingJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:parallelGateway id="Gateway_WeekstaatBeoordelingJoin">
+      <bpmn:incoming>Flow_Task_BeoordelenEnSturenBeoordelingWeekstaat_Gateway_WeekstaatBeoordelingJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_BeoordelenWeekstaat_Gateway_WeekstaatBeoordelingJoin</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_WeekstaatBeoordelingJoin_Gateway_WeekstaatAkkoord</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:exclusiveGateway id="Gateway_WeekstaatAkkoord" name="Akkoord?">
+      <bpmn:incoming>Flow_Gateway_WeekstaatBeoordelingJoin_Gateway_WeekstaatAkkoord</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_WeekstaatAkkoord_Task_AanpassenWeekstaat</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_WeekstaatAkkoord_Task_InvoerenAantallenWeekstaat</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_AanpassenWeekstaat" name="Aanpassen&#10;weekstaat" camunda:formRef="rip-aanpassen-weekstaat" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-opdrachtnemer">
+      <bpmn:incoming>Flow_Gateway_WeekstaatAkkoord_Task_AanpassenWeekstaat</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_AanpassenWeekstaat_Task_VersturenWeekstaat</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_InvoerenAantallenWeekstaat" name="Invoeren aantallen weekstaat in&#10;besteksadministratie (wekelijks)" camunda:formRef="rip-invoeren-aantallen-weekstaat" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-toezichthouder">
+      <bpmn:incoming>Flow_Gateway_WeekstaatAkkoord_Task_InvoerenAantallenWeekstaat</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_InvoerenAantallenWeekstaat_Gateway_WeekAfwJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_MeldenAfwijking" name="Melden afwijking&#10;(ON)" camunda:formRef="rip-melden-afwijking" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-opdrachtnemer" ronl:documentRef="rip-afwijkingenrapport">
+      <bpmn:incoming>Flow_Gateway_WeekAfwSplit_Task_MeldenAfwijking</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_MeldenAfwijking_Task_AfstemmenAfwijking</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_AfstemmenAfwijking" name="Afstemmen afwijking met&#10;adviseur, ontwerper en PL" camunda:formRef="rip-afstemmen-afwijking" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-directievoerder" ronl:documentRef="rip-advies-afwijking">
+      <bpmn:incoming>Flow_Task_MeldenAfwijking_Task_AfstemmenAfwijking</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_AanpassenAfwijkingenrapport_Task_AfstemmenAfwijking</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_AfstemmenAfwijking_Gateway_AfwijkingAkkoord</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_AfwijkingAkkoord" name="Akkoord?">
+      <bpmn:incoming>Flow_Task_AfstemmenAfwijking_Gateway_AfwijkingAkkoord</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_AfwijkingAkkoord_Task_AanpassenAfwijkingenrapport</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_AfwijkingAkkoord_Gateway_WeekAfwJoin</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_AanpassenAfwijkingenrapport" name="Aanpassen&#10;afwijkingenrapport (ON)" camunda:formRef="rip-aanpassen-afwijkingenrapport" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-opdrachtnemer">
+      <bpmn:incoming>Flow_Gateway_AfwijkingAkkoord_Task_AanpassenAfwijkingenrapport</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_AanpassenAfwijkingenrapport_Task_AfstemmenAfwijking</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:parallelGateway id="Gateway_WeekAfwJoin">
+      <bpmn:incoming>Flow_Task_InvoerenAantallenWeekstaat_Gateway_WeekAfwJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Gateway_AfwijkingAkkoord_Gateway_WeekAfwJoin</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_WeekAfwJoin_Task_Directievoering</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:userTask id="Task_Directievoering" name="Directievoering" camunda:formRef="rip-directievoering" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-directievoerder" ronl:documentRef="rip-weekrapport">
+      <bpmn:incoming>Flow_Gateway_WeekAfwJoin_Task_Directievoering</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_Directievoering_Gateway_TermijnenContract</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_TermijnenContract" name="Geaccordeerde termijnen&#10;binnen of buiten contract?">
+      <bpmn:incoming>Flow_Task_Directievoering_Gateway_TermijnenContract</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_TermijnenContract_Task_DoorsturenGeaccordeerdeTermijn</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_TermijnenContract_Task_SturenOverzichtAwr</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_DoorsturenGeaccordeerdeTermijn" name="Doorsturen geaccordeerde&#10;termijn (via VISI)" camunda:formRef="rip-doorsturen-geaccordeerde-termijn" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-directievoerder" ronl:documentRef="rip-geaccordeerde-termijnen">
+      <bpmn:incoming>Flow_Gateway_TermijnenContract_Task_DoorsturenGeaccordeerdeTermijn</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_DoorsturenGeaccordeerdeTermijn_Gateway_AwrJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_SturenOverzichtAwr" name="Sturen&#10;overzicht AWR" camunda:formRef="rip-sturen-overzicht-awr" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-directievoerder" ronl:documentRef="rip-awr-overzicht">
+      <bpmn:incoming>Flow_Gateway_TermijnenContract_Task_SturenOverzichtAwr</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_SturenOverzichtAwr_Task_BeoordelenOverzichtAwr</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_BeoordelenOverzichtAwr" name="Beoordelen&#10;overzicht AWR" camunda:formRef="rip-beoordelen-overzicht-awr" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-kosten-contractdeskundige">
+      <bpmn:incoming>Flow_Task_SturenOverzichtAwr_Task_BeoordelenOverzichtAwr</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_SturenAangepastOverzichtAwr_Task_BeoordelenOverzichtAwr</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_BeoordelenOverzichtAwr_Gateway_AwrAkkoord</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_AwrAkkoord" name="Akkoord?">
+      <bpmn:incoming>Flow_Task_BeoordelenOverzichtAwr_Gateway_AwrAkkoord</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_AwrAkkoord_Task_RetourSturenOverzichtAwr</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_AwrAkkoord_Task_VersturenOverzichtAwrKc</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_RetourSturenOverzichtAwr" name="Retour sturen&#10;overzicht AWR" camunda:formRef="rip-retour-sturen-overzicht-awr" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-kosten-contractdeskundige">
+      <bpmn:incoming>Flow_Gateway_AwrAkkoord_Task_RetourSturenOverzichtAwr</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_RetourSturenOverzichtAwr_Task_OnderhandelenPrijzen</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_OnderhandelenPrijzen" name="Onderhandelen over&#10;prijzen met aannemer" camunda:formRef="rip-onderhandelen-prijzen" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-directievoerder">
+      <bpmn:incoming>Flow_Task_RetourSturenOverzichtAwr_Task_OnderhandelenPrijzen</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_OnderhandelenPrijzen_Task_SturenAangepastOverzichtAwr</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_SturenAangepastOverzichtAwr" name="Sturen aangepast&#10;overzicht AWR" camunda:formRef="rip-sturen-aangepast-overzicht-awr" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-directievoerder">
+      <bpmn:incoming>Flow_Task_OnderhandelenPrijzen_Task_SturenAangepastOverzichtAwr</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_SturenAangepastOverzichtAwr_Task_BeoordelenOverzichtAwr</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_VersturenOverzichtAwrKc" name="Versturen&#10;overzicht AWR" camunda:formRef="rip-versturen-overzicht-awr-kc" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-kosten-contractdeskundige">
+      <bpmn:incoming>Flow_Gateway_AwrAkkoord_Task_VersturenOverzichtAwrKc</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_VersturenOverzichtAwrKc_Gateway_AwrJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_AwrJoin">
+      <bpmn:incoming>Flow_Task_DoorsturenGeaccordeerdeTermijn_Gateway_AwrJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_VersturenOverzichtAwrKc_Gateway_AwrJoin</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_AwrJoin_Task_VersturenOverzichtAwrDv</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_VersturenOverzichtAwrDv" name="Versturen&#10;overzicht AWR" camunda:formRef="rip-versturen-overzicht-awr-dv" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-directievoerder">
+      <bpmn:incoming>Flow_Gateway_AwrJoin_Task_VersturenOverzichtAwrDv</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_VersturenOverzichtAwrDv_Gateway_WerkGereed</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_WerkGereed" name="Werk&#10;gereed?">
+      <bpmn:incoming>Flow_Task_VersturenOverzichtAwrDv_Gateway_WerkGereed</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_WerkGereed_Gateway_WeekStart</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_WerkGereed_Gateway_UitvoeringJoin</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_SturenFactuurAanOg" name="Sturen factuur&#10;aan OG" camunda:formRef="rip-sturen-factuur-og" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-opdrachtnemer">
+      <bpmn:incoming>Flow_Gateway_UitvoeringSplit_Task_SturenFactuurAanOg</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_SturenFactuurAanOg_Task_AccorderenFactuurDoorsturenAo</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_AccorderenFactuurDoorsturenAo" name="Accorderen factuur en&#10;doorsturen naar AO" camunda:formRef="rip-accorderen-factuur-pl" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
+      <bpmn:incoming>Flow_Task_SturenFactuurAanOg_Task_AccorderenFactuurDoorsturenAo</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_AccorderenFactuurDoorsturenAo_Task_AccorderenFactuur</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_AccorderenFactuur" name="Accorderen&#10;factuur" camunda:formRef="rip-accorderen-factuur-ao" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-ao">
+      <bpmn:incoming>Flow_Task_AccorderenFactuurDoorsturenAo_Task_AccorderenFactuur</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_AccorderenFactuur_Gateway_UitvoeringJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_AanvragenTotOpneming" name="Aanvragen tot&#10;opneming" camunda:formRef="rip-aanvragen-tot-opneming" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-opdrachtnemer">
+      <bpmn:incoming>Flow_Gateway_UitvoeringSplit_Task_AanvragenTotOpneming</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_AanvragenTotOpneming_Task_VerzoekenTotUitstelOpleveren</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_VerzoekenTotUitstelOpleveren" name="Verzoeken tot&#10;(uitstel van) opleveren" camunda:formRef="rip-verzoeken-uitstel-opleveren" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-opdrachtnemer" ronl:documentRef="rip-verzoek-uitstel-oplevering">
+      <bpmn:incoming>Flow_Task_AanvragenTotOpneming_Task_VerzoekenTotUitstelOpleveren</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_VerzoekenTotUitstelOpleveren_Task_BeoordelenVerzoekOpleverenDv</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_BeoordelenVerzoekOpleverenDv" name="Beoordelen verzoek tot&#10;(uitstel van) opleveren" camunda:formRef="rip-beoordelen-verzoek-opleveren-dv" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-directievoerder">
+      <bpmn:incoming>Flow_Task_VerzoekenTotUitstelOpleveren_Task_BeoordelenVerzoekOpleverenDv</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_BeoordelenVerzoekOpleverenDv_Task_SturenAdviesVerzoekOpleveren</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_SturenAdviesVerzoekOpleveren" name="Sturen advies verzoek tot&#10;(uitstel van) opleveren" camunda:formRef="rip-sturen-advies-verzoek-opleveren" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-directievoerder">
+      <bpmn:incoming>Flow_Task_BeoordelenVerzoekOpleverenDv_Task_SturenAdviesVerzoekOpleveren</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_SturenAdviesVerzoekOpleveren_Gateway_VerzoekSplit</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:parallelGateway id="Gateway_VerzoekSplit">
+      <bpmn:incoming>Flow_Task_SturenAdviesVerzoekOpleveren_Gateway_VerzoekSplit</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_VerzoekSplit_Task_SturenVerzoekOpleveringEnBeoordeling</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_VerzoekSplit_Task_BeoordelenVerzoekOpleveringPl</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:userTask id="Task_SturenVerzoekOpleveringEnBeoordeling" name="Sturen verzoek tot (uitstel tot)&#10;oplevering en beoordeling" camunda:formRef="rip-sturen-verzoek-oplevering" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
+      <bpmn:incoming>Flow_Gateway_VerzoekSplit_Task_SturenVerzoekOpleveringEnBeoordeling</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_SturenVerzoekOpleveringEnBeoordeling_Task_BeoordelenVerzoekOpleveringAo</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_BeoordelenVerzoekOpleveringAo" name="Beoordelen verzoek tot&#10;(uitstel tot) oplevering" camunda:formRef="rip-beoordelen-verzoek-oplevering-ao" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-ao">
+      <bpmn:incoming>Flow_Task_SturenVerzoekOpleveringEnBeoordeling_Task_BeoordelenVerzoekOpleveringAo</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_BeoordelenVerzoekOpleveringAo_Task_OpstellenBriefAkkoordAfwijzing</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_OpstellenBriefAkkoordAfwijzing" name="Opstellen brief akkoord / afwijzing&#10;(uitstel tot) oplevering" camunda:formRef="rip-opstellen-brief-oplevering" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-ondersteuner" ronl:documentRef="rip-brief-uitstel-oplevering">
+      <bpmn:incoming>Flow_Task_BeoordelenVerzoekOpleveringAo_Task_OpstellenBriefAkkoordAfwijzing</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_OpstellenBriefAkkoordAfwijzing_Task_IndienenBriefBijBesluitvorming</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_IndienenBriefBijBesluitvorming" name="Indienen brief bij besluitvorming&#10;met cc PL en DV" camunda:formRef="rip-indienen-brief-besluitvorming" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-ao">
+      <bpmn:incoming>Flow_Task_OpstellenBriefAkkoordAfwijzing_Task_IndienenBriefBijBesluitvorming</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_IndienenBriefBijBesluitvorming_Task_PlaatsenBriefInVisi</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_PlaatsenBriefInVisi" name="Plaatsen brief (uitstel tot)&#10;oplevering in VISI" camunda:formRef="rip-plaatsen-brief-visi" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-directievoerder">
+      <bpmn:incoming>Flow_Task_IndienenBriefBijBesluitvorming_Task_PlaatsenBriefInVisi</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_PlaatsenBriefInVisi_Gateway_VerzoekJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_BeoordelenVerzoekOpleveringPl" name="Beoordelen verzoek tot&#10;(uitstel tot) oplevering" camunda:formRef="rip-beoordelen-verzoek-oplevering-pl" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
+      <bpmn:incoming>Flow_Gateway_VerzoekSplit_Task_BeoordelenVerzoekOpleveringPl</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_BeoordelenVerzoekOpleveringPl_Gateway_BinnenBuitenKrediet</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_BinnenBuitenKrediet" name="Binnen of&#10;buiten krediet?">
+      <bpmn:incoming>Flow_Task_BeoordelenVerzoekOpleveringPl_Gateway_BinnenBuitenKrediet</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_BinnenBuitenKrediet_Task_MakenNotaConcerndirecteur</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_BinnenBuitenKrediet_Gateway_Waarde</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_MakenNotaConcerndirecteur" name="Maken nota besluitvorming Concerndirecteur&#10;en laten invullen webformulier ATB" camunda:formRef="rip-maken-nota-concerndirecteur" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-nota-besluitvorming-concerndirecteur-oplevering">
+      <bpmn:incoming>Flow_Gateway_BinnenBuitenKrediet_Task_MakenNotaConcerndirecteur</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_MakenNotaConcerndirecteur_Gateway_NotaJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_Waarde" name="Waarde?">
+      <bpmn:incoming>Flow_Gateway_BinnenBuitenKrediet_Gateway_Waarde</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_Waarde_Task_MakenNotaAo</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_Waarde_Task_LatenInvullenWebformulierAtb</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_MakenNotaAo" name="Maken nota besluitvorming AO&#10;en laten invullen webformulier ATB" camunda:formRef="rip-maken-nota-ao" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-nota-besluitvorming-ao-oplevering">
+      <bpmn:incoming>Flow_Gateway_Waarde_Task_MakenNotaAo</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_MakenNotaAo_Gateway_NotaJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_LatenInvullenWebformulierAtb" name="Laten invullen&#10;webformulier ATB" camunda:formRef="rip-laten-invullen-webformulier-atb" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
+      <bpmn:incoming>Flow_Gateway_Waarde_Task_LatenInvullenWebformulierAtb</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_LatenInvullenWebformulierAtb_Gateway_NotaJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_NotaJoin">
+      <bpmn:incoming>Flow_Task_MakenNotaConcerndirecteur_Gateway_NotaJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_MakenNotaAo_Gateway_NotaJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_LatenInvullenWebformulierAtb_Gateway_NotaJoin</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_NotaJoin_Task_InvullenWebformulierAtb</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_InvullenWebformulierAtb" name="Invullen&#10;webformulier ATB" camunda:formRef="rip-invullen-webformulier-atb" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-ondersteuner" ronl:documentRef="rip-nota-besluitvorming-atb">
+      <bpmn:incoming>Flow_Gateway_NotaJoin_Task_InvullenWebformulierAtb</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_InvullenWebformulierAtb_Gateway_VerzoekJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:parallelGateway id="Gateway_VerzoekJoin">
+      <bpmn:incoming>Flow_Task_PlaatsenBriefInVisi_Gateway_VerzoekJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_InvullenWebformulierAtb_Gateway_VerzoekJoin</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_VerzoekJoin_Gateway_UitvoeringJoin</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:parallelGateway id="Gateway_UitvoeringJoin">
+      <bpmn:incoming>Flow_Gateway_WerkGereed_Gateway_UitvoeringJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_AccorderenFactuur_Gateway_UitvoeringJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Gateway_VerzoekJoin_Gateway_UitvoeringJoin</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_UitvoeringJoin_EndEvent_R53</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:endEvent id="EndEvent_R53" name="Werk gereed&#10;→ R5.3 Organiseren interne schouw">
+      <bpmn:incoming>Flow_Gateway_UitvoeringJoin_EndEvent_R53</bpmn:incoming>
+    </bpmn:endEvent>
+
+    <bpmn:sequenceFlow id="Flow_StartEvent_R52_Gateway_UitvoeringSplit" sourceRef="StartEvent_R52" targetRef="Gateway_UitvoeringSplit" />
+    <bpmn:sequenceFlow id="Flow_Gateway_UitvoeringSplit_Gateway_WeekStart" sourceRef="Gateway_UitvoeringSplit" targetRef="Gateway_WeekStart" />
+    <bpmn:sequenceFlow id="Flow_Gateway_UitvoeringSplit_Task_SturenFactuurAanOg" sourceRef="Gateway_UitvoeringSplit" targetRef="Task_SturenFactuurAanOg" />
+    <bpmn:sequenceFlow id="Flow_Gateway_UitvoeringSplit_Task_AanvragenTotOpneming" sourceRef="Gateway_UitvoeringSplit" targetRef="Task_AanvragenTotOpneming" />
+    <bpmn:sequenceFlow id="Flow_Gateway_WeekStart_Gateway_WeekAfwSplit" sourceRef="Gateway_WeekStart" targetRef="Gateway_WeekAfwSplit" />
+    <bpmn:sequenceFlow id="Flow_Gateway_WeekAfwSplit_Task_UitvoerenWerkzaamhedenToezichtsplan" sourceRef="Gateway_WeekAfwSplit" targetRef="Task_UitvoerenWerkzaamhedenToezichtsplan" />
+    <bpmn:sequenceFlow id="Flow_Gateway_WeekAfwSplit_Task_MeldenAfwijking" sourceRef="Gateway_WeekAfwSplit" targetRef="Task_MeldenAfwijking" />
+    <bpmn:sequenceFlow id="Flow_Task_UitvoerenWerkzaamhedenToezichtsplan_Task_OpstellenWeekstaat" sourceRef="Task_UitvoerenWerkzaamhedenToezichtsplan" targetRef="Task_OpstellenWeekstaat" />
+    <bpmn:sequenceFlow id="Flow_Task_OpstellenWeekstaat_Task_VersturenWeekstaat" sourceRef="Task_OpstellenWeekstaat" targetRef="Task_VersturenWeekstaat" />
+    <bpmn:sequenceFlow id="Flow_Task_VersturenWeekstaat_Gateway_WeekstaatBeoordelingSplit" sourceRef="Task_VersturenWeekstaat" targetRef="Gateway_WeekstaatBeoordelingSplit" />
+    <bpmn:sequenceFlow id="Flow_Gateway_WeekstaatBeoordelingSplit_Task_BeoordelenEnSturenBeoordelingWeekstaat" sourceRef="Gateway_WeekstaatBeoordelingSplit" targetRef="Task_BeoordelenEnSturenBeoordelingWeekstaat" />
+    <bpmn:sequenceFlow id="Flow_Gateway_WeekstaatBeoordelingSplit_Task_BeoordelenWeekstaat" sourceRef="Gateway_WeekstaatBeoordelingSplit" targetRef="Task_BeoordelenWeekstaat" />
+    <bpmn:sequenceFlow id="Flow_Task_BeoordelenEnSturenBeoordelingWeekstaat_Gateway_WeekstaatBeoordelingJoin" sourceRef="Task_BeoordelenEnSturenBeoordelingWeekstaat" targetRef="Gateway_WeekstaatBeoordelingJoin" />
+    <bpmn:sequenceFlow id="Flow_Task_BeoordelenWeekstaat_Gateway_WeekstaatBeoordelingJoin" sourceRef="Task_BeoordelenWeekstaat" targetRef="Gateway_WeekstaatBeoordelingJoin" />
+    <bpmn:sequenceFlow id="Flow_Gateway_WeekstaatBeoordelingJoin_Gateway_WeekstaatAkkoord" sourceRef="Gateway_WeekstaatBeoordelingJoin" targetRef="Gateway_WeekstaatAkkoord" />
+    <bpmn:sequenceFlow id="Flow_Gateway_WeekstaatAkkoord_Task_AanpassenWeekstaat" name="nee" sourceRef="Gateway_WeekstaatAkkoord" targetRef="Task_AanpassenWeekstaat">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${weekstaatAkkoord == "nee"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_WeekstaatAkkoord_Task_InvoerenAantallenWeekstaat" name="ja" sourceRef="Gateway_WeekstaatAkkoord" targetRef="Task_InvoerenAantallenWeekstaat">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${weekstaatAkkoord == "ja"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Task_AanpassenWeekstaat_Task_VersturenWeekstaat" sourceRef="Task_AanpassenWeekstaat" targetRef="Task_VersturenWeekstaat" />
+    <bpmn:sequenceFlow id="Flow_Task_InvoerenAantallenWeekstaat_Gateway_WeekAfwJoin" sourceRef="Task_InvoerenAantallenWeekstaat" targetRef="Gateway_WeekAfwJoin" />
+    <bpmn:sequenceFlow id="Flow_Task_MeldenAfwijking_Task_AfstemmenAfwijking" sourceRef="Task_MeldenAfwijking" targetRef="Task_AfstemmenAfwijking" />
+    <bpmn:sequenceFlow id="Flow_Task_AfstemmenAfwijking_Gateway_AfwijkingAkkoord" sourceRef="Task_AfstemmenAfwijking" targetRef="Gateway_AfwijkingAkkoord" />
+    <bpmn:sequenceFlow id="Flow_Gateway_AfwijkingAkkoord_Task_AanpassenAfwijkingenrapport" name="nee" sourceRef="Gateway_AfwijkingAkkoord" targetRef="Task_AanpassenAfwijkingenrapport">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${afwijkingAkkoord == "nee"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_AfwijkingAkkoord_Gateway_WeekAfwJoin" name="ja" sourceRef="Gateway_AfwijkingAkkoord" targetRef="Gateway_WeekAfwJoin">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${afwijkingAkkoord == "ja"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Task_AanpassenAfwijkingenrapport_Task_AfstemmenAfwijking" sourceRef="Task_AanpassenAfwijkingenrapport" targetRef="Task_AfstemmenAfwijking" />
+    <bpmn:sequenceFlow id="Flow_Gateway_WeekAfwJoin_Task_Directievoering" sourceRef="Gateway_WeekAfwJoin" targetRef="Task_Directievoering" />
+    <bpmn:sequenceFlow id="Flow_Task_Directievoering_Gateway_TermijnenContract" sourceRef="Task_Directievoering" targetRef="Gateway_TermijnenContract" />
+    <bpmn:sequenceFlow id="Flow_Gateway_TermijnenContract_Task_DoorsturenGeaccordeerdeTermijn" name="binnen contract" sourceRef="Gateway_TermijnenContract" targetRef="Task_DoorsturenGeaccordeerdeTermijn">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${termijnenContract == "binnen"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_TermijnenContract_Task_SturenOverzichtAwr" name="buiten contract" sourceRef="Gateway_TermijnenContract" targetRef="Task_SturenOverzichtAwr">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${termijnenContract == "buiten"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Task_DoorsturenGeaccordeerdeTermijn_Gateway_AwrJoin" sourceRef="Task_DoorsturenGeaccordeerdeTermijn" targetRef="Gateway_AwrJoin" />
+    <bpmn:sequenceFlow id="Flow_Task_SturenOverzichtAwr_Task_BeoordelenOverzichtAwr" sourceRef="Task_SturenOverzichtAwr" targetRef="Task_BeoordelenOverzichtAwr" />
+    <bpmn:sequenceFlow id="Flow_Task_BeoordelenOverzichtAwr_Gateway_AwrAkkoord" sourceRef="Task_BeoordelenOverzichtAwr" targetRef="Gateway_AwrAkkoord" />
+    <bpmn:sequenceFlow id="Flow_Gateway_AwrAkkoord_Task_RetourSturenOverzichtAwr" name="nee" sourceRef="Gateway_AwrAkkoord" targetRef="Task_RetourSturenOverzichtAwr">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${awrAkkoord == "nee"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_AwrAkkoord_Task_VersturenOverzichtAwrKc" name="ja" sourceRef="Gateway_AwrAkkoord" targetRef="Task_VersturenOverzichtAwrKc">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${awrAkkoord == "ja"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Task_RetourSturenOverzichtAwr_Task_OnderhandelenPrijzen" sourceRef="Task_RetourSturenOverzichtAwr" targetRef="Task_OnderhandelenPrijzen" />
+    <bpmn:sequenceFlow id="Flow_Task_OnderhandelenPrijzen_Task_SturenAangepastOverzichtAwr" sourceRef="Task_OnderhandelenPrijzen" targetRef="Task_SturenAangepastOverzichtAwr" />
+    <bpmn:sequenceFlow id="Flow_Task_SturenAangepastOverzichtAwr_Task_BeoordelenOverzichtAwr" sourceRef="Task_SturenAangepastOverzichtAwr" targetRef="Task_BeoordelenOverzichtAwr" />
+    <bpmn:sequenceFlow id="Flow_Task_VersturenOverzichtAwrKc_Gateway_AwrJoin" sourceRef="Task_VersturenOverzichtAwrKc" targetRef="Gateway_AwrJoin" />
+    <bpmn:sequenceFlow id="Flow_Gateway_AwrJoin_Task_VersturenOverzichtAwrDv" sourceRef="Gateway_AwrJoin" targetRef="Task_VersturenOverzichtAwrDv" />
+    <bpmn:sequenceFlow id="Flow_Task_VersturenOverzichtAwrDv_Gateway_WerkGereed" sourceRef="Task_VersturenOverzichtAwrDv" targetRef="Gateway_WerkGereed" />
+    <bpmn:sequenceFlow id="Flow_Gateway_WerkGereed_Gateway_WeekStart" name="nee" sourceRef="Gateway_WerkGereed" targetRef="Gateway_WeekStart">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${werkGereed == "nee"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_WerkGereed_Gateway_UitvoeringJoin" name="ja" sourceRef="Gateway_WerkGereed" targetRef="Gateway_UitvoeringJoin">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${werkGereed == "ja"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Task_SturenFactuurAanOg_Task_AccorderenFactuurDoorsturenAo" sourceRef="Task_SturenFactuurAanOg" targetRef="Task_AccorderenFactuurDoorsturenAo" />
+    <bpmn:sequenceFlow id="Flow_Task_AccorderenFactuurDoorsturenAo_Task_AccorderenFactuur" sourceRef="Task_AccorderenFactuurDoorsturenAo" targetRef="Task_AccorderenFactuur" />
+    <bpmn:sequenceFlow id="Flow_Task_AccorderenFactuur_Gateway_UitvoeringJoin" sourceRef="Task_AccorderenFactuur" targetRef="Gateway_UitvoeringJoin" />
+    <bpmn:sequenceFlow id="Flow_Task_AanvragenTotOpneming_Task_VerzoekenTotUitstelOpleveren" sourceRef="Task_AanvragenTotOpneming" targetRef="Task_VerzoekenTotUitstelOpleveren" />
+    <bpmn:sequenceFlow id="Flow_Task_VerzoekenTotUitstelOpleveren_Task_BeoordelenVerzoekOpleverenDv" sourceRef="Task_VerzoekenTotUitstelOpleveren" targetRef="Task_BeoordelenVerzoekOpleverenDv" />
+    <bpmn:sequenceFlow id="Flow_Task_BeoordelenVerzoekOpleverenDv_Task_SturenAdviesVerzoekOpleveren" sourceRef="Task_BeoordelenVerzoekOpleverenDv" targetRef="Task_SturenAdviesVerzoekOpleveren" />
+    <bpmn:sequenceFlow id="Flow_Task_SturenAdviesVerzoekOpleveren_Gateway_VerzoekSplit" sourceRef="Task_SturenAdviesVerzoekOpleveren" targetRef="Gateway_VerzoekSplit" />
+    <bpmn:sequenceFlow id="Flow_Gateway_VerzoekSplit_Task_SturenVerzoekOpleveringEnBeoordeling" sourceRef="Gateway_VerzoekSplit" targetRef="Task_SturenVerzoekOpleveringEnBeoordeling" />
+    <bpmn:sequenceFlow id="Flow_Gateway_VerzoekSplit_Task_BeoordelenVerzoekOpleveringPl" sourceRef="Gateway_VerzoekSplit" targetRef="Task_BeoordelenVerzoekOpleveringPl" />
+    <bpmn:sequenceFlow id="Flow_Task_SturenVerzoekOpleveringEnBeoordeling_Task_BeoordelenVerzoekOpleveringAo" sourceRef="Task_SturenVerzoekOpleveringEnBeoordeling" targetRef="Task_BeoordelenVerzoekOpleveringAo" />
+    <bpmn:sequenceFlow id="Flow_Task_BeoordelenVerzoekOpleveringAo_Task_OpstellenBriefAkkoordAfwijzing" sourceRef="Task_BeoordelenVerzoekOpleveringAo" targetRef="Task_OpstellenBriefAkkoordAfwijzing" />
+    <bpmn:sequenceFlow id="Flow_Task_OpstellenBriefAkkoordAfwijzing_Task_IndienenBriefBijBesluitvorming" sourceRef="Task_OpstellenBriefAkkoordAfwijzing" targetRef="Task_IndienenBriefBijBesluitvorming" />
+    <bpmn:sequenceFlow id="Flow_Task_IndienenBriefBijBesluitvorming_Task_PlaatsenBriefInVisi" sourceRef="Task_IndienenBriefBijBesluitvorming" targetRef="Task_PlaatsenBriefInVisi" />
+    <bpmn:sequenceFlow id="Flow_Task_PlaatsenBriefInVisi_Gateway_VerzoekJoin" sourceRef="Task_PlaatsenBriefInVisi" targetRef="Gateway_VerzoekJoin" />
+    <bpmn:sequenceFlow id="Flow_Task_BeoordelenVerzoekOpleveringPl_Gateway_BinnenBuitenKrediet" sourceRef="Task_BeoordelenVerzoekOpleveringPl" targetRef="Gateway_BinnenBuitenKrediet" />
+    <bpmn:sequenceFlow id="Flow_Gateway_BinnenBuitenKrediet_Task_MakenNotaConcerndirecteur" name="buiten" sourceRef="Gateway_BinnenBuitenKrediet" targetRef="Task_MakenNotaConcerndirecteur">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${kredietPositie == "buiten"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_BinnenBuitenKrediet_Gateway_Waarde" name="binnen" sourceRef="Gateway_BinnenBuitenKrediet" targetRef="Gateway_Waarde">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${kredietPositie == "binnen"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_Waarde_Task_MakenNotaAo" name="&gt; 50.000,-" sourceRef="Gateway_Waarde" targetRef="Task_MakenNotaAo">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${notaWaarde == "boven"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_Waarde_Task_LatenInvullenWebformulierAtb" name="&lt; 50.000,-" sourceRef="Gateway_Waarde" targetRef="Task_LatenInvullenWebformulierAtb">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${notaWaarde == "onder"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Task_MakenNotaConcerndirecteur_Gateway_NotaJoin" sourceRef="Task_MakenNotaConcerndirecteur" targetRef="Gateway_NotaJoin" />
+    <bpmn:sequenceFlow id="Flow_Task_MakenNotaAo_Gateway_NotaJoin" sourceRef="Task_MakenNotaAo" targetRef="Gateway_NotaJoin" />
+    <bpmn:sequenceFlow id="Flow_Task_LatenInvullenWebformulierAtb_Gateway_NotaJoin" sourceRef="Task_LatenInvullenWebformulierAtb" targetRef="Gateway_NotaJoin" />
+    <bpmn:sequenceFlow id="Flow_Gateway_NotaJoin_Task_InvullenWebformulierAtb" sourceRef="Gateway_NotaJoin" targetRef="Task_InvullenWebformulierAtb" />
+    <bpmn:sequenceFlow id="Flow_Task_InvullenWebformulierAtb_Gateway_VerzoekJoin" sourceRef="Task_InvullenWebformulierAtb" targetRef="Gateway_VerzoekJoin" />
+    <bpmn:sequenceFlow id="Flow_Gateway_VerzoekJoin_Gateway_UitvoeringJoin" sourceRef="Gateway_VerzoekJoin" targetRef="Gateway_UitvoeringJoin" />
+    <bpmn:sequenceFlow id="Flow_Gateway_UitvoeringJoin_EndEvent_R53" sourceRef="Gateway_UitvoeringJoin" targetRef="EndEvent_R53" />
+
+    <bpmn:textAnnotation id="Annotation_R51_Entry">
+      <bpmn:text>R5.1 Houden overleg met V&amp;G-coördinator (ON) — en R5.3 Restpunten oplossen door ON, wanneer de schouw restpunten oplevert</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Assoc_Annotation_R51_Entry" sourceRef="Task_UitvoerenWerkzaamhedenToezichtsplan" targetRef="Annotation_R51_Entry" />
+    <bpmn:textAnnotation id="Annotation_KV2_Nota">
+      <bpmn:text>KV2. Input nota — de nota's besluitvorming gaan als input naar het proces besluitvorming</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Assoc_Annotation_KV2_Nota" sourceRef="Gateway_NotaJoin" targetRef="Annotation_KV2_Nota" />
+    <bpmn:textAnnotation id="Annotation_ATB">
+      <bpmn:text>Proces ATB — het webformulier ATB wordt buiten R5.2 afgehandeld</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Assoc_Annotation_ATB" sourceRef="Task_InvullenWebformulierAtb" targetRef="Annotation_ATB" />
+    <bpmn:textAnnotation id="Annotation_KV2_Documenten">
+      <bpmn:text>KV2. Versturen documenten</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Assoc_Annotation_KV2_Documenten" sourceRef="Task_IndienenBriefBijBesluitvorming" targetRef="Annotation_KV2_Documenten" />
+  </bpmn:process>
+
+  <bpmndi:BPMNDiagram id="BPMNDiagram_RipR52Process">
+    <bpmndi:BPMNPlane id="BPMNPlane_RipR52Process" bpmnElement="Collaboration_RipR52Process">
+      <bpmndi:BPMNShape id="Participant_RipR52Process_di" bpmnElement="Participant_RipR52Process" isHorizontal="true">
+        <dc:Bounds x="160" y="80" width="3146" height="2480" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Ondersteuner_di" bpmnElement="Lane_Ondersteuner" isHorizontal="true">
+        <dc:Bounds x="190" y="80" width="3116" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_AO_di" bpmnElement="Lane_AO" isHorizontal="true">
+        <dc:Bounds x="190" y="280" width="3116" height="290" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Projectleider_di" bpmnElement="Lane_Projectleider" isHorizontal="true">
+        <dc:Bounds x="190" y="570" width="3116" height="380" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Aannemer_di" bpmnElement="Lane_Aannemer" isHorizontal="true">
+        <dc:Bounds x="190" y="950" width="3116" height="470" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Toezichthouder_di" bpmnElement="Lane_Toezichthouder" isHorizontal="true">
+        <dc:Bounds x="190" y="1420" width="3116" height="290" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Directievoerder_di" bpmnElement="Lane_Directievoerder" isHorizontal="true">
+        <dc:Bounds x="190" y="1710" width="3116" height="560" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_KostenContractdeskundige_di" bpmnElement="Lane_KostenContractdeskundige" isHorizontal="true">
+        <dc:Bounds x="190" y="2270" width="3116" height="290" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_R52_di" bpmnElement="StartEvent_R52">
+        <dc:Bounds x="240" y="992" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="182" y="1033" width="152" height="28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_UitvoeringSplit_di" bpmnElement="Gateway_UitvoeringSplit">
+        <dc:Bounds x="300" y="985" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_WeekStart_di" bpmnElement="Gateway_WeekStart" isMarkerVisible="true">
+        <dc:Bounds x="380" y="985" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="353" y="1040" width="104" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_WeekAfwSplit_di" bpmnElement="Gateway_WeekAfwSplit">
+        <dc:Bounds x="460" y="985" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_UitvoerenWerkzaamhedenToezichtsplan_di" bpmnElement="Task_UitvoerenWerkzaamhedenToezichtsplan">
+        <dc:Bounds x="540" y="1440" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_OpstellenWeekstaat_di" bpmnElement="Task_OpstellenWeekstaat">
+        <dc:Bounds x="700" y="970" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_VersturenWeekstaat_di" bpmnElement="Task_VersturenWeekstaat">
+        <dc:Bounds x="860" y="970" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_WeekstaatBeoordelingSplit_di" bpmnElement="Gateway_WeekstaatBeoordelingSplit">
+        <dc:Bounds x="1020" y="985" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_BeoordelenEnSturenBeoordelingWeekstaat_di" bpmnElement="Task_BeoordelenEnSturenBeoordelingWeekstaat">
+        <dc:Bounds x="1100" y="1530" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_BeoordelenWeekstaat_di" bpmnElement="Task_BeoordelenWeekstaat">
+        <dc:Bounds x="1100" y="1730" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_WeekstaatBeoordelingJoin_di" bpmnElement="Gateway_WeekstaatBeoordelingJoin">
+        <dc:Bounds x="1260" y="985" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_WeekstaatAkkoord_di" bpmnElement="Gateway_WeekstaatAkkoord" isMarkerVisible="true">
+        <dc:Bounds x="1340" y="985" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1320" y="1040" width="90" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_AanpassenWeekstaat_di" bpmnElement="Task_AanpassenWeekstaat">
+        <dc:Bounds x="1420" y="1060" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_InvoerenAantallenWeekstaat_di" bpmnElement="Task_InvoerenAantallenWeekstaat">
+        <dc:Bounds x="1420" y="1620" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_MeldenAfwijking_di" bpmnElement="Task_MeldenAfwijking">
+        <dc:Bounds x="540" y="1150" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_AfstemmenAfwijking_di" bpmnElement="Task_AfstemmenAfwijking">
+        <dc:Bounds x="700" y="1820" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_AfwijkingAkkoord_di" bpmnElement="Gateway_AfwijkingAkkoord" isMarkerVisible="true">
+        <dc:Bounds x="860" y="1835" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="840" y="1890" width="90" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_AanpassenAfwijkingenrapport_di" bpmnElement="Task_AanpassenAfwijkingenrapport">
+        <dc:Bounds x="940" y="1150" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_WeekAfwJoin_di" bpmnElement="Gateway_WeekAfwJoin">
+        <dc:Bounds x="1600" y="985" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_Directievoering_di" bpmnElement="Task_Directievoering">
+        <dc:Bounds x="1680" y="1910" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_TermijnenContract_di" bpmnElement="Gateway_TermijnenContract" isMarkerVisible="true">
+        <dc:Bounds x="1840" y="1925" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1761" y="1980" width="208" height="28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_DoorsturenGeaccordeerdeTermijn_di" bpmnElement="Task_DoorsturenGeaccordeerdeTermijn">
+        <dc:Bounds x="1920" y="1820" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_SturenOverzichtAwr_di" bpmnElement="Task_SturenOverzichtAwr">
+        <dc:Bounds x="1920" y="2000" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_BeoordelenOverzichtAwr_di" bpmnElement="Task_BeoordelenOverzichtAwr">
+        <dc:Bounds x="2080" y="2290" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_AwrAkkoord_di" bpmnElement="Gateway_AwrAkkoord" isMarkerVisible="true">
+        <dc:Bounds x="2240" y="2305" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2220" y="2360" width="90" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_RetourSturenOverzichtAwr_di" bpmnElement="Task_RetourSturenOverzichtAwr">
+        <dc:Bounds x="2320" y="2380" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_OnderhandelenPrijzen_di" bpmnElement="Task_OnderhandelenPrijzen">
+        <dc:Bounds x="2480" y="2090" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_SturenAangepastOverzichtAwr_di" bpmnElement="Task_SturenAangepastOverzichtAwr">
+        <dc:Bounds x="2640" y="2180" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_VersturenOverzichtAwrKc_di" bpmnElement="Task_VersturenOverzichtAwrKc">
+        <dc:Bounds x="2320" y="2470" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_AwrJoin_di" bpmnElement="Gateway_AwrJoin" isMarkerVisible="true">
+        <dc:Bounds x="2800" y="1925" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_VersturenOverzichtAwrDv_di" bpmnElement="Task_VersturenOverzichtAwrDv">
+        <dc:Bounds x="2880" y="1910" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_WerkGereed_di" bpmnElement="Gateway_WerkGereed" isMarkerVisible="true">
+        <dc:Bounds x="3040" y="1925" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3020" y="1980" width="90" height="28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_SturenFactuurAanOg_di" bpmnElement="Task_SturenFactuurAanOg">
+        <dc:Bounds x="540" y="1240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_AccorderenFactuurDoorsturenAo_di" bpmnElement="Task_AccorderenFactuurDoorsturenAo">
+        <dc:Bounds x="700" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_AccorderenFactuur_di" bpmnElement="Task_AccorderenFactuur">
+        <dc:Bounds x="860" y="300" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_AanvragenTotOpneming_di" bpmnElement="Task_AanvragenTotOpneming">
+        <dc:Bounds x="540" y="1330" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_VerzoekenTotUitstelOpleveren_di" bpmnElement="Task_VerzoekenTotUitstelOpleveren">
+        <dc:Bounds x="700" y="1330" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_BeoordelenVerzoekOpleverenDv_di" bpmnElement="Task_BeoordelenVerzoekOpleverenDv">
+        <dc:Bounds x="860" y="2090" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_SturenAdviesVerzoekOpleveren_di" bpmnElement="Task_SturenAdviesVerzoekOpleveren">
+        <dc:Bounds x="1020" y="2090" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_VerzoekSplit_di" bpmnElement="Gateway_VerzoekSplit">
+        <dc:Bounds x="1180" y="695" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_SturenVerzoekOpleveringEnBeoordeling_di" bpmnElement="Task_SturenVerzoekOpleveringEnBeoordeling">
+        <dc:Bounds x="1260" y="680" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_BeoordelenVerzoekOpleveringAo_di" bpmnElement="Task_BeoordelenVerzoekOpleveringAo">
+        <dc:Bounds x="1420" y="390" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_OpstellenBriefAkkoordAfwijzing_di" bpmnElement="Task_OpstellenBriefAkkoordAfwijzing">
+        <dc:Bounds x="1580" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_IndienenBriefBijBesluitvorming_di" bpmnElement="Task_IndienenBriefBijBesluitvorming">
+        <dc:Bounds x="1740" y="480" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_PlaatsenBriefInVisi_di" bpmnElement="Task_PlaatsenBriefInVisi">
+        <dc:Bounds x="1900" y="2180" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_BeoordelenVerzoekOpleveringPl_di" bpmnElement="Task_BeoordelenVerzoekOpleveringPl">
+        <dc:Bounds x="1260" y="770" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_BinnenBuitenKrediet_di" bpmnElement="Gateway_BinnenBuitenKrediet" isMarkerVisible="true">
+        <dc:Bounds x="1420" y="785" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1385" y="840" width="120" height="28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_MakenNotaConcerndirecteur_di" bpmnElement="Task_MakenNotaConcerndirecteur">
+        <dc:Bounds x="1500" y="860" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_Waarde_di" bpmnElement="Gateway_Waarde" isMarkerVisible="true">
+        <dc:Bounds x="1500" y="695" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1480" y="750" width="90" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_MakenNotaAo_di" bpmnElement="Task_MakenNotaAo">
+        <dc:Bounds x="1580" y="590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_LatenInvullenWebformulierAtb_di" bpmnElement="Task_LatenInvullenWebformulierAtb">
+        <dc:Bounds x="1580" y="680" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_NotaJoin_di" bpmnElement="Gateway_NotaJoin" isMarkerVisible="true">
+        <dc:Bounds x="1740" y="785" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_InvullenWebformulierAtb_di" bpmnElement="Task_InvullenWebformulierAtb">
+        <dc:Bounds x="1820" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_VerzoekJoin_di" bpmnElement="Gateway_VerzoekJoin">
+        <dc:Bounds x="2060" y="695" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_UitvoeringJoin_di" bpmnElement="Gateway_UitvoeringJoin">
+        <dc:Bounds x="3120" y="985" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_R53_di" bpmnElement="EndEvent_R53">
+        <dc:Bounds x="3200" y="992" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3086" y="1033" width="264" height="28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Annotation_R51_Entry_di" bpmnElement="Annotation_R51_Entry">
+        <dc:Bounds x="240" y="1440" width="280" height="60" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Annotation_KV2_Nota_di" bpmnElement="Annotation_KV2_Nota">
+        <dc:Bounds x="1900" y="770" width="280" height="60" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Annotation_ATB_di" bpmnElement="Annotation_ATB">
+        <dc:Bounds x="2000" y="100" width="280" height="45" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Annotation_KV2_Documenten_di" bpmnElement="Annotation_KV2_Documenten">
+        <dc:Bounds x="1900" y="480" width="240" height="45" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_StartEvent_R52_Gateway_UitvoeringSplit_di" bpmnElement="Flow_StartEvent_R52_Gateway_UitvoeringSplit">
+        <di:waypoint x="276" y="1010" />
+        <di:waypoint x="300" y="1010" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_UitvoeringSplit_Gateway_WeekStart_di" bpmnElement="Flow_Gateway_UitvoeringSplit_Gateway_WeekStart">
+        <di:waypoint x="350" y="1010" />
+        <di:waypoint x="380" y="1010" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_UitvoeringSplit_Task_SturenFactuurAanOg_di" bpmnElement="Flow_Gateway_UitvoeringSplit_Task_SturenFactuurAanOg">
+        <di:waypoint x="350" y="1010" />
+        <di:waypoint x="445" y="1010" />
+        <di:waypoint x="445" y="1280" />
+        <di:waypoint x="540" y="1280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_UitvoeringSplit_Task_AanvragenTotOpneming_di" bpmnElement="Flow_Gateway_UitvoeringSplit_Task_AanvragenTotOpneming">
+        <di:waypoint x="350" y="1010" />
+        <di:waypoint x="445" y="1010" />
+        <di:waypoint x="445" y="1370" />
+        <di:waypoint x="540" y="1370" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_WeekStart_Gateway_WeekAfwSplit_di" bpmnElement="Flow_Gateway_WeekStart_Gateway_WeekAfwSplit">
+        <di:waypoint x="430" y="1010" />
+        <di:waypoint x="460" y="1010" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_WeekAfwSplit_Task_UitvoerenWerkzaamhedenToezichtsplan_di" bpmnElement="Flow_Gateway_WeekAfwSplit_Task_UitvoerenWerkzaamhedenToezichtsplan">
+        <di:waypoint x="510" y="1010" />
+        <di:waypoint x="525" y="1010" />
+        <di:waypoint x="525" y="1480" />
+        <di:waypoint x="540" y="1480" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_WeekAfwSplit_Task_MeldenAfwijking_di" bpmnElement="Flow_Gateway_WeekAfwSplit_Task_MeldenAfwijking">
+        <di:waypoint x="510" y="1010" />
+        <di:waypoint x="525" y="1010" />
+        <di:waypoint x="525" y="1190" />
+        <di:waypoint x="540" y="1190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_UitvoerenWerkzaamhedenToezichtsplan_Task_OpstellenWeekstaat_di" bpmnElement="Flow_Task_UitvoerenWerkzaamhedenToezichtsplan_Task_OpstellenWeekstaat">
+        <di:waypoint x="640" y="1480" />
+        <di:waypoint x="670" y="1480" />
+        <di:waypoint x="670" y="1010" />
+        <di:waypoint x="700" y="1010" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_OpstellenWeekstaat_Task_VersturenWeekstaat_di" bpmnElement="Flow_Task_OpstellenWeekstaat_Task_VersturenWeekstaat">
+        <di:waypoint x="800" y="1010" />
+        <di:waypoint x="860" y="1010" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_VersturenWeekstaat_Gateway_WeekstaatBeoordelingSplit_di" bpmnElement="Flow_Task_VersturenWeekstaat_Gateway_WeekstaatBeoordelingSplit">
+        <di:waypoint x="960" y="1010" />
+        <di:waypoint x="1020" y="1010" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_WeekstaatBeoordelingSplit_Task_BeoordelenEnSturenBeoordelingWeekstaat_di" bpmnElement="Flow_Gateway_WeekstaatBeoordelingSplit_Task_BeoordelenEnSturenBeoordelingWeekstaat">
+        <di:waypoint x="1070" y="1010" />
+        <di:waypoint x="1085" y="1010" />
+        <di:waypoint x="1085" y="1570" />
+        <di:waypoint x="1100" y="1570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_WeekstaatBeoordelingSplit_Task_BeoordelenWeekstaat_di" bpmnElement="Flow_Gateway_WeekstaatBeoordelingSplit_Task_BeoordelenWeekstaat">
+        <di:waypoint x="1070" y="1010" />
+        <di:waypoint x="1085" y="1010" />
+        <di:waypoint x="1085" y="1770" />
+        <di:waypoint x="1100" y="1770" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_BeoordelenEnSturenBeoordelingWeekstaat_Gateway_WeekstaatBeoordelingJoin_di" bpmnElement="Flow_Task_BeoordelenEnSturenBeoordelingWeekstaat_Gateway_WeekstaatBeoordelingJoin">
+        <di:waypoint x="1200" y="1570" />
+        <di:waypoint x="1230" y="1570" />
+        <di:waypoint x="1230" y="1010" />
+        <di:waypoint x="1260" y="1010" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_BeoordelenWeekstaat_Gateway_WeekstaatBeoordelingJoin_di" bpmnElement="Flow_Task_BeoordelenWeekstaat_Gateway_WeekstaatBeoordelingJoin">
+        <di:waypoint x="1200" y="1770" />
+        <di:waypoint x="1230" y="1770" />
+        <di:waypoint x="1230" y="1010" />
+        <di:waypoint x="1260" y="1010" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_WeekstaatBeoordelingJoin_Gateway_WeekstaatAkkoord_di" bpmnElement="Flow_Gateway_WeekstaatBeoordelingJoin_Gateway_WeekstaatAkkoord">
+        <di:waypoint x="1310" y="1010" />
+        <di:waypoint x="1340" y="1010" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_WeekstaatAkkoord_Task_AanpassenWeekstaat_di" bpmnElement="Flow_Gateway_WeekstaatAkkoord_Task_AanpassenWeekstaat">
+        <di:waypoint x="1390" y="1010" />
+        <di:waypoint x="1405" y="1010" />
+        <di:waypoint x="1405" y="1100" />
+        <di:waypoint x="1420" y="1100" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1396" y="990" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_WeekstaatAkkoord_Task_InvoerenAantallenWeekstaat_di" bpmnElement="Flow_Gateway_WeekstaatAkkoord_Task_InvoerenAantallenWeekstaat">
+        <di:waypoint x="1390" y="1010" />
+        <di:waypoint x="1405" y="1010" />
+        <di:waypoint x="1405" y="1660" />
+        <di:waypoint x="1420" y="1660" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1396" y="990" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_AanpassenWeekstaat_Task_VersturenWeekstaat_di" bpmnElement="Flow_Task_AanpassenWeekstaat_Task_VersturenWeekstaat">
+        <di:waypoint x="1470" y="1140" />
+        <di:waypoint x="1470" y="1410" />
+        <di:waypoint x="910" y="1410" />
+        <di:waypoint x="910" y="1050" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_InvoerenAantallenWeekstaat_Gateway_WeekAfwJoin_di" bpmnElement="Flow_Task_InvoerenAantallenWeekstaat_Gateway_WeekAfwJoin">
+        <di:waypoint x="1520" y="1660" />
+        <di:waypoint x="1560" y="1660" />
+        <di:waypoint x="1560" y="1010" />
+        <di:waypoint x="1600" y="1010" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_MeldenAfwijking_Task_AfstemmenAfwijking_di" bpmnElement="Flow_Task_MeldenAfwijking_Task_AfstemmenAfwijking">
+        <di:waypoint x="640" y="1190" />
+        <di:waypoint x="670" y="1190" />
+        <di:waypoint x="670" y="1860" />
+        <di:waypoint x="700" y="1860" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_AfstemmenAfwijking_Gateway_AfwijkingAkkoord_di" bpmnElement="Flow_Task_AfstemmenAfwijking_Gateway_AfwijkingAkkoord">
+        <di:waypoint x="800" y="1860" />
+        <di:waypoint x="860" y="1860" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_AfwijkingAkkoord_Task_AanpassenAfwijkingenrapport_di" bpmnElement="Flow_Gateway_AfwijkingAkkoord_Task_AanpassenAfwijkingenrapport">
+        <di:waypoint x="910" y="1860" />
+        <di:waypoint x="925" y="1860" />
+        <di:waypoint x="925" y="1190" />
+        <di:waypoint x="940" y="1190" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="916" y="1840" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_AfwijkingAkkoord_Gateway_WeekAfwJoin_di" bpmnElement="Flow_Gateway_AfwijkingAkkoord_Gateway_WeekAfwJoin">
+        <di:waypoint x="910" y="1860" />
+        <di:waypoint x="1255" y="1860" />
+        <di:waypoint x="1255" y="1010" />
+        <di:waypoint x="1600" y="1010" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="916" y="1840" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_AanpassenAfwijkingenrapport_Task_AfstemmenAfwijking_di" bpmnElement="Flow_Task_AanpassenAfwijkingenrapport_Task_AfstemmenAfwijking">
+        <di:waypoint x="990" y="1230" />
+        <di:waypoint x="990" y="1995" />
+        <di:waypoint x="750" y="1995" />
+        <di:waypoint x="750" y="1900" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_WeekAfwJoin_Task_Directievoering_di" bpmnElement="Flow_Gateway_WeekAfwJoin_Task_Directievoering">
+        <di:waypoint x="1650" y="1010" />
+        <di:waypoint x="1665" y="1010" />
+        <di:waypoint x="1665" y="1950" />
+        <di:waypoint x="1680" y="1950" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_Directievoering_Gateway_TermijnenContract_di" bpmnElement="Flow_Task_Directievoering_Gateway_TermijnenContract">
+        <di:waypoint x="1780" y="1950" />
+        <di:waypoint x="1840" y="1950" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_TermijnenContract_Task_DoorsturenGeaccordeerdeTermijn_di" bpmnElement="Flow_Gateway_TermijnenContract_Task_DoorsturenGeaccordeerdeTermijn">
+        <di:waypoint x="1890" y="1950" />
+        <di:waypoint x="1905" y="1950" />
+        <di:waypoint x="1905" y="1860" />
+        <di:waypoint x="1920" y="1860" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1896" y="1930" width="120" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_TermijnenContract_Task_SturenOverzichtAwr_di" bpmnElement="Flow_Gateway_TermijnenContract_Task_SturenOverzichtAwr">
+        <di:waypoint x="1890" y="1950" />
+        <di:waypoint x="1905" y="1950" />
+        <di:waypoint x="1905" y="2040" />
+        <di:waypoint x="1920" y="2040" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1896" y="1930" width="120" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_DoorsturenGeaccordeerdeTermijn_Gateway_AwrJoin_di" bpmnElement="Flow_Task_DoorsturenGeaccordeerdeTermijn_Gateway_AwrJoin">
+        <di:waypoint x="2020" y="1860" />
+        <di:waypoint x="2410" y="1860" />
+        <di:waypoint x="2410" y="1950" />
+        <di:waypoint x="2800" y="1950" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_SturenOverzichtAwr_Task_BeoordelenOverzichtAwr_di" bpmnElement="Flow_Task_SturenOverzichtAwr_Task_BeoordelenOverzichtAwr">
+        <di:waypoint x="2020" y="2040" />
+        <di:waypoint x="2050" y="2040" />
+        <di:waypoint x="2050" y="2330" />
+        <di:waypoint x="2080" y="2330" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_BeoordelenOverzichtAwr_Gateway_AwrAkkoord_di" bpmnElement="Flow_Task_BeoordelenOverzichtAwr_Gateway_AwrAkkoord">
+        <di:waypoint x="2180" y="2330" />
+        <di:waypoint x="2240" y="2330" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_AwrAkkoord_Task_RetourSturenOverzichtAwr_di" bpmnElement="Flow_Gateway_AwrAkkoord_Task_RetourSturenOverzichtAwr">
+        <di:waypoint x="2290" y="2330" />
+        <di:waypoint x="2305" y="2330" />
+        <di:waypoint x="2305" y="2420" />
+        <di:waypoint x="2320" y="2420" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2296" y="2310" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_AwrAkkoord_Task_VersturenOverzichtAwrKc_di" bpmnElement="Flow_Gateway_AwrAkkoord_Task_VersturenOverzichtAwrKc">
+        <di:waypoint x="2290" y="2330" />
+        <di:waypoint x="2305" y="2330" />
+        <di:waypoint x="2305" y="2510" />
+        <di:waypoint x="2320" y="2510" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2296" y="2310" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_RetourSturenOverzichtAwr_Task_OnderhandelenPrijzen_di" bpmnElement="Flow_Task_RetourSturenOverzichtAwr_Task_OnderhandelenPrijzen">
+        <di:waypoint x="2420" y="2420" />
+        <di:waypoint x="2450" y="2420" />
+        <di:waypoint x="2450" y="2130" />
+        <di:waypoint x="2480" y="2130" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_OnderhandelenPrijzen_Task_SturenAangepastOverzichtAwr_di" bpmnElement="Flow_Task_OnderhandelenPrijzen_Task_SturenAangepastOverzichtAwr">
+        <di:waypoint x="2580" y="2130" />
+        <di:waypoint x="2610" y="2130" />
+        <di:waypoint x="2610" y="2220" />
+        <di:waypoint x="2640" y="2220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_SturenAangepastOverzichtAwr_Task_BeoordelenOverzichtAwr_di" bpmnElement="Flow_Task_SturenAangepastOverzichtAwr_Task_BeoordelenOverzichtAwr">
+        <di:waypoint x="2690" y="2260" />
+        <di:waypoint x="2690" y="2560" />
+        <di:waypoint x="2130" y="2560" />
+        <di:waypoint x="2130" y="2370" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_VersturenOverzichtAwrKc_Gateway_AwrJoin_di" bpmnElement="Flow_Task_VersturenOverzichtAwrKc_Gateway_AwrJoin">
+        <di:waypoint x="2420" y="2510" />
+        <di:waypoint x="2610" y="2510" />
+        <di:waypoint x="2610" y="1950" />
+        <di:waypoint x="2800" y="1950" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_AwrJoin_Task_VersturenOverzichtAwrDv_di" bpmnElement="Flow_Gateway_AwrJoin_Task_VersturenOverzichtAwrDv">
+        <di:waypoint x="2850" y="1950" />
+        <di:waypoint x="2880" y="1950" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_VersturenOverzichtAwrDv_Gateway_WerkGereed_di" bpmnElement="Flow_Task_VersturenOverzichtAwrDv_Gateway_WerkGereed">
+        <di:waypoint x="2980" y="1950" />
+        <di:waypoint x="3040" y="1950" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_WerkGereed_Gateway_WeekStart_di" bpmnElement="Flow_Gateway_WerkGereed_Gateway_WeekStart">
+        <di:waypoint x="3065" y="1975" />
+        <di:waypoint x="3065" y="1415" />
+        <di:waypoint x="405" y="1415" />
+        <di:waypoint x="405" y="1035" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3071" y="1955" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_WerkGereed_Gateway_UitvoeringJoin_di" bpmnElement="Flow_Gateway_WerkGereed_Gateway_UitvoeringJoin">
+        <di:waypoint x="3090" y="1950" />
+        <di:waypoint x="3105" y="1950" />
+        <di:waypoint x="3105" y="1010" />
+        <di:waypoint x="3120" y="1010" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3096" y="1930" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_SturenFactuurAanOg_Task_AccorderenFactuurDoorsturenAo_di" bpmnElement="Flow_Task_SturenFactuurAanOg_Task_AccorderenFactuurDoorsturenAo">
+        <di:waypoint x="640" y="1280" />
+        <di:waypoint x="670" y="1280" />
+        <di:waypoint x="670" y="630" />
+        <di:waypoint x="700" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_AccorderenFactuurDoorsturenAo_Task_AccorderenFactuur_di" bpmnElement="Flow_Task_AccorderenFactuurDoorsturenAo_Task_AccorderenFactuur">
+        <di:waypoint x="800" y="630" />
+        <di:waypoint x="830" y="630" />
+        <di:waypoint x="830" y="340" />
+        <di:waypoint x="860" y="340" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_AccorderenFactuur_Gateway_UitvoeringJoin_di" bpmnElement="Flow_Task_AccorderenFactuur_Gateway_UitvoeringJoin">
+        <di:waypoint x="960" y="340" />
+        <di:waypoint x="2040" y="340" />
+        <di:waypoint x="2040" y="1010" />
+        <di:waypoint x="3120" y="1010" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_AanvragenTotOpneming_Task_VerzoekenTotUitstelOpleveren_di" bpmnElement="Flow_Task_AanvragenTotOpneming_Task_VerzoekenTotUitstelOpleveren">
+        <di:waypoint x="640" y="1370" />
+        <di:waypoint x="700" y="1370" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_VerzoekenTotUitstelOpleveren_Task_BeoordelenVerzoekOpleverenDv_di" bpmnElement="Flow_Task_VerzoekenTotUitstelOpleveren_Task_BeoordelenVerzoekOpleverenDv">
+        <di:waypoint x="800" y="1370" />
+        <di:waypoint x="830" y="1370" />
+        <di:waypoint x="830" y="2130" />
+        <di:waypoint x="860" y="2130" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_BeoordelenVerzoekOpleverenDv_Task_SturenAdviesVerzoekOpleveren_di" bpmnElement="Flow_Task_BeoordelenVerzoekOpleverenDv_Task_SturenAdviesVerzoekOpleveren">
+        <di:waypoint x="960" y="2130" />
+        <di:waypoint x="1020" y="2130" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_SturenAdviesVerzoekOpleveren_Gateway_VerzoekSplit_di" bpmnElement="Flow_Task_SturenAdviesVerzoekOpleveren_Gateway_VerzoekSplit">
+        <di:waypoint x="1120" y="2130" />
+        <di:waypoint x="1150" y="2130" />
+        <di:waypoint x="1150" y="720" />
+        <di:waypoint x="1180" y="720" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_VerzoekSplit_Task_SturenVerzoekOpleveringEnBeoordeling_di" bpmnElement="Flow_Gateway_VerzoekSplit_Task_SturenVerzoekOpleveringEnBeoordeling">
+        <di:waypoint x="1230" y="720" />
+        <di:waypoint x="1260" y="720" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_VerzoekSplit_Task_BeoordelenVerzoekOpleveringPl_di" bpmnElement="Flow_Gateway_VerzoekSplit_Task_BeoordelenVerzoekOpleveringPl">
+        <di:waypoint x="1230" y="720" />
+        <di:waypoint x="1245" y="720" />
+        <di:waypoint x="1245" y="810" />
+        <di:waypoint x="1260" y="810" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_SturenVerzoekOpleveringEnBeoordeling_Task_BeoordelenVerzoekOpleveringAo_di" bpmnElement="Flow_Task_SturenVerzoekOpleveringEnBeoordeling_Task_BeoordelenVerzoekOpleveringAo">
+        <di:waypoint x="1360" y="720" />
+        <di:waypoint x="1390" y="720" />
+        <di:waypoint x="1390" y="430" />
+        <di:waypoint x="1420" y="430" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_BeoordelenVerzoekOpleveringAo_Task_OpstellenBriefAkkoordAfwijzing_di" bpmnElement="Flow_Task_BeoordelenVerzoekOpleveringAo_Task_OpstellenBriefAkkoordAfwijzing">
+        <di:waypoint x="1520" y="430" />
+        <di:waypoint x="1550" y="430" />
+        <di:waypoint x="1550" y="140" />
+        <di:waypoint x="1580" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_OpstellenBriefAkkoordAfwijzing_Task_IndienenBriefBijBesluitvorming_di" bpmnElement="Flow_Task_OpstellenBriefAkkoordAfwijzing_Task_IndienenBriefBijBesluitvorming">
+        <di:waypoint x="1680" y="140" />
+        <di:waypoint x="1710" y="140" />
+        <di:waypoint x="1710" y="520" />
+        <di:waypoint x="1740" y="520" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_IndienenBriefBijBesluitvorming_Task_PlaatsenBriefInVisi_di" bpmnElement="Flow_Task_IndienenBriefBijBesluitvorming_Task_PlaatsenBriefInVisi">
+        <di:waypoint x="1840" y="520" />
+        <di:waypoint x="1870" y="520" />
+        <di:waypoint x="1870" y="2220" />
+        <di:waypoint x="1900" y="2220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_PlaatsenBriefInVisi_Gateway_VerzoekJoin_di" bpmnElement="Flow_Task_PlaatsenBriefInVisi_Gateway_VerzoekJoin">
+        <di:waypoint x="2000" y="2220" />
+        <di:waypoint x="2030" y="2220" />
+        <di:waypoint x="2030" y="720" />
+        <di:waypoint x="2060" y="720" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_BeoordelenVerzoekOpleveringPl_Gateway_BinnenBuitenKrediet_di" bpmnElement="Flow_Task_BeoordelenVerzoekOpleveringPl_Gateway_BinnenBuitenKrediet">
+        <di:waypoint x="1360" y="810" />
+        <di:waypoint x="1420" y="810" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_BinnenBuitenKrediet_Task_MakenNotaConcerndirecteur_di" bpmnElement="Flow_Gateway_BinnenBuitenKrediet_Task_MakenNotaConcerndirecteur">
+        <di:waypoint x="1470" y="810" />
+        <di:waypoint x="1485" y="810" />
+        <di:waypoint x="1485" y="900" />
+        <di:waypoint x="1500" y="900" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1476" y="790" width="48" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_BinnenBuitenKrediet_Gateway_Waarde_di" bpmnElement="Flow_Gateway_BinnenBuitenKrediet_Gateway_Waarde">
+        <di:waypoint x="1470" y="810" />
+        <di:waypoint x="1485" y="810" />
+        <di:waypoint x="1485" y="720" />
+        <di:waypoint x="1500" y="720" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1476" y="790" width="48" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_Waarde_Task_MakenNotaAo_di" bpmnElement="Flow_Gateway_Waarde_Task_MakenNotaAo">
+        <di:waypoint x="1550" y="720" />
+        <di:waypoint x="1565" y="720" />
+        <di:waypoint x="1565" y="630" />
+        <di:waypoint x="1580" y="630" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1556" y="700" width="80" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_Waarde_Task_LatenInvullenWebformulierAtb_di" bpmnElement="Flow_Gateway_Waarde_Task_LatenInvullenWebformulierAtb">
+        <di:waypoint x="1550" y="720" />
+        <di:waypoint x="1580" y="720" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1556" y="700" width="80" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_MakenNotaConcerndirecteur_Gateway_NotaJoin_di" bpmnElement="Flow_Task_MakenNotaConcerndirecteur_Gateway_NotaJoin">
+        <di:waypoint x="1600" y="900" />
+        <di:waypoint x="1670" y="900" />
+        <di:waypoint x="1670" y="810" />
+        <di:waypoint x="1740" y="810" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_MakenNotaAo_Gateway_NotaJoin_di" bpmnElement="Flow_Task_MakenNotaAo_Gateway_NotaJoin">
+        <di:waypoint x="1680" y="630" />
+        <di:waypoint x="1710" y="630" />
+        <di:waypoint x="1710" y="810" />
+        <di:waypoint x="1740" y="810" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_LatenInvullenWebformulierAtb_Gateway_NotaJoin_di" bpmnElement="Flow_Task_LatenInvullenWebformulierAtb_Gateway_NotaJoin">
+        <di:waypoint x="1680" y="720" />
+        <di:waypoint x="1710" y="720" />
+        <di:waypoint x="1710" y="810" />
+        <di:waypoint x="1740" y="810" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_NotaJoin_Task_InvullenWebformulierAtb_di" bpmnElement="Flow_Gateway_NotaJoin_Task_InvullenWebformulierAtb">
+        <di:waypoint x="1790" y="810" />
+        <di:waypoint x="1805" y="810" />
+        <di:waypoint x="1805" y="230" />
+        <di:waypoint x="1820" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_InvullenWebformulierAtb_Gateway_VerzoekJoin_di" bpmnElement="Flow_Task_InvullenWebformulierAtb_Gateway_VerzoekJoin">
+        <di:waypoint x="1920" y="230" />
+        <di:waypoint x="1990" y="230" />
+        <di:waypoint x="1990" y="720" />
+        <di:waypoint x="2060" y="720" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_VerzoekJoin_Gateway_UitvoeringJoin_di" bpmnElement="Flow_Gateway_VerzoekJoin_Gateway_UitvoeringJoin">
+        <di:waypoint x="2110" y="720" />
+        <di:waypoint x="2615" y="720" />
+        <di:waypoint x="2615" y="1010" />
+        <di:waypoint x="3120" y="1010" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_UitvoeringJoin_EndEvent_R53_di" bpmnElement="Flow_Gateway_UitvoeringJoin_EndEvent_R53">
+        <di:waypoint x="3170" y="1010" />
+        <di:waypoint x="3200" y="1010" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Assoc_Annotation_R51_Entry_di" bpmnElement="Assoc_Annotation_R51_Entry">
+        <di:waypoint x="590" y="1440" />
+        <di:waypoint x="380" y="1500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Assoc_Annotation_KV2_Nota_di" bpmnElement="Assoc_Annotation_KV2_Nota">
+        <di:waypoint x="1765" y="785" />
+        <di:waypoint x="2040" y="830" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Assoc_Annotation_ATB_di" bpmnElement="Assoc_Annotation_ATB">
+        <di:waypoint x="1870" y="190" />
+        <di:waypoint x="2140" y="145" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Assoc_Annotation_KV2_Documenten_di" bpmnElement="Assoc_Annotation_KV2_Documenten">
+        <di:waypoint x="1790" y="480" />
+        <di:waypoint x="2020" y="525" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/examples/organizations/flevoland/rip-phase-52/rip-aanpassen-afwijkingenrapport.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-aanpassen-afwijkingenrapport.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-aanpassen-afwijkingenrapport",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Amend the deviation report"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The deviation report was not accepted. The contractor amends it and it is aligned again."
+    },
+    {
+      "id": "F_Aanpassing",
+      "type": "textarea",
+      "label": "What was amended",
+      "key": "afwijkingenrapportAanpassing",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Amended on",
+      "key": "afwijkingenrapportAangepastOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-aanpassen-weekstaat.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-aanpassen-weekstaat.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-aanpassen-weekstaat",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Amend the weekly statement"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The weekstaat was not approved. The contractor amends it and sends it again for assessment."
+    },
+    {
+      "id": "F_Aanpassing",
+      "type": "textarea",
+      "label": "What was amended",
+      "key": "weekstaatAanpassing",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Amended on",
+      "key": "weekstaatAangepastOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-aanvragen-tot-opneming.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-aanvragen-tot-opneming.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-aanvragen-tot-opneming",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Request an inspection"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The contractor requests the opneming that precedes delivery."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Inspection request reference",
+      "key": "opnemingReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Requested on",
+      "key": "opnemingAangevraagdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-accorderen-factuur-ao.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-accorderen-factuur-ao.form
@@ -1,0 +1,65 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-accorderen-factuur-ao",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Approve the invoice"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The AO approves the invoice for payment."
+    },
+    {
+      "id": "F_Akkoord",
+      "type": "select",
+      "label": "Invoice approved by AO",
+      "key": "factuurAkkoordAo",
+      "values": [
+        {
+          "label": "Yes",
+          "value": "ja"
+        },
+        {
+          "label": "No",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Door",
+      "type": "textfield",
+      "label": "Approved by",
+      "key": "factuurGeaccordeerdDoor",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Approved on",
+      "key": "factuurGeaccordeerdOpAo",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-accorderen-factuur-pl.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-accorderen-factuur-pl.form
@@ -1,0 +1,62 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-accorderen-factuur-pl",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Approve the invoice and forward it to the AO"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The projectleider approves the invoice against the approved terms and forwards it to the AO."
+    },
+    {
+      "id": "F_Akkoord",
+      "type": "select",
+      "label": "Invoice approved by PL",
+      "key": "factuurAkkoordPl",
+      "values": [
+        {
+          "label": "Yes",
+          "value": "ja"
+        },
+        {
+          "label": "No",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Toel",
+      "type": "textarea",
+      "label": "Notes",
+      "key": "factuurToelichtingPl"
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Approved on",
+      "key": "factuurGeaccordeerdOpPl",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-advies-afwijking.document
+++ b/examples/organizations/flevoland/rip-phase-52/rip-advies-afwijking.document
@@ -1,0 +1,218 @@
+{
+  "id": "rip-advies-afwijking",
+  "name": "RIP — Deviation Advice (Advies afwijking)",
+  "description": "The advice on a reported deviation, aligned with the adviser, the designer and the projectleider.",
+  "processKey": "RipR52Process",
+  "serviceId": "RipR52",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-02T00:00:00.000Z",
+  "updatedAt": "2026-09-02T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{adviesAfwijkingReferentie}}",
+      "variableKey": "adviesAfwijkingReferentie",
+      "source": "process",
+      "label": "Advice reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{afwijkingenrapportReferentie}}",
+      "variableKey": "afwijkingenrapportReferentie",
+      "source": "process",
+      "label": "Deviation report reference"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{afwijkingAfgestemdOp}}",
+      "variableKey": "afwijkingAfgestemdOp",
+      "source": "process",
+      "label": "Aligned on"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{adviesAfwijkingInhoud}}",
+      "variableKey": "adviesAfwijkingInhoud",
+      "source": "process",
+      "label": "Advice"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{afwijkingAkkoord}}",
+      "variableKey": "afwijkingAkkoord",
+      "source": "process",
+      "label": "Accepted"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Advies {{adviesAfwijkingReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Deviation advice",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Deviation advice"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Advice {{adviesAfwijkingReferentie}} on afwijkingenrapport {{afwijkingenrapportReferentie}} for project {{projectNumber}} — {{projectName}} was aligned on {{afwijkingAfgestemdOp}} with the adviser, the designer and the projectleider."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Advice: {{adviesAfwijkingInhoud}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Deviation report accepted: {{afwijkingAkkoord}}."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Aligned by the directievoerder"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-afstemmen-afwijking.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-afstemmen-afwijking.form
@@ -1,0 +1,74 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-afstemmen-afwijking",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Align the deviation with adviser, designer and PL"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The directievoerder aligns the reported deviation with the adviser, the designer and the projectleider, and records the resulting advice."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Deviation advice reference",
+      "key": "adviesAfwijkingReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Advies",
+      "type": "textarea",
+      "label": "Advice on the deviation",
+      "key": "adviesAfwijkingInhoud",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Akkoord",
+      "type": "select",
+      "label": "Deviation report accepted",
+      "key": "afwijkingAkkoord",
+      "values": [
+        {
+          "label": "Yes",
+          "value": "ja"
+        },
+        {
+          "label": "No",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Aligned on",
+      "key": "afwijkingAfgestemdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-afwijkingenrapport.document
+++ b/examples/organizations/flevoland/rip-phase-52/rip-afwijkingenrapport.document
@@ -1,0 +1,211 @@
+{
+  "id": "rip-afwijkingenrapport",
+  "name": "RIP — Deviation Report (Afwijkingenrapport)",
+  "description": "A deviation from the work specification reported by the contractor.",
+  "processKey": "RipR52Process",
+  "serviceId": "RipR52",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-02T00:00:00.000Z",
+  "updatedAt": "2026-09-02T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{afwijkingenrapportReferentie}}",
+      "variableKey": "afwijkingenrapportReferentie",
+      "source": "process",
+      "label": "Deviation report reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{afwijkingGemeldOp}}",
+      "variableKey": "afwijkingGemeldOp",
+      "source": "process",
+      "label": "Reported on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{afwijkingOmschrijving}}",
+      "variableKey": "afwijkingOmschrijving",
+      "source": "process",
+      "label": "Deviation"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{afwijkingBedrag}}",
+      "variableKey": "afwijkingBedrag",
+      "source": "process",
+      "label": "Estimated financial effect"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Afwijkingenrapport {{afwijkingenrapportReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Deviation report",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Deviation report"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Afwijkingenrapport {{afwijkingenrapportReferentie}} for project {{projectNumber}} — {{projectName}} was reported on {{afwijkingGemeldOp}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Deviation: {{afwijkingOmschrijving}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Estimated financial effect: EUR {{afwijkingBedrag}}."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Reported by the contractor"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-awr-overzicht.document
+++ b/examples/organizations/flevoland/rip-phase-52/rip-awr-overzicht.document
@@ -1,0 +1,264 @@
+{
+  "id": "rip-awr-overzicht",
+  "name": "RIP — Deviation Reporting Overview (Afwijkingenrapportage AWR)",
+  "description": "The AWR overview of deviations falling outside the contract, assessed by the cost and contract specialist before it is issued.",
+  "processKey": "RipR52Process",
+  "serviceId": "RipR52",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-02T00:00:00.000Z",
+  "updatedAt": "2026-09-02T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{awrOverzichtReferentie}}",
+      "variableKey": "awrOverzichtReferentie",
+      "source": "process",
+      "label": "AWR overview reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{awrOverzichtVerstuurdOp}}",
+      "variableKey": "awrOverzichtVerstuurdOp",
+      "source": "process",
+      "label": "Sent on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{awrOverzichtBedrag}}",
+      "variableKey": "awrOverzichtBedrag",
+      "source": "process",
+      "label": "Overview value"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{awrOverzichtInhoud}}",
+      "variableKey": "awrOverzichtInhoud",
+      "source": "process",
+      "label": "Deviations"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{awrBevindingen}}",
+      "variableKey": "awrBevindingen",
+      "source": "process",
+      "label": "Assessment findings"
+    },
+    {
+      "id": "b8",
+      "placeholder": "{{awrAkkoord}}",
+      "variableKey": "awrAkkoord",
+      "source": "process",
+      "label": "Approved"
+    },
+    {
+      "id": "b9",
+      "placeholder": "{{onderhandelingUitkomst}}",
+      "variableKey": "onderhandelingUitkomst",
+      "source": "process",
+      "label": "Negotiation outcome"
+    },
+    {
+      "id": "b10",
+      "placeholder": "{{awrUitgegevenAan}}",
+      "variableKey": "awrUitgegevenAan",
+      "source": "process",
+      "label": "Issued to"
+    },
+    {
+      "id": "b11",
+      "placeholder": "{{awrUitgegevenOp}}",
+      "variableKey": "awrUitgegevenOp",
+      "source": "process",
+      "label": "Issued on"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "AWR {{awrOverzichtReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Deviation reporting overview",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Deviation reporting overview"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "AWR overview {{awrOverzichtReferentie}} for project {{projectNumber}} — {{projectName}} was sent for assessment on {{awrOverzichtVerstuurdOp}} and covers EUR {{awrOverzichtBedrag}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Deviations: {{awrOverzichtInhoud}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Assessment: {{awrBevindingen}} Approved: {{awrAkkoord}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Where it was not approved, the prices were renegotiated with the contractor — {{onderhandelingUitkomst}} — and the overview resubmitted."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Issued to {{awrUitgegevenAan}} on {{awrUitgegevenOp}}."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Assessed by the cost and contract specialist, issued by the directievoerder"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-beoordelen-overzicht-awr.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-beoordelen-overzicht-awr.form
@@ -1,0 +1,65 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-beoordelen-overzicht-awr",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Assess the AWR overview"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The cost and contract specialist assesses the AWR overview against the deviation reports and decides whether it can go out."
+    },
+    {
+      "id": "F_Bevindingen",
+      "type": "textarea",
+      "label": "Assessment findings",
+      "key": "awrBevindingen",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Akkoord",
+      "type": "select",
+      "label": "AWR overview approved",
+      "key": "awrAkkoord",
+      "values": [
+        {
+          "label": "Yes",
+          "value": "ja"
+        },
+        {
+          "label": "No",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Assessed on",
+      "key": "awrBeoordeeldOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-beoordelen-sturen-weekstaat.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-beoordelen-sturen-weekstaat.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-beoordelen-sturen-weekstaat",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Assess the weekly statement and send the assessment"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The toezichthouder assesses the weekstaat against what was observed on site and sends the assessment on."
+    },
+    {
+      "id": "F_Bevindingen",
+      "type": "textarea",
+      "label": "Assessment findings",
+      "key": "weekstaatBevindingenTzh",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Assessed on",
+      "key": "weekstaatBeoordeeldOpTzh",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-beoordelen-verzoek-opleveren-dv.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-beoordelen-verzoek-opleveren-dv.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-beoordelen-verzoek-opleveren-dv",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Assess the request to deliver or postpone (DV)"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The directievoerder assesses the contractor request against the state of the work."
+    },
+    {
+      "id": "F_Bevindingen",
+      "type": "textarea",
+      "label": "Assessment findings",
+      "key": "opleveringBevindingenDv",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Assessed on",
+      "key": "opleveringBeoordeeldOpDv",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-beoordelen-verzoek-oplevering-ao.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-beoordelen-verzoek-oplevering-ao.form
@@ -1,0 +1,65 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-beoordelen-verzoek-oplevering-ao",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Assess the request to deliver or postpone (AO)"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The AO assesses the request and decides whether it is granted."
+    },
+    {
+      "id": "F_Toegekend",
+      "type": "select",
+      "label": "Request granted",
+      "key": "opleveringVerzoekToegekend",
+      "values": [
+        {
+          "label": "Yes",
+          "value": "ja"
+        },
+        {
+          "label": "No",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Motivering",
+      "type": "textarea",
+      "label": "Substantiation",
+      "key": "opleveringBesluitMotivering",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Decided on",
+      "key": "opleveringBesluitOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-beoordelen-verzoek-oplevering-pl.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-beoordelen-verzoek-oplevering-pl.form
@@ -1,0 +1,84 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-beoordelen-verzoek-oplevering-pl",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Assess the request against the credit (PL)"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The projectleider assesses what the request means financially: whether it stays within the credit, and — where it does — whether the value passes the EUR 50.000 threshold that decides which decision-note template is used."
+    },
+    {
+      "id": "F_Bedrag",
+      "type": "number",
+      "label": "Financial effect of the request (EUR)",
+      "key": "opleveringBedrag",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Krediet",
+      "type": "select",
+      "label": "Financial effect falls",
+      "key": "kredietPositie",
+      "values": [
+        {
+          "label": "Within the credit",
+          "value": "binnen"
+        },
+        {
+          "label": "Outside the credit",
+          "value": "buiten"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Waarde",
+      "type": "select",
+      "label": "Value against the EUR 50.000 threshold",
+      "key": "notaWaarde",
+      "values": [
+        {
+          "label": "Below EUR 50.000",
+          "value": "onder"
+        },
+        {
+          "label": "Above EUR 50.000",
+          "value": "boven"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Assessed on",
+      "key": "opleveringBeoordeeldOpPl",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-beoordelen-weekstaat.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-beoordelen-weekstaat.form
@@ -1,0 +1,65 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-beoordelen-weekstaat",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Assess the weekly statement"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The directievoerder assesses the weekstaat and gives the decisive verdict, having the toezichthouder assessment alongside."
+    },
+    {
+      "id": "F_Bevindingen",
+      "type": "textarea",
+      "label": "Assessment findings",
+      "key": "weekstaatBevindingenDv",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Akkoord",
+      "type": "select",
+      "label": "Weekly statement approved",
+      "key": "weekstaatAkkoord",
+      "values": [
+        {
+          "label": "Yes",
+          "value": "ja"
+        },
+        {
+          "label": "No",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Assessed on",
+      "key": "weekstaatBeoordeeldOpDv",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-brief-uitstel-oplevering.document
+++ b/examples/organizations/flevoland/rip-phase-52/rip-brief-uitstel-oplevering.document
@@ -1,0 +1,239 @@
+{
+  "id": "rip-brief-uitstel-oplevering",
+  "name": "RIP — Letter on (Postponement of) Delivery (Brief uitstel tot oplevering)",
+  "description": "The letter conveying the decision on the request to the contractor, submitted for decision-making and placed in VISI.",
+  "processKey": "RipR52Process",
+  "serviceId": "RipR52",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-02T00:00:00.000Z",
+  "updatedAt": "2026-09-02T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{briefOpleveringReferentie}}",
+      "variableKey": "briefOpleveringReferentie",
+      "source": "process",
+      "label": "Letter reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{briefOpleveringOp}}",
+      "variableKey": "briefOpleveringOp",
+      "source": "process",
+      "label": "Drawn up on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{opleveringVerzoekReferentie}}",
+      "variableKey": "opleveringVerzoekReferentie",
+      "source": "process",
+      "label": "Request reference"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{briefOpleveringInhoud}}",
+      "variableKey": "briefOpleveringInhoud",
+      "source": "process",
+      "label": "Letter content"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{briefIngediendOp}}",
+      "variableKey": "briefIngediendOp",
+      "source": "process",
+      "label": "Submitted on"
+    },
+    {
+      "id": "b8",
+      "placeholder": "{{besluitvormingReferentie}}",
+      "variableKey": "besluitvormingReferentie",
+      "source": "process",
+      "label": "Decision-making reference"
+    },
+    {
+      "id": "b9",
+      "placeholder": "{{briefInVisiOp}}",
+      "variableKey": "briefInVisiOp",
+      "source": "process",
+      "label": "Placed in VISI on"
+    },
+    {
+      "id": "b10",
+      "placeholder": "{{briefVisiReferentie}}",
+      "variableKey": "briefVisiReferentie",
+      "source": "process",
+      "label": "VISI message reference"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Brief {{briefOpleveringReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Letter on (postponement of) delivery",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Letter on (postponement of) delivery"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Letter {{briefOpleveringReferentie}} for project {{projectNumber}} — {{projectName}} was drawn up on {{briefOpleveringOp}} and conveys the decision on request {{opleveringVerzoekReferentie}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "{{briefOpleveringInhoud}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "It was submitted for decision-making on {{briefIngediendOp}} under {{besluitvormingReferentie}}, with the projectleider and the directievoerder in copy, and placed in VISI on {{briefInVisiOp}} under message {{briefVisiReferentie}}."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up by the ondersteuner, submitted by the AO"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-directievoering.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-directievoering.form
@@ -1,0 +1,92 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-directievoering",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Directievoering for the week"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The directievoerder closes the week: the weekrapport, the approved terms and the deviation reporting (AWR) are brought together, and it is decided whether the approved terms fall within or outside the contract."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Weekly report reference",
+      "key": "weekrapportReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Voortgang",
+      "type": "textarea",
+      "label": "Progress this week",
+      "key": "weekrapportVoortgang",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Termijnen",
+      "type": "textfield",
+      "label": "Approved terms reference",
+      "key": "geaccordeerdeTermijnenReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bedrag",
+      "type": "number",
+      "label": "Approved term value (EUR)",
+      "key": "geaccordeerdeTermijnBedrag",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Contract",
+      "type": "select",
+      "label": "Approved terms fall",
+      "key": "termijnenContract",
+      "values": [
+        {
+          "label": "Within the contract",
+          "value": "binnen"
+        },
+        {
+          "label": "Outside the contract",
+          "value": "buiten"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Closed on",
+      "key": "directievoeringOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-doorsturen-geaccordeerde-termijn.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-doorsturen-geaccordeerde-termijn.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-doorsturen-geaccordeerde-termijn",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Forward the approved term via VISI"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The approved terms fall within the contract, so the term is forwarded through VISI without an AWR overview."
+    },
+    {
+      "id": "F_Visi",
+      "type": "textfield",
+      "label": "VISI message reference",
+      "key": "visiBerichtReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Forwarded on",
+      "key": "termijnDoorgestuurdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-geaccordeerde-termijnen.document
+++ b/examples/organizations/flevoland/rip-phase-52/rip-geaccordeerde-termijnen.document
@@ -1,0 +1,202 @@
+{
+  "id": "rip-geaccordeerde-termijnen",
+  "name": "RIP — Approved Terms (Geaccordeerde termijnen)",
+  "description": "The approved terms forwarded through VISI, where they fall within the contract.",
+  "processKey": "RipR52Process",
+  "serviceId": "RipR52",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-02T00:00:00.000Z",
+  "updatedAt": "2026-09-02T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{geaccordeerdeTermijnenReferentie}}",
+      "variableKey": "geaccordeerdeTermijnenReferentie",
+      "source": "process",
+      "label": "Approved terms reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{geaccordeerdeTermijnBedrag}}",
+      "variableKey": "geaccordeerdeTermijnBedrag",
+      "source": "process",
+      "label": "Approved term value"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{termijnDoorgestuurdOp}}",
+      "variableKey": "termijnDoorgestuurdOp",
+      "source": "process",
+      "label": "Forwarded on"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{visiBerichtReferentie}}",
+      "variableKey": "visiBerichtReferentie",
+      "source": "process",
+      "label": "VISI message reference"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Termijnen {{geaccordeerdeTermijnenReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Approved terms",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Approved terms"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Approved terms {{geaccordeerdeTermijnenReferentie}} for project {{projectNumber}} — {{projectName}} amount to EUR {{geaccordeerdeTermijnBedrag}} and fall within the contract."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "They were forwarded through VISI on {{termijnDoorgestuurdOp}} under message {{visiBerichtReferentie}}."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Forwarded by the directievoerder"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-indienen-brief-besluitvorming.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-indienen-brief-besluitvorming.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-indienen-brief-besluitvorming",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Submit the letter for decision-making, cc PL and DV"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The AO submits the letter into the decision-making process, with the projectleider and the directievoerder in copy."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Decision-making reference",
+      "key": "besluitvormingReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Submitted on",
+      "key": "briefIngediendOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-invoeren-aantallen-weekstaat.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-invoeren-aantallen-weekstaat.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-invoeren-aantallen-weekstaat",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Enter the weekly quantities in the specification administration"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Enter the approved quantities from the weekstaat in the besteksadministratie. Done weekly."
+    },
+    {
+      "id": "F_Bedrag",
+      "type": "number",
+      "label": "Value entered (EUR)",
+      "key": "weekstaatBedrag",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Admin",
+      "type": "textfield",
+      "label": "Specification administration reference",
+      "key": "besteksadministratieReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Entered on",
+      "key": "weekstaatIngevoerdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-invullen-webformulier-atb.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-invullen-webformulier-atb.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-invullen-webformulier-atb",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Fill in the ATB webform"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The ondersteuner fills in the ATB webform. Handling of the ATB itself sits outside R5.2."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "ATB webform reference",
+      "key": "atbFormulierReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Inhoud",
+      "type": "textarea",
+      "label": "What was recorded",
+      "key": "atbInhoud",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Filled in on",
+      "key": "atbIngevuldOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-laten-invullen-webformulier-atb.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-laten-invullen-webformulier-atb.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-laten-invullen-webformulier-atb",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Have the ATB webform filled in"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The financial effect stays within the credit and below EUR 50.000, so no decision note is needed and only the ATB webform is filled in."
+    },
+    {
+      "id": "F_Toel",
+      "type": "textarea",
+      "label": "What is to be recorded",
+      "key": "atbToelichting",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Requested on",
+      "key": "atbVerzochtOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-maken-nota-ao.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-maken-nota-ao.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-maken-nota-ao",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Draw up the decision note (AO template)"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The financial effect stays within the credit but passes EUR 50.000, so the decision note goes to the AO and the ATB webform is filled in."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Decision note reference",
+      "key": "notaAoOpleveringReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Toel",
+      "type": "textarea",
+      "label": "Substantiation",
+      "key": "notaAoOpleveringToelichting",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Drawn up on",
+      "key": "notaAoOpleveringOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-maken-nota-concerndirecteur.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-maken-nota-concerndirecteur.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-maken-nota-concerndirecteur",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Draw up the decision note (Concerndirecteur template)"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The financial effect falls outside the credit, so the decision note goes to the concern director and the ATB webform is filled in."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Decision note reference",
+      "key": "notaConcerndirecteurOpleveringReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Toel",
+      "type": "textarea",
+      "label": "Substantiation",
+      "key": "notaConcerndirecteurOpleveringToelichting",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Drawn up on",
+      "key": "notaConcerndirecteurOpleveringOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-melden-afwijking.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-melden-afwijking.form
@@ -1,0 +1,61 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-melden-afwijking",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Report a deviation"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The contractor reports a deviation from the work specification in an afwijkingenrapport."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Deviation report reference",
+      "key": "afwijkingenrapportReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Omschrijving",
+      "type": "textarea",
+      "label": "Deviation reported",
+      "key": "afwijkingOmschrijving",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bedrag",
+      "type": "number",
+      "label": "Estimated financial effect (EUR)",
+      "key": "afwijkingBedrag"
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Reported on",
+      "key": "afwijkingGemeldOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-nota-besluitvorming-ao-oplevering.document
+++ b/examples/organizations/flevoland/rip-phase-52/rip-nota-besluitvorming-ao-oplevering.document
@@ -1,0 +1,218 @@
+{
+  "id": "rip-nota-besluitvorming-ao-oplevering",
+  "name": "RIP — Decision Note on Delivery, AO (Nota besluitvorming)",
+  "description": "Sjabloon nota besluitvorming for the AO, used when the financial effect stays within the credit but passes EUR 50.000.",
+  "processKey": "RipR52Process",
+  "serviceId": "RipR52",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-02T00:00:00.000Z",
+  "updatedAt": "2026-09-02T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{notaAoOpleveringReferentie}}",
+      "variableKey": "notaAoOpleveringReferentie",
+      "source": "process",
+      "label": "Decision note reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{opleveringVerzoekReferentie}}",
+      "variableKey": "opleveringVerzoekReferentie",
+      "source": "process",
+      "label": "Request reference"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{opleveringBedrag}}",
+      "variableKey": "opleveringBedrag",
+      "source": "process",
+      "label": "Financial effect"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{notaAoOpleveringToelichting}}",
+      "variableKey": "notaAoOpleveringToelichting",
+      "source": "process",
+      "label": "Substantiation"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{notaAoOpleveringOp}}",
+      "variableKey": "notaAoOpleveringOp",
+      "source": "process",
+      "label": "Drawn up on"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Nota {{notaAoOpleveringReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Decision note — AO",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Decision note — AO"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The financial effect of request {{opleveringVerzoekReferentie}} for project {{projectNumber}} — {{projectName}} is EUR {{opleveringBedrag}}. It stays within the credit but passes EUR 50.000, so the decision goes to the AO."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Substantiation: {{notaAoOpleveringToelichting}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up on {{notaAoOpleveringOp}}; the ATB webform is filled in alongside."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up by the projectleider for the AO"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-nota-besluitvorming-atb.document
+++ b/examples/organizations/flevoland/rip-phase-52/rip-nota-besluitvorming-atb.document
@@ -1,0 +1,232 @@
+{
+  "id": "rip-nota-besluitvorming-atb",
+  "name": "RIP — ATB Webform Record (Nota besluitvorming ATB)",
+  "description": "What was recorded in the ATB webform for the delivery request. Handling of the ATB itself sits outside R5.2.",
+  "processKey": "RipR52Process",
+  "serviceId": "RipR52",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-02T00:00:00.000Z",
+  "updatedAt": "2026-09-02T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{atbFormulierReferentie}}",
+      "variableKey": "atbFormulierReferentie",
+      "source": "process",
+      "label": "ATB webform reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{atbIngevuldOp}}",
+      "variableKey": "atbIngevuldOp",
+      "source": "process",
+      "label": "Filled in on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{atbInhoud}}",
+      "variableKey": "atbInhoud",
+      "source": "process",
+      "label": "Recorded"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{opleveringVerzoekReferentie}}",
+      "variableKey": "opleveringVerzoekReferentie",
+      "source": "process",
+      "label": "Request reference"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{opleveringBedrag}}",
+      "variableKey": "opleveringBedrag",
+      "source": "process",
+      "label": "Financial effect"
+    },
+    {
+      "id": "b8",
+      "placeholder": "{{kredietPositie}}",
+      "variableKey": "kredietPositie",
+      "source": "process",
+      "label": "Credit position"
+    },
+    {
+      "id": "b9",
+      "placeholder": "{{notaWaarde}}",
+      "variableKey": "notaWaarde",
+      "source": "process",
+      "label": "Value against threshold"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "ATB {{atbFormulierReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "ATB webform record",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "ATB webform record"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "ATB webform {{atbFormulierReferentie}} for project {{projectNumber}} — {{projectName}} was filled in on {{atbIngevuldOp}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Recorded: {{atbInhoud}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "It follows request {{opleveringVerzoekReferentie}}, whose financial effect of EUR {{opleveringBedrag}} falls {{kredietPositie}} the credit and lies {{notaWaarde}} the EUR 50.000 threshold."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Filled in by the ondersteuner"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-nota-besluitvorming-concerndirecteur-oplevering.document
+++ b/examples/organizations/flevoland/rip-phase-52/rip-nota-besluitvorming-concerndirecteur-oplevering.document
@@ -1,0 +1,218 @@
+{
+  "id": "rip-nota-besluitvorming-concerndirecteur-oplevering",
+  "name": "RIP — Decision Note on Delivery, Concerndirecteur (Nota besluitvorming)",
+  "description": "Sjabloon nota besluitvorming for the concern director, used when the financial effect of the delivery request falls outside the credit.",
+  "processKey": "RipR52Process",
+  "serviceId": "RipR52",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-02T00:00:00.000Z",
+  "updatedAt": "2026-09-02T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{notaConcerndirecteurOpleveringReferentie}}",
+      "variableKey": "notaConcerndirecteurOpleveringReferentie",
+      "source": "process",
+      "label": "Decision note reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{opleveringVerzoekReferentie}}",
+      "variableKey": "opleveringVerzoekReferentie",
+      "source": "process",
+      "label": "Request reference"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{opleveringBedrag}}",
+      "variableKey": "opleveringBedrag",
+      "source": "process",
+      "label": "Financial effect"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{notaConcerndirecteurOpleveringToelichting}}",
+      "variableKey": "notaConcerndirecteurOpleveringToelichting",
+      "source": "process",
+      "label": "Substantiation"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{notaConcerndirecteurOpleveringOp}}",
+      "variableKey": "notaConcerndirecteurOpleveringOp",
+      "source": "process",
+      "label": "Drawn up on"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Nota {{notaConcerndirecteurOpleveringReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Decision note — concern director",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Decision note — concern director"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The financial effect of request {{opleveringVerzoekReferentie}} for project {{projectNumber}} — {{projectName}} is EUR {{opleveringBedrag}} and falls outside the credit, so the decision goes to the concern director."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Substantiation: {{notaConcerndirecteurOpleveringToelichting}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up on {{notaConcerndirecteurOpleveringOp}}; the ATB webform is filled in alongside."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up by the projectleider for the concern director"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-onderhandelen-prijzen.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-onderhandelen-prijzen.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-onderhandelen-prijzen",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Negotiate prices with the contractor"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Negotiate the disputed prices with the contractor before the overview is resubmitted."
+    },
+    {
+      "id": "F_Uitkomst",
+      "type": "textarea",
+      "label": "Outcome of the negotiation",
+      "key": "onderhandelingUitkomst",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bedrag",
+      "type": "number",
+      "label": "Agreed value (EUR)",
+      "key": "onderhandeldBedrag",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Negotiated on",
+      "key": "onderhandeldOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-opstellen-brief-oplevering.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-opstellen-brief-oplevering.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-opstellen-brief-oplevering",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Draw up the letter granting or refusing (postponement of) delivery"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The ondersteuner draws up the letter conveying the decision to the contractor."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Letter reference",
+      "key": "briefOpleveringReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Inhoud",
+      "type": "textarea",
+      "label": "Letter content",
+      "key": "briefOpleveringInhoud",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Drawn up on",
+      "key": "briefOpleveringOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-opstellen-weekstaat.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-opstellen-weekstaat.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-opstellen-weekstaat",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Draw up the weekly statement"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The contractor draws up the weekstaat for the week: the quantities carried out against the work specification."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Weekly statement reference",
+      "key": "weekstaatReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Hoeveelheden",
+      "type": "textarea",
+      "label": "Quantities carried out",
+      "key": "weekstaatHoeveelheden",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Drawn up on",
+      "key": "weekstaatOpgesteldOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-plaatsen-brief-visi.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-plaatsen-brief-visi.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-plaatsen-brief-visi",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Place the letter in VISI"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The directievoerder places the letter on (postponement of) delivery in VISI, so it reaches the contractor through the contract channel."
+    },
+    {
+      "id": "F_Visi",
+      "type": "textfield",
+      "label": "VISI message reference",
+      "key": "briefVisiReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Placed on",
+      "key": "briefInVisiOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-retour-sturen-overzicht-awr.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-retour-sturen-overzicht-awr.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-retour-sturen-overzicht-awr",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Return the AWR overview"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The AWR overview was not approved. Return it so the prices can be renegotiated with the contractor."
+    },
+    {
+      "id": "F_Reden",
+      "type": "textarea",
+      "label": "Reason for returning",
+      "key": "awrRetourReden",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Returned on",
+      "key": "awrRetourOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-sturen-aangepast-overzicht-awr.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-sturen-aangepast-overzicht-awr.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-sturen-aangepast-overzicht-awr",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Send the amended AWR overview"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Send the AWR overview again, amended for the negotiated prices."
+    },
+    {
+      "id": "F_Aanpassing",
+      "type": "textarea",
+      "label": "What was amended",
+      "key": "awrAanpassing",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Sent on",
+      "key": "awrAangepastVerstuurdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-sturen-advies-verzoek-opleveren.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-sturen-advies-verzoek-opleveren.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-sturen-advies-verzoek-opleveren",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Send the advice on the request to deliver or postpone"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The directievoerder sends the advice on to the projectleider, who takes it into both the letter chain and the funding decision."
+    },
+    {
+      "id": "F_Advies",
+      "type": "textarea",
+      "label": "Advice",
+      "key": "opleveringAdvies",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Sent on",
+      "key": "opleveringAdviesVerstuurdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-sturen-factuur-og.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-sturen-factuur-og.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-sturen-factuur-og",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Send the invoice to the client"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The contractor invoices the client for the approved terms."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Invoice reference",
+      "key": "factuurReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bedrag",
+      "type": "number",
+      "label": "Invoice amount (EUR)",
+      "key": "factuurBedrag",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Invoiced on",
+      "key": "factuurVerstuurdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-sturen-overzicht-awr.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-sturen-overzicht-awr.form
@@ -1,0 +1,64 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-sturen-overzicht-awr",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Send the AWR overview"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The approved terms fall outside the contract, so the deviation reporting overview (AWR) goes to the cost and contract specialist for assessment."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "AWR overview reference",
+      "key": "awrOverzichtReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Inhoud",
+      "type": "textarea",
+      "label": "Deviations in the overview",
+      "key": "awrOverzichtInhoud",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bedrag",
+      "type": "number",
+      "label": "Overview value (EUR)",
+      "key": "awrOverzichtBedrag",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Sent on",
+      "key": "awrOverzichtVerstuurdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-sturen-verzoek-oplevering.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-sturen-verzoek-oplevering.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-sturen-verzoek-oplevering",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Send the request and the assessment on for decision"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The projectleider sends the request and the assessment to the AO for a decision."
+    },
+    {
+      "id": "F_Aan",
+      "type": "textfield",
+      "label": "Sent to",
+      "key": "opleveringVerzoekAan",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Sent on",
+      "key": "opleveringVerzoekVerstuurdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-uitvoeren-toezichtsplan.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-uitvoeren-toezichtsplan.form
@@ -1,0 +1,64 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-uitvoeren-toezichtsplan",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Carry out supervision under the supervision plan"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The toezichthouder supervises the work for the week against the toezichtsplan adopted in R5.1."
+    },
+    {
+      "id": "F_Week",
+      "type": "textfield",
+      "label": "Week number",
+      "key": "weeknummer",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Plan",
+      "type": "textfield",
+      "label": "Adopted supervision plan reference (from R5.1)",
+      "key": "toezichtsplanReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Waarnemingen",
+      "type": "textarea",
+      "label": "Observations on site",
+      "key": "toezichtWaarnemingen",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Supervised on",
+      "key": "toezichtUitgevoerdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-versturen-overzicht-awr-dv.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-versturen-overzicht-awr-dv.form
@@ -1,0 +1,65 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-versturen-overzicht-awr-dv",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Issue the AWR overview"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The directievoerder issues the AWR overview for the week and records whether the work is finished. While it is not, the next week begins."
+    },
+    {
+      "id": "F_Aan",
+      "type": "textfield",
+      "label": "Issued to",
+      "key": "awrUitgegevenAan",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Issued on",
+      "key": "awrUitgegevenOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Gereed",
+      "type": "select",
+      "label": "Work finished",
+      "key": "werkGereed",
+      "values": [
+        {
+          "label": "Yes",
+          "value": "ja"
+        },
+        {
+          "label": "No",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-versturen-overzicht-awr-kc.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-versturen-overzicht-awr-kc.form
@@ -1,0 +1,43 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-versturen-overzicht-awr-kc",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Send out the AWR overview"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The AWR overview is approved; the cost and contract specialist sends it on to the directievoerder."
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Sent on",
+      "key": "awrVerstuurdOpKc",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Notes",
+      "key": "awrOpmerkingenKc"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-versturen-weekstaat.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-versturen-weekstaat.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-versturen-weekstaat",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Send the weekly statement to DV and TZH"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Send the weekstaat to the directievoerder and the toezichthouder, who assess it independently."
+    },
+    {
+      "id": "F_Aan",
+      "type": "textfield",
+      "label": "Sent to",
+      "key": "weekstaatVerstuurdAan",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Sent on",
+      "key": "weekstaatVerstuurdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-verzoek-uitstel-oplevering.document
+++ b/examples/organizations/flevoland/rip-phase-52/rip-verzoek-uitstel-oplevering.document
@@ -1,0 +1,262 @@
+{
+  "id": "rip-verzoek-uitstel-oplevering",
+  "name": "RIP — Request for (Postponement of) Delivery (Uitstel tot oplevering)",
+  "description": "The contractor request to deliver the work or to postpone delivery, with the assessments it passes through.",
+  "processKey": "RipR52Process",
+  "serviceId": "RipR52",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-02T00:00:00.000Z",
+  "updatedAt": "2026-09-02T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{opleveringVerzoekReferentie}}",
+      "variableKey": "opleveringVerzoekReferentie",
+      "source": "process",
+      "label": "Request reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{opleveringVerzoekSoort}}",
+      "variableKey": "opleveringVerzoekSoort",
+      "source": "process",
+      "label": "Request concerns"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{opleveringVerzochtOp}}",
+      "variableKey": "opleveringVerzochtOp",
+      "source": "process",
+      "label": "Requested on"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{opnemingReferentie}}",
+      "variableKey": "opnemingReferentie",
+      "source": "process",
+      "label": "Inspection request reference"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{opleveringVerzoekMotivering}}",
+      "variableKey": "opleveringVerzoekMotivering",
+      "source": "process",
+      "label": "Substantiation"
+    },
+    {
+      "id": "b8",
+      "placeholder": "{{opleveringBevindingenDv}}",
+      "variableKey": "opleveringBevindingenDv",
+      "source": "process",
+      "label": "Directievoerder assessment"
+    },
+    {
+      "id": "b9",
+      "placeholder": "{{opleveringAdvies}}",
+      "variableKey": "opleveringAdvies",
+      "source": "process",
+      "label": "Advice"
+    },
+    {
+      "id": "b10",
+      "placeholder": "{{opleveringVerzoekToegekend}}",
+      "variableKey": "opleveringVerzoekToegekend",
+      "source": "process",
+      "label": "Granted"
+    },
+    {
+      "id": "b11",
+      "placeholder": "{{opleveringBesluitMotivering}}",
+      "variableKey": "opleveringBesluitMotivering",
+      "source": "process",
+      "label": "Decision substantiation"
+    },
+    {
+      "id": "b12",
+      "placeholder": "{{opleveringBesluitOp}}",
+      "variableKey": "opleveringBesluitOp",
+      "source": "process",
+      "label": "Decided on"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Verzoek {{opleveringVerzoekReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Request for (postponement of) delivery",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Request for (postponement of) delivery"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Request {{opleveringVerzoekReferentie}} for project {{projectNumber}} — {{projectName}} concerns {{opleveringVerzoekSoort}} and was submitted on {{opleveringVerzochtOp}}, following inspection request {{opnemingReferentie}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Substantiation: {{opleveringVerzoekMotivering}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Directievoerder assessment: {{opleveringBevindingenDv}} Advice: {{opleveringAdvies}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Granted: {{opleveringVerzoekToegekend}} — {{opleveringBesluitMotivering}} Decided on {{opleveringBesluitOp}}."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Submitted by the contractor, decided by the AO"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-verzoeken-uitstel-opleveren.form
+++ b/examples/organizations/flevoland/rip-phase-52/rip-verzoeken-uitstel-opleveren.form
@@ -1,0 +1,74 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-verzoeken-uitstel-opleveren",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Request delivery, or postponement of delivery"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The contractor asks to deliver the work, or asks for delivery to be postponed."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Request reference",
+      "key": "opleveringVerzoekReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Soort",
+      "type": "select",
+      "label": "Request concerns",
+      "key": "opleveringVerzoekSoort",
+      "values": [
+        {
+          "label": "Delivery",
+          "value": "oplevering"
+        },
+        {
+          "label": "Postponement of delivery",
+          "value": "uitstel"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Motivering",
+      "type": "textarea",
+      "label": "Substantiation",
+      "key": "opleveringVerzoekMotivering",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Requested on",
+      "key": "opleveringVerzochtOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-weekrapport.document
+++ b/examples/organizations/flevoland/rip-phase-52/rip-weekrapport.document
@@ -1,0 +1,248 @@
+{
+  "id": "rip-weekrapport",
+  "name": "RIP — Weekly Report (Weekrapport)",
+  "description": "The directievoerder weekly report closing the week: progress, approved terms and the deviation reporting.",
+  "processKey": "RipR52Process",
+  "serviceId": "RipR52",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-02T00:00:00.000Z",
+  "updatedAt": "2026-09-02T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{weekrapportReferentie}}",
+      "variableKey": "weekrapportReferentie",
+      "source": "process",
+      "label": "Weekly report reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{weeknummer}}",
+      "variableKey": "weeknummer",
+      "source": "process",
+      "label": "Week number"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{directievoeringOp}}",
+      "variableKey": "directievoeringOp",
+      "source": "process",
+      "label": "Closed on"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{weekrapportVoortgang}}",
+      "variableKey": "weekrapportVoortgang",
+      "source": "process",
+      "label": "Progress"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{geaccordeerdeTermijnenReferentie}}",
+      "variableKey": "geaccordeerdeTermijnenReferentie",
+      "source": "process",
+      "label": "Approved terms reference"
+    },
+    {
+      "id": "b8",
+      "placeholder": "{{geaccordeerdeTermijnBedrag}}",
+      "variableKey": "geaccordeerdeTermijnBedrag",
+      "source": "process",
+      "label": "Approved term value"
+    },
+    {
+      "id": "b9",
+      "placeholder": "{{termijnenContract}}",
+      "variableKey": "termijnenContract",
+      "source": "process",
+      "label": "Terms fall"
+    },
+    {
+      "id": "b10",
+      "placeholder": "{{werkGereed}}",
+      "variableKey": "werkGereed",
+      "source": "process",
+      "label": "Work finished"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Weekrapport {{weekrapportReferentie}} · week {{weeknummer}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Weekly report",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Weekly report"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Weekrapport {{weekrapportReferentie}} for week {{weeknummer}} of project {{projectNumber}} — {{projectName}} was closed on {{directievoeringOp}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Progress: {{weekrapportVoortgang}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Approved terms {{geaccordeerdeTermijnenReferentie}} amount to EUR {{geaccordeerdeTermijnBedrag}} and fall {{termijnenContract}} the contract."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Work finished: {{werkGereed}}. While it is not, the next week begins."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Closed by the directievoerder"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-52/rip-weekstaat.document
+++ b/examples/organizations/flevoland/rip-phase-52/rip-weekstaat.document
@@ -1,0 +1,285 @@
+{
+  "id": "rip-weekstaat",
+  "name": "RIP — Weekly Statement (Weekstaat)",
+  "description": "The contractor weekly statement of quantities carried out, and its assessment by the toezichthouder and the directievoerder.",
+  "processKey": "RipR52Process",
+  "serviceId": "RipR52",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-02T00:00:00.000Z",
+  "updatedAt": "2026-09-02T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{weekstaatReferentie}}",
+      "variableKey": "weekstaatReferentie",
+      "source": "process",
+      "label": "Weekly statement reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{weeknummer}}",
+      "variableKey": "weeknummer",
+      "source": "process",
+      "label": "Week number"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{weekstaatOpgesteldOp}}",
+      "variableKey": "weekstaatOpgesteldOp",
+      "source": "process",
+      "label": "Drawn up on"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{weekstaatVerstuurdAan}}",
+      "variableKey": "weekstaatVerstuurdAan",
+      "source": "process",
+      "label": "Sent to"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{weekstaatVerstuurdOp}}",
+      "variableKey": "weekstaatVerstuurdOp",
+      "source": "process",
+      "label": "Sent on"
+    },
+    {
+      "id": "b8",
+      "placeholder": "{{weekstaatHoeveelheden}}",
+      "variableKey": "weekstaatHoeveelheden",
+      "source": "process",
+      "label": "Quantities"
+    },
+    {
+      "id": "b9",
+      "placeholder": "{{weekstaatBevindingenTzh}}",
+      "variableKey": "weekstaatBevindingenTzh",
+      "source": "process",
+      "label": "Toezichthouder findings"
+    },
+    {
+      "id": "b10",
+      "placeholder": "{{weekstaatBevindingenDv}}",
+      "variableKey": "weekstaatBevindingenDv",
+      "source": "process",
+      "label": "Directievoerder findings"
+    },
+    {
+      "id": "b11",
+      "placeholder": "{{weekstaatAkkoord}}",
+      "variableKey": "weekstaatAkkoord",
+      "source": "process",
+      "label": "Approved"
+    },
+    {
+      "id": "b12",
+      "placeholder": "{{weekstaatBedrag}}",
+      "variableKey": "weekstaatBedrag",
+      "source": "process",
+      "label": "Value entered"
+    },
+    {
+      "id": "b13",
+      "placeholder": "{{besteksadministratieReferentie}}",
+      "variableKey": "besteksadministratieReferentie",
+      "source": "process",
+      "label": "Specification administration"
+    },
+    {
+      "id": "b14",
+      "placeholder": "{{weekstaatIngevoerdOp}}",
+      "variableKey": "weekstaatIngevoerdOp",
+      "source": "process",
+      "label": "Entered on"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Weekstaat {{weekstaatReferentie}} · week {{weeknummer}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Weekly statement",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Weekly statement"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Weekstaat {{weekstaatReferentie}} for week {{weeknummer}} of project {{projectNumber}} — {{projectName}} was drawn up on {{weekstaatOpgesteldOp}} and sent to {{weekstaatVerstuurdAan}} on {{weekstaatVerstuurdOp}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Quantities carried out: {{weekstaatHoeveelheden}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Toezichthouder findings: {{weekstaatBevindingenTzh}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Directievoerder findings: {{weekstaatBevindingenDv}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Approved: {{weekstaatAkkoord}}. Once approved, EUR {{weekstaatBedrag}} is entered in specification administration {{besteksadministratieReferentie}} on {{weekstaatIngevoerdOp}}."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up by the contractor, assessed by the directievoerder"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}


### PR DESCRIPTION
Stacked on #61. **Merge #61 first.**

Models `R5_2 Directievoering en toezicht UAV 2007 DEF.pdf` (sheet dated 20-7-2026) as `RipR52Process`. The densest sheet in the ladder, and the only one whose subject is a **period** rather than a deliverable.

| | |
|---|---|
| Files | 48 (1 BPMN, 36 forms, 11 documents) |
| Nodes / flows / lanes | 56 / 67 / 7 |

## The period drove the structure

The sheet draws several streams running alongside each other for the duration of the work — the weekly weekstaat cycle, deviation reporting, invoicing, and the contractor's request to deliver or postpone delivery — and draws the weekly part looping until the work is done:

```
start → parallel split → { weekly cycle | invoicing | delivery request }
      → parallel join → R5.3
```

with the repetition confined to the weekly branch, where the sheet's own "Werk gereed?" loop sits.

**The flat alternative was rejected.** One loop containing every stream would force an invoice *and* a delivery request through every single week — not how the sheet reads, and it would deadlock a real instance on the parallel join.

Inside the weekly branch the weekstaat and afwijkingen streams fork again, because the sheet has the toezichthouder and the directievoerder assessing the same weekstaat independently before "Akkoord?" consumes both.

## Loops

| Loop | Trigger |
|---|---|
| weekstaat | rejected → contractor amends → resend for assessment |
| AWR overview | rejected → negotiate prices → resend for assessment |
| weekly cycle | work not finished → next week |

## The delivery-request branch

Forks in two as drawn: the letter chain (PL → AO → ondersteuner → AO → VISI) runs alongside the funding decision — *binnen* or *buiten krediet*, then a EUR 50.000 threshold choosing between the AO and concerndirecteur templates — and both end in the ATB webform.

## Roles

One is new: `rip-ondersteuner`. The sheet's "Aannemer" lane is the same party as R5.1's "ON", so it reuses `rip-opdrachtnemer` rather than introducing a second slug for the contractor.

## Verification

Faseladder contract holds. Both validators pass. All four parallel splits balance against their joins (3/3, 2/2, 2/2, 2/2); every exclusive gateway is either a decision with conditions on both legs or a merge.