### PR TITLE
fix(ci): audit every pull request, not only those targeting acc or main

### DIFF
--- a/.claude/commands/bump-release.md
+++ b/.claude/commands/bump-release.md
@@ -108,7 +108,17 @@ gh pr list --state open --json number,title,author,files
 ```
 
 Present the open pull requests and ask which are in scope: all, a subset, or
-none. Out-of-scope ones stay open and are gathered by the next release. Then:
+none. Out-of-scope ones stay open and are gathered by the next release.
+
+**A pull request showing `CLEAN` with zero checks has not been audited -- it has
+not run the gate, not passed it.** Read the check list, not just
+`mergeStateStatus`. This used to happen to every stacked pull request, because
+the audit was branch-filtered to `acc`/`main` and a retarget fires no
+`pull_request` event; closing and reopening was the only cure. Fixed in the
+workflow on 2026-09-02, so it should not recur -- but the reading habit is worth
+keeping, and `ronl-business-api` and `ttl-editor` still carry the old shape.
+
+Then:
 
 1. **Merge the in-scope ones before any version editing.** Dependency pull
    requests rewrite `package-lock.json` -- the same file step 4 edits. Bump the

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,10 +1,15 @@
 name: Supply-chain audit
 
 on:
+  # Deliberately NO branches filter either. A stacked pull request based on a
+  # feature branch matched no trigger and so accumulated no audit at all, while
+  # still reporting mergeStateStatus=CLEAN with zero checks — which reads as
+  # ready and is not. The moment its parent merged and GitHub retargeted it to
+  # acc, the required audit was missing and it blocked permanently: a retarget
+  # emits no pull_request event, so nothing ever ran it. Closing and reopening
+  # the pull request was the only way out, and it was needed four times in one
+  # session on 2026-09-02 (#59, #62, #63, #64).
   pull_request:
-    branches:
-      - acc
-      - main
   push:
     branches:
       - acc
@@ -12,7 +17,19 @@ on:
 
 # Deliberately NO paths filter. The audit must run on every pull request
 # regardless of what changed — filtering it would let a pull request skip the
-# gate by touching nothing the filter watches.
+# gate by touching nothing the filter watches. The branches filter removed above
+# was the same hole in another dimension: paths let a pull request skip the gate
+# by touching nothing watched, branches let it skip by targeting a base that is
+# not watched.
+#
+# This reasoning does NOT extend to the azure-*-acc.yml deploy workflows, which
+# carry the same branches filter for the opposite reason. The two fail in
+# opposite directions: an absent audit filter makes a REQUIRED CHECK silently
+# missing, so a pull request looks ready and is not; an absent deploy filter
+# makes a SCARCE ENVIRONMENT silently exhausted, every pull request against any
+# base claiming a staging slot. ronl-business-api hit that second failure on
+# 2026-08-28, when five open pull requests exhausted a three-environment
+# ceiling. Same syntax, opposite consequence — audit widely, deploy narrowly.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Closes a hole in the supply-chain gate that cost four manual interventions in one session.

## The trap

The audit triggered on `pull_request` filtered to `branches: [acc, main]`. A **stacked** PR based on a feature branch matched no trigger, so it accumulated **no audit at all** — while still reporting `mergeStateStatus=CLEAN` with zero checks. That reads as ready and is not.

The moment its parent merged and GitHub retargeted it to `acc`, the `acc supply-chain gate` ruleset applied, the required `audit` was missing, and the PR **blocked permanently**. A retarget emits no `pull_request` event, so nothing ever ran it.

Close-and-reopen was the only way out. It was needed four times on 2026-09-02 — #59, #62, #63, #64.

## The workflow already made this argument, one dimension over

> Deliberately NO paths filter. The audit must run on every pull request regardless of what changed — filtering it would let a pull request skip the gate by touching nothing the filter watches.

A branches filter is the same hole: **paths** lets a PR skip the gate by touching nothing watched, **branches** lets it skip by *targeting* a base that isn't watched. The reasoning was done for paths and not for branches.

```yaml
on:
  pull_request:          # ← filter removed
  push:
    branches: [acc, main]   # ← kept; only these deploy
```

## Explicitly NOT generalised to the deploy workflows

`azure-*-acc.yml` carry the same filter **for the opposite reason**, and the two fail in opposite directions:

| filter absent on | consequence |
|---|---|
| **audit** | a required check is **silently missing** — the PR looks ready and is not |
| **deploy** | a scarce environment is **silently exhausted** — every PR against any base claims a staging slot |

`ronl-business-api` hit that second failure on 2026-08-28, when five open PRs exhausted a three-environment Static Web Apps ceiling. **Audit widely, deploy narrowly** — the distinction is now recorded in `zizmor.yml` itself, where a future reader would be tempted to generalise.

## Also

A reading habit added to `bump-release` step 0: *a pull request showing `CLEAN` with zero checks has not been audited — it has not run the gate, not passed it.* Read the check list, not just `mergeStateStatus`.

## Cost

One extra zizmor run (~40s) per PR targeting a feature branch. This PR targets `acc`, so its own audit would have run either way.

## Sibling repos

`ronl-business-api` and `ttl-editor` carry the **identical** trigger and an identical `acc supply-chain gate` on `refs/heads/acc` requiring `audit`. Both are affected — `ronl-business-api` already hit it on its PR #45. Neither is changed here; each is its own repo's call.