### PR TITLE
feat(rip): add R6.1 Projectdecharge bundle for Flevoland

### DIFF
--- a/examples/organizations/flevoland/rip-phase-61/RipR61Process.bpmn
+++ b/examples/organizations/flevoland/rip-phase-61/RipR61Process.bpmn
@@ -1,0 +1,535 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:ronl="http://ronl.nl/schema/1.0" id="Definitions_RipR61Process" targetNamespace="http://example.com/rip-phase-61" exporter="Camunda Modeler" exporterVersion="5.45.0">
+  <bpmn:collaboration id="Collaboration_RipR61Process">
+    <bpmn:participant id="Participant_RipR61Process" name="R6.1 - Projectdecharge" processRef="RipR61Process" />
+  </bpmn:collaboration>
+  <bpmn:process id="RipR61Process" name="R6.1 - Projectdecharge" isExecutable="true" camunda:historyTimeToLive="180">
+    <bpmn:laneSet id="LaneSet_RipR61Process">
+      <bpmn:lane id="Lane_RipTeam" name="RIP-team">
+        <bpmn:flowNodeRef>Task_BesprekenEindevaluatie</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_BeheerderVestigingsmanager" name="Beheerder, Vestigingsmanager">
+        <bpmn:flowNodeRef>Task_BeoordelenOndertekenenOverdrachtsverklaring</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_OverdrachtsverklaringAkkoord</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_VersturenOndertekendeOverdrachtsverklaring</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_Projectondersteuner" name="Projectondersteuner">
+        <bpmn:flowNodeRef>Task_AanmakenFinancieelOverzicht</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_VersturenOverdrachtsverklaringTerOndertekening</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_InformerenPlOverOndertekening</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_PlannenAfspraakEindevaluatie</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_UpdatenEindevaluatie</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_VersturenGeaccordeerdDechargedossier</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_AfsluitenSplit</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_LatenSluitenProjectmap</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_LatenAanpassenRechtenRelatics</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_AfsluitenJoin</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndEvent_EindeProces</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_Projectleider" name="Projectleider">
+        <bpmn:flowNodeRef>StartEvent_R61</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_OpstartenDecharge</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_DechargeSplit</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_ControlerenOndertekenenFinancieelOverzicht</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_OpstellenOverdrachtsverklaring</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_VersturenOverdrachtsverklaring</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_OpstellenVersturenEindevaluatie</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_DechargeJoin</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_OpstellenDechargedossier</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_InformerenPoOverAkkoord</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_Financien" name="Financiën">
+        <bpmn:flowNodeRef>Task_InvullenFinancieelOverzicht</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_VerwerkenFinancieleEindstand</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_AO" name="AO">
+        <bpmn:flowNodeRef>Task_AccorderenDechargedossier</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+
+    <bpmn:startEvent id="StartEvent_R61" name="Start R6.1 - Projectdecharge&#10;(vanuit R5.4 Gereedmelden VISI)">
+      <bpmn:outgoing>Flow_StartEvent_R61_Task_OpstartenDecharge</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:userTask id="Task_OpstartenDecharge" name="Opstarten&#10;decharge" camunda:formRef="rip-opstarten-decharge" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
+      <bpmn:incoming>Flow_StartEvent_R61_Task_OpstartenDecharge</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_OpstartenDecharge_Gateway_DechargeSplit</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:parallelGateway id="Gateway_DechargeSplit">
+      <bpmn:incoming>Flow_Task_OpstartenDecharge_Gateway_DechargeSplit</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_DechargeSplit_Task_AanmakenFinancieelOverzicht</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_DechargeSplit_Task_OpstellenOverdrachtsverklaring</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_DechargeSplit_Task_OpstellenVersturenEindevaluatie</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:userTask id="Task_AanmakenFinancieelOverzicht" name="A. Aanmaken financieel overzicht voor decharge,&#10;opslaan in zaakmap DMS en versturen naar Financiën (cc PL)" camunda:formRef="rip-aanmaken-financieel-overzicht" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectondersteuner" ronl:documentRef="rip-financieel-overzicht-decharge">
+      <bpmn:incoming>Flow_Gateway_DechargeSplit_Task_AanmakenFinancieelOverzicht</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_AanmakenFinancieelOverzicht_Task_InvullenFinancieelOverzicht</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_InvullenFinancieelOverzicht" name="Invullen financieel overzicht voor decharge&#10;en versturen ter ondertekening naar PL" camunda:formRef="rip-invullen-financieel-overzicht" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-financien">
+      <bpmn:incoming>Flow_Task_AanmakenFinancieelOverzicht_Task_InvullenFinancieelOverzicht</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_InvullenFinancieelOverzicht_Task_ControlerenOndertekenenFinancieelOverzicht</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_ControlerenOndertekenenFinancieelOverzicht" name="Controleren en ondertekenen&#10;financieel overzicht voor decharge" camunda:formRef="rip-controleren-ondertekenen-financieel-overzicht" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
+      <bpmn:incoming>Flow_Task_InvullenFinancieelOverzicht_Task_ControlerenOndertekenenFinancieelOverzicht</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_ControlerenOndertekenenFinancieelOverzicht_Gateway_DechargeJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_OpstellenOverdrachtsverklaring" name="B. Opstellen&#10;overdrachtsverklaring" camunda:formRef="rip-opstellen-overdrachtsverklaring" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-overdrachtsverklaring">
+      <bpmn:incoming>Flow_Gateway_DechargeSplit_Task_OpstellenOverdrachtsverklaring</bpmn:incoming>
+      <bpmn:incoming>Flow_Gateway_OverdrachtsverklaringAkkoord_Task_OpstellenOverdrachtsverklaring</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_OpstellenOverdrachtsverklaring_Task_VersturenOverdrachtsverklaring</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_VersturenOverdrachtsverklaring" name="Versturen&#10;overdrachtsverklaring" camunda:formRef="rip-versturen-overdrachtsverklaring" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
+      <bpmn:incoming>Flow_Task_OpstellenOverdrachtsverklaring_Task_VersturenOverdrachtsverklaring</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_VersturenOverdrachtsverklaring_Task_VersturenOverdrachtsverklaringTerOndertekening</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_VersturenOverdrachtsverklaringTerOndertekening" name="Versturen overdrachtsverklaring aan&#10;Beheerder en VM ter ondertekening" camunda:formRef="rip-versturen-overdrachtsverklaring-ondertekening" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectondersteuner">
+      <bpmn:incoming>Flow_Task_VersturenOverdrachtsverklaring_Task_VersturenOverdrachtsverklaringTerOndertekening</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_VersturenOverdrachtsverklaringTerOndertekening_Task_BeoordelenOndertekenenOverdrachtsverklaring</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_BeoordelenOndertekenenOverdrachtsverklaring" name="Beoordelen en ondertekenen&#10;overdrachtsverklaring" camunda:formRef="rip-beoordelen-ondertekenen-overdrachtsverklaring" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-beheerder,rip-vestigingsmanager">
+      <bpmn:incoming>Flow_Task_VersturenOverdrachtsverklaringTerOndertekening_Task_BeoordelenOndertekenenOverdrachtsverklaring</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_BeoordelenOndertekenenOverdrachtsverklaring_Gateway_OverdrachtsverklaringAkkoord</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_OverdrachtsverklaringAkkoord" name="Akkoord?">
+      <bpmn:incoming>Flow_Task_BeoordelenOndertekenenOverdrachtsverklaring_Gateway_OverdrachtsverklaringAkkoord</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_OverdrachtsverklaringAkkoord_Task_OpstellenOverdrachtsverklaring</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_OverdrachtsverklaringAkkoord_Task_VersturenOndertekendeOverdrachtsverklaring</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Task_VersturenOndertekendeOverdrachtsverklaring" name="Versturen ondertekende&#10;overdrachtsverklaring naar PO" camunda:formRef="rip-versturen-ondertekende-overdrachtsverklaring" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-beheerder,rip-vestigingsmanager">
+      <bpmn:incoming>Flow_Gateway_OverdrachtsverklaringAkkoord_Task_VersturenOndertekendeOverdrachtsverklaring</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_VersturenOndertekendeOverdrachtsverklaring_Task_InformerenPlOverOndertekening</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_InformerenPlOverOndertekening" name="Informeren PL over ondertekenen&#10;overdrachtsverklaring" camunda:formRef="rip-informeren-pl-ondertekening" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectondersteuner">
+      <bpmn:incoming>Flow_Task_VersturenOndertekendeOverdrachtsverklaring_Task_InformerenPlOverOndertekening</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_InformerenPlOverOndertekening_Gateway_DechargeJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_OpstellenVersturenEindevaluatie" name="C. Opstellen en&#10;versturen eindevaluatie" camunda:formRef="rip-opstellen-versturen-eindevaluatie" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-eindevaluatie">
+      <bpmn:incoming>Flow_Gateway_DechargeSplit_Task_OpstellenVersturenEindevaluatie</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_OpstellenVersturenEindevaluatie_Task_PlannenAfspraakEindevaluatie</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_PlannenAfspraakEindevaluatie" name="Plannen afspraak RIP-team&#10;bespreken eindevaluatie" camunda:formRef="rip-plannen-afspraak-eindevaluatie" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectondersteuner">
+      <bpmn:incoming>Flow_Task_OpstellenVersturenEindevaluatie_Task_PlannenAfspraakEindevaluatie</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_PlannenAfspraakEindevaluatie_Task_BesprekenEindevaluatie</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_BesprekenEindevaluatie" name="Bespreken&#10;eindevaluatie" camunda:formRef="rip-bespreken-eindevaluatie" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-team">
+      <bpmn:incoming>Flow_Task_PlannenAfspraakEindevaluatie_Task_BesprekenEindevaluatie</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_BesprekenEindevaluatie_Task_UpdatenEindevaluatie</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_UpdatenEindevaluatie" name="Updaten eindevaluatie n.a.v.&#10;bespreking RIP-team" camunda:formRef="rip-updaten-eindevaluatie" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectondersteuner">
+      <bpmn:incoming>Flow_Task_BesprekenEindevaluatie_Task_UpdatenEindevaluatie</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_UpdatenEindevaluatie_Gateway_DechargeJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:parallelGateway id="Gateway_DechargeJoin">
+      <bpmn:incoming>Flow_Task_ControlerenOndertekenenFinancieelOverzicht_Gateway_DechargeJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_InformerenPlOverOndertekening_Gateway_DechargeJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_UpdatenEindevaluatie_Gateway_DechargeJoin</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_DechargeJoin_Task_OpstellenDechargedossier</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:userTask id="Task_OpstellenDechargedossier" name="Opstellen dechargedossier&#10;en versturen naar AO" camunda:formRef="rip-opstellen-dechargedossier" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider" ronl:documentRef="rip-dechargedossier">
+      <bpmn:incoming>Flow_Gateway_DechargeJoin_Task_OpstellenDechargedossier</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_OpstellenDechargedossier_Task_AccorderenDechargedossier</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_AccorderenDechargedossier" name="Accorderen dechargedossier&#10;en informeren PL" camunda:formRef="rip-accorderen-dechargedossier" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-ao">
+      <bpmn:incoming>Flow_Task_OpstellenDechargedossier_Task_AccorderenDechargedossier</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_AccorderenDechargedossier_Task_InformerenPoOverAkkoord</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_InformerenPoOverAkkoord" name="Informeren PO&#10;over akkoord AO" camunda:formRef="rip-informeren-po-akkoord" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectleider">
+      <bpmn:incoming>Flow_Task_AccorderenDechargedossier_Task_InformerenPoOverAkkoord</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_InformerenPoOverAkkoord_Task_VersturenGeaccordeerdDechargedossier</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_VersturenGeaccordeerdDechargedossier" name="Versturen geaccordeerd&#10;dechargedossier aan Financiën" camunda:formRef="rip-versturen-geaccordeerd-dechargedossier" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectondersteuner">
+      <bpmn:incoming>Flow_Task_InformerenPoOverAkkoord_Task_VersturenGeaccordeerdDechargedossier</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_VersturenGeaccordeerdDechargedossier_Gateway_AfsluitenSplit</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:parallelGateway id="Gateway_AfsluitenSplit">
+      <bpmn:incoming>Flow_Task_VersturenGeaccordeerdDechargedossier_Gateway_AfsluitenSplit</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_AfsluitenSplit_Task_VerwerkenFinancieleEindstand</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_AfsluitenSplit_Task_LatenSluitenProjectmap</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gateway_AfsluitenSplit_Task_LatenAanpassenRechtenRelatics</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:userTask id="Task_VerwerkenFinancieleEindstand" name="Verwerken financiële eindstand uit&#10;dechargedossier in raamkrediet Infra" camunda:formRef="rip-verwerken-financiele-eindstand" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-financien">
+      <bpmn:incoming>Flow_Gateway_AfsluitenSplit_Task_VerwerkenFinancieleEindstand</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_VerwerkenFinancieleEindstand_Gateway_AfsluitenJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_LatenSluitenProjectmap" name="Laten sluiten projectmap in DMS&#10;via TopDeskmelding" camunda:formRef="rip-laten-sluiten-projectmap" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectondersteuner">
+      <bpmn:incoming>Flow_Gateway_AfsluitenSplit_Task_LatenSluitenProjectmap</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_LatenSluitenProjectmap_Gateway_AfsluitenJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_LatenAanpassenRechtenRelatics" name="Laten aanpassen rechten&#10;workspace Relatics" camunda:formRef="rip-laten-aanpassen-rechten-relatics" camunda:formRefBinding="deployment" camunda:candidateGroups="rip-projectondersteuner">
+      <bpmn:incoming>Flow_Gateway_AfsluitenSplit_Task_LatenAanpassenRechtenRelatics</bpmn:incoming>
+      <bpmn:outgoing>Flow_Task_LatenAanpassenRechtenRelatics_Gateway_AfsluitenJoin</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:parallelGateway id="Gateway_AfsluitenJoin">
+      <bpmn:incoming>Flow_Task_VerwerkenFinancieleEindstand_Gateway_AfsluitenJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_LatenSluitenProjectmap_Gateway_AfsluitenJoin</bpmn:incoming>
+      <bpmn:incoming>Flow_Task_LatenAanpassenRechtenRelatics_Gateway_AfsluitenJoin</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gateway_AfsluitenJoin_EndEvent_EindeProces</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:endEvent id="EndEvent_EindeProces" name="Einde proces&#10;(project gedechargeerd)">
+      <bpmn:incoming>Flow_Gateway_AfsluitenJoin_EndEvent_EindeProces</bpmn:incoming>
+    </bpmn:endEvent>
+
+    <bpmn:sequenceFlow id="Flow_StartEvent_R61_Task_OpstartenDecharge" sourceRef="StartEvent_R61" targetRef="Task_OpstartenDecharge" />
+    <bpmn:sequenceFlow id="Flow_Task_OpstartenDecharge_Gateway_DechargeSplit" sourceRef="Task_OpstartenDecharge" targetRef="Gateway_DechargeSplit" />
+    <bpmn:sequenceFlow id="Flow_Gateway_DechargeSplit_Task_AanmakenFinancieelOverzicht" name="A. Fin. overzicht decharge" sourceRef="Gateway_DechargeSplit" targetRef="Task_AanmakenFinancieelOverzicht" />
+    <bpmn:sequenceFlow id="Flow_Gateway_DechargeSplit_Task_OpstellenOverdrachtsverklaring" name="B. Overdrachtsverklaring" sourceRef="Gateway_DechargeSplit" targetRef="Task_OpstellenOverdrachtsverklaring" />
+    <bpmn:sequenceFlow id="Flow_Gateway_DechargeSplit_Task_OpstellenVersturenEindevaluatie" name="C. Eindevaluatie" sourceRef="Gateway_DechargeSplit" targetRef="Task_OpstellenVersturenEindevaluatie" />
+    <bpmn:sequenceFlow id="Flow_Task_AanmakenFinancieelOverzicht_Task_InvullenFinancieelOverzicht" sourceRef="Task_AanmakenFinancieelOverzicht" targetRef="Task_InvullenFinancieelOverzicht" />
+    <bpmn:sequenceFlow id="Flow_Task_InvullenFinancieelOverzicht_Task_ControlerenOndertekenenFinancieelOverzicht" sourceRef="Task_InvullenFinancieelOverzicht" targetRef="Task_ControlerenOndertekenenFinancieelOverzicht" />
+    <bpmn:sequenceFlow id="Flow_Task_ControlerenOndertekenenFinancieelOverzicht_Gateway_DechargeJoin" sourceRef="Task_ControlerenOndertekenenFinancieelOverzicht" targetRef="Gateway_DechargeJoin" />
+    <bpmn:sequenceFlow id="Flow_Task_OpstellenOverdrachtsverklaring_Task_VersturenOverdrachtsverklaring" sourceRef="Task_OpstellenOverdrachtsverklaring" targetRef="Task_VersturenOverdrachtsverklaring" />
+    <bpmn:sequenceFlow id="Flow_Task_VersturenOverdrachtsverklaring_Task_VersturenOverdrachtsverklaringTerOndertekening" sourceRef="Task_VersturenOverdrachtsverklaring" targetRef="Task_VersturenOverdrachtsverklaringTerOndertekening" />
+    <bpmn:sequenceFlow id="Flow_Task_VersturenOverdrachtsverklaringTerOndertekening_Task_BeoordelenOndertekenenOverdrachtsverklaring" sourceRef="Task_VersturenOverdrachtsverklaringTerOndertekening" targetRef="Task_BeoordelenOndertekenenOverdrachtsverklaring" />
+    <bpmn:sequenceFlow id="Flow_Task_BeoordelenOndertekenenOverdrachtsverklaring_Gateway_OverdrachtsverklaringAkkoord" sourceRef="Task_BeoordelenOndertekenenOverdrachtsverklaring" targetRef="Gateway_OverdrachtsverklaringAkkoord" />
+    <bpmn:sequenceFlow id="Flow_Gateway_OverdrachtsverklaringAkkoord_Task_OpstellenOverdrachtsverklaring" name="nee" sourceRef="Gateway_OverdrachtsverklaringAkkoord" targetRef="Task_OpstellenOverdrachtsverklaring">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${overdrachtsverklaringAkkoord == "nee"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gateway_OverdrachtsverklaringAkkoord_Task_VersturenOndertekendeOverdrachtsverklaring" name="ja" sourceRef="Gateway_OverdrachtsverklaringAkkoord" targetRef="Task_VersturenOndertekendeOverdrachtsverklaring">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${overdrachtsverklaringAkkoord == "ja"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Task_VersturenOndertekendeOverdrachtsverklaring_Task_InformerenPlOverOndertekening" sourceRef="Task_VersturenOndertekendeOverdrachtsverklaring" targetRef="Task_InformerenPlOverOndertekening" />
+    <bpmn:sequenceFlow id="Flow_Task_InformerenPlOverOndertekening_Gateway_DechargeJoin" sourceRef="Task_InformerenPlOverOndertekening" targetRef="Gateway_DechargeJoin" />
+    <bpmn:sequenceFlow id="Flow_Task_OpstellenVersturenEindevaluatie_Task_PlannenAfspraakEindevaluatie" sourceRef="Task_OpstellenVersturenEindevaluatie" targetRef="Task_PlannenAfspraakEindevaluatie" />
+    <bpmn:sequenceFlow id="Flow_Task_PlannenAfspraakEindevaluatie_Task_BesprekenEindevaluatie" sourceRef="Task_PlannenAfspraakEindevaluatie" targetRef="Task_BesprekenEindevaluatie" />
+    <bpmn:sequenceFlow id="Flow_Task_BesprekenEindevaluatie_Task_UpdatenEindevaluatie" sourceRef="Task_BesprekenEindevaluatie" targetRef="Task_UpdatenEindevaluatie" />
+    <bpmn:sequenceFlow id="Flow_Task_UpdatenEindevaluatie_Gateway_DechargeJoin" sourceRef="Task_UpdatenEindevaluatie" targetRef="Gateway_DechargeJoin" />
+    <bpmn:sequenceFlow id="Flow_Gateway_DechargeJoin_Task_OpstellenDechargedossier" sourceRef="Gateway_DechargeJoin" targetRef="Task_OpstellenDechargedossier" />
+    <bpmn:sequenceFlow id="Flow_Task_OpstellenDechargedossier_Task_AccorderenDechargedossier" sourceRef="Task_OpstellenDechargedossier" targetRef="Task_AccorderenDechargedossier" />
+    <bpmn:sequenceFlow id="Flow_Task_AccorderenDechargedossier_Task_InformerenPoOverAkkoord" sourceRef="Task_AccorderenDechargedossier" targetRef="Task_InformerenPoOverAkkoord" />
+    <bpmn:sequenceFlow id="Flow_Task_InformerenPoOverAkkoord_Task_VersturenGeaccordeerdDechargedossier" sourceRef="Task_InformerenPoOverAkkoord" targetRef="Task_VersturenGeaccordeerdDechargedossier" />
+    <bpmn:sequenceFlow id="Flow_Task_VersturenGeaccordeerdDechargedossier_Gateway_AfsluitenSplit" sourceRef="Task_VersturenGeaccordeerdDechargedossier" targetRef="Gateway_AfsluitenSplit" />
+    <bpmn:sequenceFlow id="Flow_Gateway_AfsluitenSplit_Task_VerwerkenFinancieleEindstand" sourceRef="Gateway_AfsluitenSplit" targetRef="Task_VerwerkenFinancieleEindstand" />
+    <bpmn:sequenceFlow id="Flow_Gateway_AfsluitenSplit_Task_LatenSluitenProjectmap" sourceRef="Gateway_AfsluitenSplit" targetRef="Task_LatenSluitenProjectmap" />
+    <bpmn:sequenceFlow id="Flow_Gateway_AfsluitenSplit_Task_LatenAanpassenRechtenRelatics" sourceRef="Gateway_AfsluitenSplit" targetRef="Task_LatenAanpassenRechtenRelatics" />
+    <bpmn:sequenceFlow id="Flow_Task_VerwerkenFinancieleEindstand_Gateway_AfsluitenJoin" sourceRef="Task_VerwerkenFinancieleEindstand" targetRef="Gateway_AfsluitenJoin" />
+    <bpmn:sequenceFlow id="Flow_Task_LatenSluitenProjectmap_Gateway_AfsluitenJoin" sourceRef="Task_LatenSluitenProjectmap" targetRef="Gateway_AfsluitenJoin" />
+    <bpmn:sequenceFlow id="Flow_Task_LatenAanpassenRechtenRelatics_Gateway_AfsluitenJoin" sourceRef="Task_LatenAanpassenRechtenRelatics" targetRef="Gateway_AfsluitenJoin" />
+    <bpmn:sequenceFlow id="Flow_Gateway_AfsluitenJoin_EndEvent_EindeProces" sourceRef="Gateway_AfsluitenJoin" targetRef="EndEvent_EindeProces" />
+
+    <bpmn:textAnnotation id="Annotation_R54_Entry">
+      <bpmn:text>R5.4 Gereedmelden VISI — de decharge start zodra het werk in VISI gereed is gemeld</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Assoc_Annotation_R54_Entry" sourceRef="Task_OpstartenDecharge" targetRef="Annotation_R54_Entry" />
+    <bpmn:textAnnotation id="Annotation_EindeProces">
+      <bpmn:text>De sheet tekent twee markers "Einde proces", één per afsluitende PO-actie. Ze betekenen dezelfde afronding en zijn hier samengevoegd tot één eindgebeurtenis achter de join.</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Assoc_Annotation_EindeProces" sourceRef="Gateway_AfsluitenJoin" targetRef="Annotation_EindeProces" />
+  </bpmn:process>
+
+  <bpmndi:BPMNDiagram id="BPMNDiagram_RipR61Process">
+    <bpmndi:BPMNPlane id="BPMNPlane_RipR61Process" bpmnElement="Collaboration_RipR61Process">
+      <bpmndi:BPMNShape id="Participant_RipR61Process_di" bpmnElement="Participant_RipR61Process" isHorizontal="true">
+        <dc:Bounds x="160" y="80" width="2566" height="1220" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_RipTeam_di" bpmnElement="Lane_RipTeam" isHorizontal="true">
+        <dc:Bounds x="190" y="80" width="2536" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_BeheerderVestigingsmanager_di" bpmnElement="Lane_BeheerderVestigingsmanager" isHorizontal="true">
+        <dc:Bounds x="190" y="200" width="2536" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Projectondersteuner_di" bpmnElement="Lane_Projectondersteuner" isHorizontal="true">
+        <dc:Bounds x="190" y="400" width="2536" height="290" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Projectleider_di" bpmnElement="Lane_Projectleider" isHorizontal="true">
+        <dc:Bounds x="190" y="690" width="2536" height="290" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_Financien_di" bpmnElement="Lane_Financien" isHorizontal="true">
+        <dc:Bounds x="190" y="980" width="2536" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_AO_di" bpmnElement="Lane_AO" isHorizontal="true">
+        <dc:Bounds x="190" y="1180" width="2536" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_R61_di" bpmnElement="StartEvent_R61">
+        <dc:Bounds x="240" y="732" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="134" y="773" width="248" height="28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_OpstartenDecharge_di" bpmnElement="Task_OpstartenDecharge">
+        <dc:Bounds x="300" y="710" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_DechargeSplit_di" bpmnElement="Gateway_DechargeSplit">
+        <dc:Bounds x="460" y="725" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_AanmakenFinancieelOverzicht_di" bpmnElement="Task_AanmakenFinancieelOverzicht">
+        <dc:Bounds x="540" y="420" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_InvullenFinancieelOverzicht_di" bpmnElement="Task_InvullenFinancieelOverzicht">
+        <dc:Bounds x="700" y="1000" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_ControlerenOndertekenenFinancieelOverzicht_di" bpmnElement="Task_ControlerenOndertekenenFinancieelOverzicht">
+        <dc:Bounds x="860" y="710" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_OpstellenOverdrachtsverklaring_di" bpmnElement="Task_OpstellenOverdrachtsverklaring">
+        <dc:Bounds x="540" y="800" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_VersturenOverdrachtsverklaring_di" bpmnElement="Task_VersturenOverdrachtsverklaring">
+        <dc:Bounds x="700" y="800" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_VersturenOverdrachtsverklaringTerOndertekening_di" bpmnElement="Task_VersturenOverdrachtsverklaringTerOndertekening">
+        <dc:Bounds x="860" y="510" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_BeoordelenOndertekenenOverdrachtsverklaring_di" bpmnElement="Task_BeoordelenOndertekenenOverdrachtsverklaring">
+        <dc:Bounds x="1020" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_OverdrachtsverklaringAkkoord_di" bpmnElement="Gateway_OverdrachtsverklaringAkkoord" isMarkerVisible="true">
+        <dc:Bounds x="1180" y="235" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1160" y="290" width="90" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_VersturenOndertekendeOverdrachtsverklaring_di" bpmnElement="Task_VersturenOndertekendeOverdrachtsverklaring">
+        <dc:Bounds x="1260" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_InformerenPlOverOndertekening_di" bpmnElement="Task_InformerenPlOverOndertekening">
+        <dc:Bounds x="1420" y="420" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_OpstellenVersturenEindevaluatie_di" bpmnElement="Task_OpstellenVersturenEindevaluatie">
+        <dc:Bounds x="540" y="890" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_PlannenAfspraakEindevaluatie_di" bpmnElement="Task_PlannenAfspraakEindevaluatie">
+        <dc:Bounds x="700" y="600" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_BesprekenEindevaluatie_di" bpmnElement="Task_BesprekenEindevaluatie">
+        <dc:Bounds x="860" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_UpdatenEindevaluatie_di" bpmnElement="Task_UpdatenEindevaluatie">
+        <dc:Bounds x="1020" y="600" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_DechargeJoin_di" bpmnElement="Gateway_DechargeJoin">
+        <dc:Bounds x="1580" y="725" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_OpstellenDechargedossier_di" bpmnElement="Task_OpstellenDechargedossier">
+        <dc:Bounds x="1660" y="710" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_AccorderenDechargedossier_di" bpmnElement="Task_AccorderenDechargedossier">
+        <dc:Bounds x="1820" y="1200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_InformerenPoOverAkkoord_di" bpmnElement="Task_InformerenPoOverAkkoord">
+        <dc:Bounds x="1980" y="710" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_VersturenGeaccordeerdDechargedossier_di" bpmnElement="Task_VersturenGeaccordeerdDechargedossier">
+        <dc:Bounds x="2140" y="420" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_AfsluitenSplit_di" bpmnElement="Gateway_AfsluitenSplit">
+        <dc:Bounds x="2300" y="435" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_VerwerkenFinancieleEindstand_di" bpmnElement="Task_VerwerkenFinancieleEindstand">
+        <dc:Bounds x="2380" y="1090" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_LatenSluitenProjectmap_di" bpmnElement="Task_LatenSluitenProjectmap">
+        <dc:Bounds x="2380" y="420" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_LatenAanpassenRechtenRelatics_di" bpmnElement="Task_LatenAanpassenRechtenRelatics">
+        <dc:Bounds x="2380" y="510" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_AfsluitenJoin_di" bpmnElement="Gateway_AfsluitenJoin">
+        <dc:Bounds x="2540" y="435" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_EindeProces_di" bpmnElement="EndEvent_EindeProces">
+        <dc:Bounds x="2620" y="442" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2546" y="483" width="184" height="28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Annotation_R54_Entry_di" bpmnElement="Annotation_R54_Entry">
+        <dc:Bounds x="240" y="890" width="280" height="60" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Annotation_EindeProces_di" bpmnElement="Annotation_EindeProces">
+        <dc:Bounds x="2300" y="600" width="320" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_StartEvent_R61_Task_OpstartenDecharge_di" bpmnElement="Flow_StartEvent_R61_Task_OpstartenDecharge">
+        <di:waypoint x="276" y="750" />
+        <di:waypoint x="300" y="750" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_OpstartenDecharge_Gateway_DechargeSplit_di" bpmnElement="Flow_Task_OpstartenDecharge_Gateway_DechargeSplit">
+        <di:waypoint x="400" y="750" />
+        <di:waypoint x="460" y="750" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_DechargeSplit_Task_AanmakenFinancieelOverzicht_di" bpmnElement="Flow_Gateway_DechargeSplit_Task_AanmakenFinancieelOverzicht">
+        <di:waypoint x="510" y="750" />
+        <di:waypoint x="525" y="750" />
+        <di:waypoint x="525" y="460" />
+        <di:waypoint x="540" y="460" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="516" y="730" width="208" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_DechargeSplit_Task_OpstellenOverdrachtsverklaring_di" bpmnElement="Flow_Gateway_DechargeSplit_Task_OpstellenOverdrachtsverklaring">
+        <di:waypoint x="510" y="750" />
+        <di:waypoint x="525" y="750" />
+        <di:waypoint x="525" y="840" />
+        <di:waypoint x="540" y="840" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="516" y="730" width="192" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_DechargeSplit_Task_OpstellenVersturenEindevaluatie_di" bpmnElement="Flow_Gateway_DechargeSplit_Task_OpstellenVersturenEindevaluatie">
+        <di:waypoint x="510" y="750" />
+        <di:waypoint x="525" y="750" />
+        <di:waypoint x="525" y="930" />
+        <di:waypoint x="540" y="930" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="516" y="730" width="128" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_AanmakenFinancieelOverzicht_Task_InvullenFinancieelOverzicht_di" bpmnElement="Flow_Task_AanmakenFinancieelOverzicht_Task_InvullenFinancieelOverzicht">
+        <di:waypoint x="640" y="460" />
+        <di:waypoint x="670" y="460" />
+        <di:waypoint x="670" y="1040" />
+        <di:waypoint x="700" y="1040" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_InvullenFinancieelOverzicht_Task_ControlerenOndertekenenFinancieelOverzicht_di" bpmnElement="Flow_Task_InvullenFinancieelOverzicht_Task_ControlerenOndertekenenFinancieelOverzicht">
+        <di:waypoint x="800" y="1040" />
+        <di:waypoint x="830" y="1040" />
+        <di:waypoint x="830" y="750" />
+        <di:waypoint x="860" y="750" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_ControlerenOndertekenenFinancieelOverzicht_Gateway_DechargeJoin_di" bpmnElement="Flow_Task_ControlerenOndertekenenFinancieelOverzicht_Gateway_DechargeJoin">
+        <di:waypoint x="960" y="750" />
+        <di:waypoint x="1580" y="750" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_OpstellenOverdrachtsverklaring_Task_VersturenOverdrachtsverklaring_di" bpmnElement="Flow_Task_OpstellenOverdrachtsverklaring_Task_VersturenOverdrachtsverklaring">
+        <di:waypoint x="640" y="840" />
+        <di:waypoint x="700" y="840" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_VersturenOverdrachtsverklaring_Task_VersturenOverdrachtsverklaringTerOndertekening_di" bpmnElement="Flow_Task_VersturenOverdrachtsverklaring_Task_VersturenOverdrachtsverklaringTerOndertekening">
+        <di:waypoint x="800" y="840" />
+        <di:waypoint x="830" y="840" />
+        <di:waypoint x="830" y="550" />
+        <di:waypoint x="860" y="550" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_VersturenOverdrachtsverklaringTerOndertekening_Task_BeoordelenOndertekenenOverdrachtsverklaring_di" bpmnElement="Flow_Task_VersturenOverdrachtsverklaringTerOndertekening_Task_BeoordelenOndertekenenOverdrachtsverklaring">
+        <di:waypoint x="960" y="550" />
+        <di:waypoint x="990" y="550" />
+        <di:waypoint x="990" y="260" />
+        <di:waypoint x="1020" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_BeoordelenOndertekenenOverdrachtsverklaring_Gateway_OverdrachtsverklaringAkkoord_di" bpmnElement="Flow_Task_BeoordelenOndertekenenOverdrachtsverklaring_Gateway_OverdrachtsverklaringAkkoord">
+        <di:waypoint x="1120" y="260" />
+        <di:waypoint x="1180" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_OverdrachtsverklaringAkkoord_Task_OpstellenOverdrachtsverklaring_di" bpmnElement="Flow_Gateway_OverdrachtsverklaringAkkoord_Task_OpstellenOverdrachtsverklaring">
+        <di:waypoint x="1205" y="285" />
+        <di:waypoint x="1205" y="975" />
+        <di:waypoint x="590" y="975" />
+        <di:waypoint x="590" y="880" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1211" y="265" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_OverdrachtsverklaringAkkoord_Task_VersturenOndertekendeOverdrachtsverklaring_di" bpmnElement="Flow_Gateway_OverdrachtsverklaringAkkoord_Task_VersturenOndertekendeOverdrachtsverklaring">
+        <di:waypoint x="1230" y="260" />
+        <di:waypoint x="1260" y="260" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1236" y="240" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_VersturenOndertekendeOverdrachtsverklaring_Task_InformerenPlOverOndertekening_di" bpmnElement="Flow_Task_VersturenOndertekendeOverdrachtsverklaring_Task_InformerenPlOverOndertekening">
+        <di:waypoint x="1360" y="260" />
+        <di:waypoint x="1390" y="260" />
+        <di:waypoint x="1390" y="460" />
+        <di:waypoint x="1420" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_InformerenPlOverOndertekening_Gateway_DechargeJoin_di" bpmnElement="Flow_Task_InformerenPlOverOndertekening_Gateway_DechargeJoin">
+        <di:waypoint x="1520" y="460" />
+        <di:waypoint x="1550" y="460" />
+        <di:waypoint x="1550" y="750" />
+        <di:waypoint x="1580" y="750" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_OpstellenVersturenEindevaluatie_Task_PlannenAfspraakEindevaluatie_di" bpmnElement="Flow_Task_OpstellenVersturenEindevaluatie_Task_PlannenAfspraakEindevaluatie">
+        <di:waypoint x="640" y="930" />
+        <di:waypoint x="670" y="930" />
+        <di:waypoint x="670" y="640" />
+        <di:waypoint x="700" y="640" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_PlannenAfspraakEindevaluatie_Task_BesprekenEindevaluatie_di" bpmnElement="Flow_Task_PlannenAfspraakEindevaluatie_Task_BesprekenEindevaluatie">
+        <di:waypoint x="800" y="640" />
+        <di:waypoint x="830" y="640" />
+        <di:waypoint x="830" y="140" />
+        <di:waypoint x="860" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_BesprekenEindevaluatie_Task_UpdatenEindevaluatie_di" bpmnElement="Flow_Task_BesprekenEindevaluatie_Task_UpdatenEindevaluatie">
+        <di:waypoint x="960" y="140" />
+        <di:waypoint x="990" y="140" />
+        <di:waypoint x="990" y="640" />
+        <di:waypoint x="1020" y="640" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_UpdatenEindevaluatie_Gateway_DechargeJoin_di" bpmnElement="Flow_Task_UpdatenEindevaluatie_Gateway_DechargeJoin">
+        <di:waypoint x="1120" y="640" />
+        <di:waypoint x="1350" y="640" />
+        <di:waypoint x="1350" y="750" />
+        <di:waypoint x="1580" y="750" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_DechargeJoin_Task_OpstellenDechargedossier_di" bpmnElement="Flow_Gateway_DechargeJoin_Task_OpstellenDechargedossier">
+        <di:waypoint x="1630" y="750" />
+        <di:waypoint x="1660" y="750" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_OpstellenDechargedossier_Task_AccorderenDechargedossier_di" bpmnElement="Flow_Task_OpstellenDechargedossier_Task_AccorderenDechargedossier">
+        <di:waypoint x="1760" y="750" />
+        <di:waypoint x="1790" y="750" />
+        <di:waypoint x="1790" y="1240" />
+        <di:waypoint x="1820" y="1240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_AccorderenDechargedossier_Task_InformerenPoOverAkkoord_di" bpmnElement="Flow_Task_AccorderenDechargedossier_Task_InformerenPoOverAkkoord">
+        <di:waypoint x="1920" y="1240" />
+        <di:waypoint x="1950" y="1240" />
+        <di:waypoint x="1950" y="750" />
+        <di:waypoint x="1980" y="750" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_InformerenPoOverAkkoord_Task_VersturenGeaccordeerdDechargedossier_di" bpmnElement="Flow_Task_InformerenPoOverAkkoord_Task_VersturenGeaccordeerdDechargedossier">
+        <di:waypoint x="2080" y="750" />
+        <di:waypoint x="2110" y="750" />
+        <di:waypoint x="2110" y="460" />
+        <di:waypoint x="2140" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_VersturenGeaccordeerdDechargedossier_Gateway_AfsluitenSplit_di" bpmnElement="Flow_Task_VersturenGeaccordeerdDechargedossier_Gateway_AfsluitenSplit">
+        <di:waypoint x="2240" y="460" />
+        <di:waypoint x="2300" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_AfsluitenSplit_Task_VerwerkenFinancieleEindstand_di" bpmnElement="Flow_Gateway_AfsluitenSplit_Task_VerwerkenFinancieleEindstand">
+        <di:waypoint x="2350" y="460" />
+        <di:waypoint x="2365" y="460" />
+        <di:waypoint x="2365" y="1130" />
+        <di:waypoint x="2380" y="1130" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_AfsluitenSplit_Task_LatenSluitenProjectmap_di" bpmnElement="Flow_Gateway_AfsluitenSplit_Task_LatenSluitenProjectmap">
+        <di:waypoint x="2350" y="460" />
+        <di:waypoint x="2380" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_AfsluitenSplit_Task_LatenAanpassenRechtenRelatics_di" bpmnElement="Flow_Gateway_AfsluitenSplit_Task_LatenAanpassenRechtenRelatics">
+        <di:waypoint x="2350" y="460" />
+        <di:waypoint x="2365" y="460" />
+        <di:waypoint x="2365" y="550" />
+        <di:waypoint x="2380" y="550" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_VerwerkenFinancieleEindstand_Gateway_AfsluitenJoin_di" bpmnElement="Flow_Task_VerwerkenFinancieleEindstand_Gateway_AfsluitenJoin">
+        <di:waypoint x="2480" y="1130" />
+        <di:waypoint x="2510" y="1130" />
+        <di:waypoint x="2510" y="460" />
+        <di:waypoint x="2540" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_LatenSluitenProjectmap_Gateway_AfsluitenJoin_di" bpmnElement="Flow_Task_LatenSluitenProjectmap_Gateway_AfsluitenJoin">
+        <di:waypoint x="2480" y="460" />
+        <di:waypoint x="2540" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Task_LatenAanpassenRechtenRelatics_Gateway_AfsluitenJoin_di" bpmnElement="Flow_Task_LatenAanpassenRechtenRelatics_Gateway_AfsluitenJoin">
+        <di:waypoint x="2480" y="550" />
+        <di:waypoint x="2510" y="550" />
+        <di:waypoint x="2510" y="460" />
+        <di:waypoint x="2540" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Gateway_AfsluitenJoin_EndEvent_EindeProces_di" bpmnElement="Flow_Gateway_AfsluitenJoin_EndEvent_EindeProces">
+        <di:waypoint x="2590" y="460" />
+        <di:waypoint x="2620" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Assoc_Annotation_R54_Entry_di" bpmnElement="Assoc_Annotation_R54_Entry">
+        <di:waypoint x="350" y="710" />
+        <di:waypoint x="380" y="950" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Assoc_Annotation_EindeProces_di" bpmnElement="Assoc_Annotation_EindeProces">
+        <di:waypoint x="2565" y="435" />
+        <di:waypoint x="2460" y="680" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/examples/organizations/flevoland/rip-phase-61/rip-aanmaken-financieel-overzicht.form
+++ b/examples/organizations/flevoland/rip-phase-61/rip-aanmaken-financieel-overzicht.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-aanmaken-financieel-overzicht",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Create the financial overview for discharge"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The projectondersteuner creates the financieel overzicht voor decharge, files it in the case folder in the DMS and sends it to Financiën, with the projectleider in copy."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Financial overview reference",
+      "key": "financieelOverzichtReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Dms",
+      "type": "textfield",
+      "label": "DMS case folder reference",
+      "key": "zaakmapDmsReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Created on",
+      "key": "financieelOverzichtAangemaaktOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-61/rip-accorderen-dechargedossier.form
+++ b/examples/organizations/flevoland/rip-phase-61/rip-accorderen-dechargedossier.form
@@ -1,0 +1,71 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-accorderen-dechargedossier",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Approve the discharge dossier and inform the projectleider"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The AO approves the discharge dossier — discharging the project — and informs the projectleider."
+    },
+    {
+      "id": "F_Akkoord",
+      "type": "select",
+      "label": "Discharge dossier approved",
+      "key": "dechargedossierAkkoord",
+      "values": [
+        {
+          "label": "Yes",
+          "value": "ja"
+        },
+        {
+          "label": "No",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Door",
+      "type": "textfield",
+      "label": "Approved by",
+      "key": "dechargedossierAkkoordDoor",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Comments",
+      "key": "dechargedossierOpmerkingen"
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Approved on",
+      "key": "dechargedossierGeaccordeerdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-61/rip-beoordelen-ondertekenen-overdrachtsverklaring.form
+++ b/examples/organizations/flevoland/rip-phase-61/rip-beoordelen-ondertekenen-overdrachtsverklaring.form
@@ -1,0 +1,71 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-beoordelen-ondertekenen-overdrachtsverklaring",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Assess and sign the transfer declaration"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The beheerder and the vestigingsmanager assess the transfer declaration and sign it. Where they do not, it goes back to the projectleider to be redrafted."
+    },
+    {
+      "id": "F_Bevindingen",
+      "type": "textarea",
+      "label": "Assessment findings",
+      "key": "overdrachtsverklaringBevindingen",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Akkoord",
+      "type": "select",
+      "label": "Transfer declaration signed",
+      "key": "overdrachtsverklaringAkkoord",
+      "values": [
+        {
+          "label": "Yes",
+          "value": "ja"
+        },
+        {
+          "label": "No",
+          "value": "nee"
+        }
+      ],
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Door",
+      "type": "textfield",
+      "label": "Signed by",
+      "key": "overdrachtsverklaringGetekendDoor"
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Assessed on",
+      "key": "overdrachtsverklaringBeoordeeldOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-61/rip-bespreken-eindevaluatie.form
+++ b/examples/organizations/flevoland/rip-phase-61/rip-bespreken-eindevaluatie.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-bespreken-eindevaluatie",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Discuss the final evaluation"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The RIP team discusses the final evaluation of the project process."
+    },
+    {
+      "id": "F_Aanwezig",
+      "type": "textarea",
+      "label": "Attendees",
+      "key": "eindevaluatieAanwezigen",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bespreking",
+      "type": "textarea",
+      "label": "What was discussed",
+      "key": "eindevaluatieBespreking",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Discussed on",
+      "key": "eindevaluatieBesprokenOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-61/rip-controleren-ondertekenen-financieel-overzicht.form
+++ b/examples/organizations/flevoland/rip-phase-61/rip-controleren-ondertekenen-financieel-overzicht.form
@@ -1,0 +1,52 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-controleren-ondertekenen-financieel-overzicht",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Check and sign the financial overview for discharge"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The projectleider checks the financial overview against the project and signs it."
+    },
+    {
+      "id": "F_Door",
+      "type": "textfield",
+      "label": "Signed by",
+      "key": "financieelOverzichtGetekendDoor",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bevindingen",
+      "type": "textarea",
+      "label": "Check findings",
+      "key": "financieelOverzichtBevindingen"
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Signed on",
+      "key": "financieelOverzichtGetekendOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-61/rip-dechargedossier.document
+++ b/examples/organizations/flevoland/rip-phase-61/rip-dechargedossier.document
@@ -1,0 +1,276 @@
+{
+  "id": "rip-dechargedossier",
+  "name": "RIP — Discharge Dossier (Dechargedossier)",
+  "description": "The dossier on which the AO discharges the project: the signed financial overview, the signed transfer declaration and the final evaluation.",
+  "processKey": "RipR61Process",
+  "serviceId": "RipR61",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-02T00:00:00.000Z",
+  "updatedAt": "2026-09-02T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{dechargedossierReferentie}}",
+      "variableKey": "dechargedossierReferentie",
+      "source": "process",
+      "label": "Discharge dossier reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{dechargedossierVerstuurdOp}}",
+      "variableKey": "dechargedossierVerstuurdOp",
+      "source": "process",
+      "label": "Sent on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{financieelOverzichtReferentie}}",
+      "variableKey": "financieelOverzichtReferentie",
+      "source": "process",
+      "label": "Financial overview reference"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{overdrachtsverklaringReferentie}}",
+      "variableKey": "overdrachtsverklaringReferentie",
+      "source": "process",
+      "label": "Transfer declaration reference"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{eindevaluatieReferentie}}",
+      "variableKey": "eindevaluatieReferentie",
+      "source": "process",
+      "label": "Final evaluation reference"
+    },
+    {
+      "id": "b8",
+      "placeholder": "{{dechargedossierInhoud}}",
+      "variableKey": "dechargedossierInhoud",
+      "source": "process",
+      "label": "Dossier contents"
+    },
+    {
+      "id": "b9",
+      "placeholder": "{{dechargedossierAkkoord}}",
+      "variableKey": "dechargedossierAkkoord",
+      "source": "process",
+      "label": "Approved"
+    },
+    {
+      "id": "b10",
+      "placeholder": "{{dechargedossierAkkoordDoor}}",
+      "variableKey": "dechargedossierAkkoordDoor",
+      "source": "process",
+      "label": "Approved by"
+    },
+    {
+      "id": "b11",
+      "placeholder": "{{dechargedossierGeaccordeerdOp}}",
+      "variableKey": "dechargedossierGeaccordeerdOp",
+      "source": "process",
+      "label": "Approved on"
+    },
+    {
+      "id": "b12",
+      "placeholder": "{{dechargedossierOpmerkingen}}",
+      "variableKey": "dechargedossierOpmerkingen",
+      "source": "process",
+      "label": "Comments"
+    },
+    {
+      "id": "b13",
+      "placeholder": "{{topdeskMeldingReferentie}}",
+      "variableKey": "topdeskMeldingReferentie",
+      "source": "process",
+      "label": "TopDesk request reference"
+    },
+    {
+      "id": "b14",
+      "placeholder": "{{relaticsWorkspace}}",
+      "variableKey": "relaticsWorkspace",
+      "source": "process",
+      "label": "Relatics workspace"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Dechargedossier {{dechargedossierReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Discharge dossier",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Discharge dossier"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Dechargedossier {{dechargedossierReferentie}} for project {{projectNumber}} — {{projectName}} was sent to the AO on {{dechargedossierVerstuurdOp}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "It brings together financial overview {{financieelOverzichtReferentie}}, transfer declaration {{overdrachtsverklaringReferentie}} and final evaluation {{eindevaluatieReferentie}}. {{dechargedossierInhoud}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Approved: {{dechargedossierAkkoord}}, by {{dechargedossierAkkoordDoor}} on {{dechargedossierGeaccordeerdOp}}. {{dechargedossierOpmerkingen}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "With approval the project is discharged: the financial end position goes into the Infra framework credit, the project folder is closed in the DMS under TopDesk request {{topdeskMeldingReferentie}}, and the rights on Relatics workspace {{relaticsWorkspace}} are adjusted."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Approved by the AO"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-61/rip-eindevaluatie.document
+++ b/examples/organizations/flevoland/rip-phase-61/rip-eindevaluatie.document
@@ -1,0 +1,264 @@
+{
+  "id": "rip-eindevaluatie",
+  "name": "RIP — Final Evaluation (Eindevaluatie RIP projectenproces)",
+  "description": "The final evaluation of the RIP project process, discussed with the RIP team and updated afterwards.",
+  "processKey": "RipR61Process",
+  "serviceId": "RipR61",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-02T00:00:00.000Z",
+  "updatedAt": "2026-09-02T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{eindevaluatieReferentie}}",
+      "variableKey": "eindevaluatieReferentie",
+      "source": "process",
+      "label": "Final evaluation reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{eindevaluatieOp}}",
+      "variableKey": "eindevaluatieOp",
+      "source": "process",
+      "label": "Drawn up on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{eindevaluatieGeleerd}}",
+      "variableKey": "eindevaluatieGeleerd",
+      "source": "process",
+      "label": "What was learned"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{eindevaluatieAanbevelingen}}",
+      "variableKey": "eindevaluatieAanbevelingen",
+      "source": "process",
+      "label": "Recommendations"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{eindevaluatieBesprokenOp}}",
+      "variableKey": "eindevaluatieBesprokenOp",
+      "source": "process",
+      "label": "Discussed on"
+    },
+    {
+      "id": "b8",
+      "placeholder": "{{eindevaluatieAanwezigen}}",
+      "variableKey": "eindevaluatieAanwezigen",
+      "source": "process",
+      "label": "Attendees"
+    },
+    {
+      "id": "b9",
+      "placeholder": "{{eindevaluatieBespreking}}",
+      "variableKey": "eindevaluatieBespreking",
+      "source": "process",
+      "label": "Discussion"
+    },
+    {
+      "id": "b10",
+      "placeholder": "{{eindevaluatieBijgewerktOp}}",
+      "variableKey": "eindevaluatieBijgewerktOp",
+      "source": "process",
+      "label": "Updated on"
+    },
+    {
+      "id": "b11",
+      "placeholder": "{{eindevaluatieWijzigingen}}",
+      "variableKey": "eindevaluatieWijzigingen",
+      "source": "process",
+      "label": "What was changed"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Eindevaluatie {{eindevaluatieReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Final evaluation of the RIP project process",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Final evaluation of the RIP project process"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Final evaluation {{eindevaluatieReferentie}} for project {{projectNumber}} — {{projectName}} was drawn up on {{eindevaluatieOp}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "What was learned: {{eindevaluatieGeleerd}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Recommendations: {{eindevaluatieAanbevelingen}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "It was discussed with the RIP team on {{eindevaluatieBesprokenOp}} ({{eindevaluatieAanwezigen}}): {{eindevaluatieBespreking}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Updated on {{eindevaluatieBijgewerktOp}}: {{eindevaluatieWijzigingen}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up by the projectleider, discussed with the RIP team"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-61/rip-financieel-overzicht-decharge.document
+++ b/examples/organizations/flevoland/rip-phase-61/rip-financieel-overzicht-decharge.document
@@ -1,0 +1,269 @@
+{
+  "id": "rip-financieel-overzicht-decharge",
+  "name": "RIP — Financial Overview for Discharge (Financieel overzicht voor decharge)",
+  "description": "The financial end position of the project, filled in by Financiën and signed by the projectleider.",
+  "processKey": "RipR61Process",
+  "serviceId": "RipR61",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-02T00:00:00.000Z",
+  "updatedAt": "2026-09-02T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{financieelOverzichtReferentie}}",
+      "variableKey": "financieelOverzichtReferentie",
+      "source": "process",
+      "label": "Financial overview reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{financieelOverzichtAangemaaktOp}}",
+      "variableKey": "financieelOverzichtAangemaaktOp",
+      "source": "process",
+      "label": "Created on"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{zaakmapDmsReferentie}}",
+      "variableKey": "zaakmapDmsReferentie",
+      "source": "process",
+      "label": "DMS case folder"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{financieleEindstand}}",
+      "variableKey": "financieleEindstand",
+      "source": "process",
+      "label": "Financial end position"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{kredietVerleend}}",
+      "variableKey": "kredietVerleend",
+      "source": "process",
+      "label": "Credit granted"
+    },
+    {
+      "id": "b8",
+      "placeholder": "{{financieleEindstandToelichting}}",
+      "variableKey": "financieleEindstandToelichting",
+      "source": "process",
+      "label": "Explanation"
+    },
+    {
+      "id": "b9",
+      "placeholder": "{{financieelOverzichtGetekendDoor}}",
+      "variableKey": "financieelOverzichtGetekendDoor",
+      "source": "process",
+      "label": "Signed by"
+    },
+    {
+      "id": "b10",
+      "placeholder": "{{financieelOverzichtGetekendOp}}",
+      "variableKey": "financieelOverzichtGetekendOp",
+      "source": "process",
+      "label": "Signed on"
+    },
+    {
+      "id": "b11",
+      "placeholder": "{{financieelOverzichtBevindingen}}",
+      "variableKey": "financieelOverzichtBevindingen",
+      "source": "process",
+      "label": "Check findings"
+    },
+    {
+      "id": "b12",
+      "placeholder": "{{raamkredietReferentie}}",
+      "variableKey": "raamkredietReferentie",
+      "source": "process",
+      "label": "Framework credit reference"
+    },
+    {
+      "id": "b13",
+      "placeholder": "{{eindstandVerwerktOp}}",
+      "variableKey": "eindstandVerwerktOp",
+      "source": "process",
+      "label": "Processed on"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Overzicht {{financieelOverzichtReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Financial overview for discharge",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Financial overview for discharge"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Financial overview {{financieelOverzichtReferentie}} for project {{projectNumber}} — {{projectName}} was created on {{financieelOverzichtAangemaaktOp}} and filed in DMS case folder {{zaakmapDmsReferentie}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The financial end position is EUR {{financieleEindstand}} against a granted credit of EUR {{kredietVerleend}}. {{financieleEindstandToelichting}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Checked and signed by {{financieelOverzichtGetekendDoor}} on {{financieelOverzichtGetekendOp}}. {{financieelOverzichtBevindingen}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "The end position is processed in Infra framework credit {{raamkredietReferentie}} on {{eindstandVerwerktOp}}."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Filled in by Financiën, signed by the projectleider"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-61/rip-informeren-pl-ondertekening.form
+++ b/examples/organizations/flevoland/rip-phase-61/rip-informeren-pl-ondertekening.form
@@ -1,0 +1,43 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-informeren-pl-ondertekening",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Inform the projectleider that the transfer declaration is signed"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The projectondersteuner informs the projectleider that the transfer declaration is signed, so it can go into the discharge dossier."
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Informed on",
+      "key": "plGeinformeerdOndertekeningOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bericht",
+      "type": "textarea",
+      "label": "Message",
+      "key": "plBerichtOndertekening"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-61/rip-informeren-po-akkoord.form
+++ b/examples/organizations/flevoland/rip-phase-61/rip-informeren-po-akkoord.form
@@ -1,0 +1,43 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-informeren-po-akkoord",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Inform the projectondersteuner of the AO approval"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The projectleider informs the projectondersteuner that the AO approved the discharge dossier, so the project can be closed out."
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Informed on",
+      "key": "poGeinformeerdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Bericht",
+      "type": "textarea",
+      "label": "Message",
+      "key": "poBericht"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-61/rip-invullen-financieel-overzicht.form
+++ b/examples/organizations/flevoland/rip-phase-61/rip-invullen-financieel-overzicht.form
@@ -1,0 +1,64 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-invullen-financieel-overzicht",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Fill in the financial overview and send it for signature"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Financiën fills in the financial end position and sends the overview to the projectleider for signature."
+    },
+    {
+      "id": "F_Eindstand",
+      "type": "number",
+      "label": "Financial end position (EUR)",
+      "key": "financieleEindstand",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Krediet",
+      "type": "number",
+      "label": "Credit granted (EUR)",
+      "key": "kredietVerleend",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Toel",
+      "type": "textarea",
+      "label": "Explanation of the end position",
+      "key": "financieleEindstandToelichting",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Filled in on",
+      "key": "financieelOverzichtIngevuldOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-61/rip-laten-aanpassen-rechten-relatics.form
+++ b/examples/organizations/flevoland/rip-phase-61/rip-laten-aanpassen-rechten-relatics.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-laten-aanpassen-rechten-relatics",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Have the Relatics workspace rights adjusted"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The projectondersteuner has the rights on the Relatics workspace adjusted now the project is discharged."
+    },
+    {
+      "id": "F_Workspace",
+      "type": "textfield",
+      "label": "Relatics workspace",
+      "key": "relaticsWorkspace",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Rechten",
+      "type": "textarea",
+      "label": "Rights to be adjusted",
+      "key": "relaticsRechten",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Requested on",
+      "key": "relaticsRechtenVerzochtOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-61/rip-laten-sluiten-projectmap.form
+++ b/examples/organizations/flevoland/rip-phase-61/rip-laten-sluiten-projectmap.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-laten-sluiten-projectmap",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Have the project folder closed in the DMS"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The projectondersteuner raises a TopDesk request to have the project folder closed in the DMS."
+    },
+    {
+      "id": "F_Melding",
+      "type": "textfield",
+      "label": "TopDesk request reference",
+      "key": "topdeskMeldingReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Requested on",
+      "key": "projectmapSluitenVerzochtOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-61/rip-opstarten-decharge.form
+++ b/examples/organizations/flevoland/rip-phase-61/rip-opstarten-decharge.form
@@ -1,0 +1,52 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-opstarten-decharge",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Start the project discharge"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The projectleider starts the discharge. Three streams run alongside each other from here: A the financial overview for discharge, B the transfer declaration, and C the final evaluation."
+    },
+    {
+      "id": "F_Visi",
+      "type": "textfield",
+      "label": "VISI completion reference (from R5.4)",
+      "key": "gereedmeldingVisiReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Discharge started on",
+      "key": "dechargeGestartOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Notes",
+      "key": "dechargeOpmerkingen"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-61/rip-opstellen-dechargedossier.form
+++ b/examples/organizations/flevoland/rip-phase-61/rip-opstellen-dechargedossier.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-opstellen-dechargedossier",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Draw up the discharge dossier and send it to the AO"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The projectleider brings the signed financial overview, the signed transfer declaration and the updated final evaluation together into the dechargedossier and sends it to the AO."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Discharge dossier reference",
+      "key": "dechargedossierReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Inhoud",
+      "type": "textarea",
+      "label": "Dossier contents",
+      "key": "dechargedossierInhoud",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Sent on",
+      "key": "dechargedossierVerstuurdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-61/rip-opstellen-overdrachtsverklaring.form
+++ b/examples/organizations/flevoland/rip-phase-61/rip-opstellen-overdrachtsverklaring.form
@@ -1,0 +1,64 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-opstellen-overdrachtsverklaring",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Draw up the transfer declaration"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The projectleider draws up the overdrachtsverklaring, transferring the asset to the beheerder. Where an earlier version was not signed, this is the redrafted declaration."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Transfer declaration reference",
+      "key": "overdrachtsverklaringReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Versie",
+      "type": "number",
+      "label": "Version",
+      "key": "overdrachtsverklaringVersie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Areaal",
+      "type": "textarea",
+      "label": "Asset transferred",
+      "key": "overgedragenAreaal",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Drawn up on",
+      "key": "overdrachtsverklaringOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-61/rip-opstellen-versturen-eindevaluatie.form
+++ b/examples/organizations/flevoland/rip-phase-61/rip-opstellen-versturen-eindevaluatie.form
@@ -1,0 +1,64 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-opstellen-versturen-eindevaluatie",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Draw up and send the final evaluation"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The projectleider draws up the eindevaluatie of the RIP project process and sends it for discussion with the RIP team."
+    },
+    {
+      "id": "F_Ref",
+      "type": "textfield",
+      "label": "Final evaluation reference",
+      "key": "eindevaluatieReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Geleerd",
+      "type": "textarea",
+      "label": "What was learned",
+      "key": "eindevaluatieGeleerd",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Aanbevelingen",
+      "type": "textarea",
+      "label": "Recommendations",
+      "key": "eindevaluatieAanbevelingen",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Drawn up on",
+      "key": "eindevaluatieOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-61/rip-overdrachtsverklaring.document
+++ b/examples/organizations/flevoland/rip-phase-61/rip-overdrachtsverklaring.document
@@ -1,0 +1,262 @@
+{
+  "id": "rip-overdrachtsverklaring",
+  "name": "RIP — Transfer Declaration (Overdrachtsverklaring)",
+  "description": "The declaration transferring the completed asset to the beheerder, signed by the beheerder and the vestigingsmanager.",
+  "processKey": "RipR61Process",
+  "serviceId": "RipR61",
+  "schemaVersion": 1,
+  "readonly": false,
+  "status": "wip",
+  "createdAt": "2026-09-02T00:00:00.000Z",
+  "updatedAt": "2026-09-02T00:00:00.000Z",
+  "assets": [],
+  "bindings": [
+    {
+      "id": "b1",
+      "placeholder": "{{projectNumber}}",
+      "variableKey": "projectNumber",
+      "source": "process",
+      "label": "Project number"
+    },
+    {
+      "id": "b2",
+      "placeholder": "{{projectName}}",
+      "variableKey": "projectName",
+      "source": "process",
+      "label": "Project name"
+    },
+    {
+      "id": "b3",
+      "placeholder": "{{overdrachtsverklaringReferentie}}",
+      "variableKey": "overdrachtsverklaringReferentie",
+      "source": "process",
+      "label": "Transfer declaration reference"
+    },
+    {
+      "id": "b4",
+      "placeholder": "{{overdrachtsverklaringVersie}}",
+      "variableKey": "overdrachtsverklaringVersie",
+      "source": "process",
+      "label": "Version"
+    },
+    {
+      "id": "b5",
+      "placeholder": "{{overdrachtsverklaringOp}}",
+      "variableKey": "overdrachtsverklaringOp",
+      "source": "process",
+      "label": "Drawn up on"
+    },
+    {
+      "id": "b6",
+      "placeholder": "{{overgedragenAreaal}}",
+      "variableKey": "overgedragenAreaal",
+      "source": "process",
+      "label": "Asset transferred"
+    },
+    {
+      "id": "b7",
+      "placeholder": "{{overdrachtsverklaringAan}}",
+      "variableKey": "overdrachtsverklaringAan",
+      "source": "process",
+      "label": "Sent to"
+    },
+    {
+      "id": "b8",
+      "placeholder": "{{overdrachtsverklaringTerTekeningOp}}",
+      "variableKey": "overdrachtsverklaringTerTekeningOp",
+      "source": "process",
+      "label": "Sent for signature on"
+    },
+    {
+      "id": "b9",
+      "placeholder": "{{overdrachtsverklaringBevindingen}}",
+      "variableKey": "overdrachtsverklaringBevindingen",
+      "source": "process",
+      "label": "Assessment findings"
+    },
+    {
+      "id": "b10",
+      "placeholder": "{{overdrachtsverklaringAkkoord}}",
+      "variableKey": "overdrachtsverklaringAkkoord",
+      "source": "process",
+      "label": "Signed"
+    },
+    {
+      "id": "b11",
+      "placeholder": "{{overdrachtsverklaringGetekendDoor}}",
+      "variableKey": "overdrachtsverklaringGetekendDoor",
+      "source": "process",
+      "label": "Signed by"
+    },
+    {
+      "id": "b12",
+      "placeholder": "{{overdrachtsverklaringBeoordeeldOp}}",
+      "variableKey": "overdrachtsverklaringBeoordeeldOp",
+      "source": "process",
+      "label": "Assessed on"
+    }
+  ],
+  "zones": {
+    "letterhead": {
+      "blocks": [
+        {
+          "id": "lh1",
+          "type": "text",
+          "label": "Organisation header",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 1
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Province of Flevoland"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Infrastructure — Regular Infrastructure Projects"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "reference": {
+      "blocks": [
+        {
+          "id": "ref1",
+          "type": "text",
+          "label": "Document reference",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Overdrachtsverklaring {{overdrachtsverklaringReferentie}} · project {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "body": {
+      "blocks": [
+        {
+          "id": "bd1",
+          "type": "text",
+          "label": "Transfer declaration",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "attrs": {
+                  "level": 2
+                },
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Transfer declaration"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Transfer declaration {{overdrachtsverklaringReferentie}} (version {{overdrachtsverklaringVersie}}) for project {{projectNumber}} — {{projectName}} was drawn up on {{overdrachtsverklaringOp}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Asset transferred: {{overgedragenAreaal}}"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "It was sent to {{overdrachtsverklaringAan}} for signature on {{overdrachtsverklaringTerTekeningOp}}."
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Assessment: {{overdrachtsverklaringBevindingen}} Signed: {{overdrachtsverklaringAkkoord}}, by {{overdrachtsverklaringGetekendDoor}} on {{overdrachtsverklaringBeoordeeldOp}}."
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "closing": {
+      "blocks": []
+    },
+    "signOff": {
+      "blocks": [
+        {
+          "id": "so1",
+          "type": "text",
+          "label": "Signatures",
+          "content": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Drawn up by the projectleider, signed by the beheerder and the vestigingsmanager"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Project: {{projectNumber}} — {{projectName}}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "contactInformation": {
+      "blocks": []
+    },
+    "annex": {
+      "blocks": []
+    }
+  }
+}

--- a/examples/organizations/flevoland/rip-phase-61/rip-plannen-afspraak-eindevaluatie.form
+++ b/examples/organizations/flevoland/rip-phase-61/rip-plannen-afspraak-eindevaluatie.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-plannen-afspraak-eindevaluatie",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Plan the RIP team meeting on the final evaluation"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The projectondersteuner plans the meeting at which the RIP team discusses the final evaluation."
+    },
+    {
+      "id": "F_Datum",
+      "type": "datetime",
+      "label": "Meeting date",
+      "key": "eindevaluatieOverlegDatum",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Genodigden",
+      "type": "textarea",
+      "label": "Invited",
+      "key": "eindevaluatieGenodigden",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-61/rip-updaten-eindevaluatie.form
+++ b/examples/organizations/flevoland/rip-phase-61/rip-updaten-eindevaluatie.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-updaten-eindevaluatie",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Update the final evaluation after the discussion"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The projectondersteuner works the RIP team discussion into the final evaluation."
+    },
+    {
+      "id": "F_Wijzigingen",
+      "type": "textarea",
+      "label": "What was changed",
+      "key": "eindevaluatieWijzigingen",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Updated on",
+      "key": "eindevaluatieBijgewerktOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-61/rip-versturen-geaccordeerd-dechargedossier.form
+++ b/examples/organizations/flevoland/rip-phase-61/rip-versturen-geaccordeerd-dechargedossier.form
@@ -1,0 +1,37 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-versturen-geaccordeerd-dechargedossier",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Send the approved discharge dossier to Financiën"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The projectondersteuner sends the approved discharge dossier to Financiën, and the close-out begins."
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Sent on",
+      "key": "geaccordeerdDossierVerstuurdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-61/rip-versturen-ondertekende-overdrachtsverklaring.form
+++ b/examples/organizations/flevoland/rip-phase-61/rip-versturen-ondertekende-overdrachtsverklaring.form
@@ -1,0 +1,37 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-versturen-ondertekende-overdrachtsverklaring",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Send the signed transfer declaration to the PO"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Send the signed transfer declaration back to the projectondersteuner."
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Sent on",
+      "key": "ondertekendeOverdrachtsverklaringVerstuurdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-61/rip-versturen-overdrachtsverklaring-ondertekening.form
+++ b/examples/organizations/flevoland/rip-phase-61/rip-versturen-overdrachtsverklaring-ondertekening.form
@@ -1,0 +1,46 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-versturen-overdrachtsverklaring-ondertekening",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Send the transfer declaration to the beheerder and VM for signature"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "The projectondersteuner sends the transfer declaration to the beheerder and the vestigingsmanager for signature."
+    },
+    {
+      "id": "F_Aan",
+      "type": "textfield",
+      "label": "Sent to",
+      "key": "overdrachtsverklaringAan",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Sent on",
+      "key": "overdrachtsverklaringTerTekeningOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-61/rip-versturen-overdrachtsverklaring.form
+++ b/examples/organizations/flevoland/rip-phase-61/rip-versturen-overdrachtsverklaring.form
@@ -1,0 +1,43 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-versturen-overdrachtsverklaring",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Send the transfer declaration"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Send the transfer declaration on to the projectondersteuner."
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Sent on",
+      "key": "overdrachtsverklaringVerstuurdOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Opm",
+      "type": "textarea",
+      "label": "Notes",
+      "key": "overdrachtsverklaringOpmerkingen"
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}

--- a/examples/organizations/flevoland/rip-phase-61/rip-verwerken-financiele-eindstand.form
+++ b/examples/organizations/flevoland/rip-phase-61/rip-verwerken-financiele-eindstand.form
@@ -1,0 +1,55 @@
+{
+  "e2eFixture": true,
+  "schemaVersion": 16,
+  "type": "default",
+  "id": "rip-verwerken-financiele-eindstand",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.21.0",
+  "components": [
+    {
+      "id": "Text_Header",
+      "type": "text",
+      "text": "# Process the financial end position in the Infra framework credit"
+    },
+    {
+      "id": "Text_Intro",
+      "type": "text",
+      "text": "Financiën processes the financial end position from the discharge dossier in the Infra framework credit."
+    },
+    {
+      "id": "F_Bedrag",
+      "type": "number",
+      "label": "Amount processed (EUR)",
+      "key": "eindstandVerwerktBedrag",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Admin",
+      "type": "textfield",
+      "label": "Framework credit reference",
+      "key": "raamkredietReferentie",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "F_Op",
+      "type": "datetime",
+      "label": "Processed on",
+      "key": "eindstandVerwerktOp",
+      "subtype": "date",
+      "dateLabel": "Date",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "id": "Button_Submit",
+      "type": "button",
+      "label": "Submit",
+      "action": "submit"
+    }
+  ]
+}


### PR DESCRIPTION
Stacked on #63, and the last of the four. **Merge #61 → #62 → #63 first.**

Models `R6_1 Projectdecharge 2007 DEF.pdf` (sheet dated 14-7-2026) as `RipR61Process`.

| | |
|---|---|
| Files | 26 (1 BPMN, 21 forms, 4 documents) |
| Nodes / flows / lanes | 28 / 32 / 6 |

## The one sheet that labels its own concurrency

Unusual in this set, and it makes the structure unambiguous for once: "Opstarten decharge" fans out into **A. Financieel overzicht decharge**, **B. Overdrachtsverklaring** and **C. Eindevaluatie**. Those letters are kept as sequence-flow names so the diagram reads the way the sheet does.

The three streams converge on the dechargedossier, which the AO approves. The close-out then fans out once more into the three things that finish a project: the financial end position into the raamkrediet Infra, closing the project folder in the DMS via TopDesk, and adjusting the Relatics workspace rights.

## Two end markers, one end event

The sheet draws two "Einde proces" markers, one per closing projectondersteuner action. They are modelled as **one end event behind a parallel join** rather than two: they mean the same completion, and a single exit keeps the phase's end detectable the way every other phase in the ladder is. Recorded in a text annotation.

One rework loop: an unsigned overdrachtsverklaring goes back to the projectleider to be redrafted.

## Roles

None new. `rip-beheerder`, introduced in #63, is reused for the "Beheerder, Vestigingsmanager" lane.

## With this the ladder is complete

Every sheet that has a design now has a bundle: R2.1–R2.4, R3.1–R3.2, R4.1, R5.1–R5.2, R5.4, R6.1 — eleven phases. **R5.3 remains unmodelled; no design exists for it yet.**

The ladder now carries **34 distinct candidate groups**, seven of them introduced across #61–#63.

## Verification

Faseladder contract holds. Both validators pass.