### PR TITLE
feat(frontend): identify the build, not just the release, in the changelog

### DIFF
--- a/.github/workflows/azure-frontend-acc.yml
+++ b/.github/workflows/azure-frontend-acc.yml
@@ -61,6 +61,24 @@ jobs:
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
+        # Stamps the bundle with which BUILD it is, not just which release —
+        # the changelog version is authored at release time, so ACC and
+        # production can serve different builds of the same version string.
+        #
+        # These sit on the deploy step rather than a build step because there
+        # is no build step: app_build_command hands the build to Oryx inside
+        # the action's own container, and the action forwards the runner's
+        # environment into it. That is also why nothing is derived from git at
+        # build time — .git is not guaranteed to exist in that container, and a
+        # build id that silently fails to resolve is worse than none.
+        #
+        # Absent (local builds, forks), src/utils/buildInfo.ts renders
+        # 'local build'. On a pull request github.sha is the merge commit
+        # GitHub synthesises, so a preview's SHA matches no commit in the
+        # branch — that is the commit that was built, not a bug to chase.
+        env:
+          VITE_BUILD_SHA: ${{ github.sha }}
+          VITE_BUILD_RUN: ${{ github.run_number }}
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_BRAVE_BAY_04F351E03 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)

--- a/.github/workflows/azure-frontend-production.yml
+++ b/.github/workflows/azure-frontend-production.yml
@@ -59,6 +59,13 @@ jobs:
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
+        # See azure-frontend-acc.yml for why these sit on the deploy step and
+        # are injected rather than derived from git. Production deploys from a
+        # push to main, so github.sha is a real commit here, never a
+        # synthesised merge commit.
+        env:
+          VITE_BUILD_SHA: ${{ github.sha }}
+          VITE_BUILD_RUN: ${{ github.run_number }}
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_WITTY_BEACH_0A7CFA203 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)

--- a/packages/frontend/.prettierignore
+++ b/packages/frontend/.prettierignore
@@ -14,6 +14,11 @@ yarn.lock
 .cache/
 .parcel-cache/
 
+# Semgrep Guardian writes state into the working tree, one .semgrep/ per
+# directory it scans. Already ignored by git (.gitignore); ignored here too so
+# check-format does not fail on a tool's scratch files.
+.semgrep/
+
 # Misc
 .DS_Store
 *.log

--- a/packages/frontend/src/components/Changelog.tsx
+++ b/packages/frontend/src/components/Changelog.tsx
@@ -2,6 +2,7 @@ import { ChevronDown, ChevronUp } from 'lucide-react';
 import React, { useState } from 'react';
 
 import changelogData from '../changelog.json';
+import { getBuildInfo } from '../utils/buildInfo';
 
 // ── Per-commit format (v2) ───────────────────────────────────────────
 // A version entry with "format": "commits" is the new shape bump-release
@@ -132,6 +133,11 @@ function CommitBlock({ commit }: { commit: ChangelogCommit }) {
 }
 
 const Changelog: React.FC = () => {
+  // Which build is being served, as opposed to which release the version
+  // entries below name. Cheap and synchronous — see utils/buildInfo.ts for why
+  // it is a call rather than a module-scope constant.
+  const buildInfo = getBuildInfo();
+
   const [expandedVersions, setExpandedVersions] = useState<Set<string>>(
     new Set([versions[0]?.version])
   );
@@ -199,6 +205,11 @@ const Changelog: React.FC = () => {
           <h1 className="text-3xl font-bold text-slate-800 mb-2">Changelog</h1>
           <p className="text-slate-600">
             Track new features, improvements, and bug fixes in Linked Data Explorer.
+          </p>
+          {/* title carries the full 40-char SHA so it can be copied for a
+              lookup; the visible label stays short. */}
+          <p className="mt-2 font-mono text-xs text-slate-400" title={buildInfo.sha || undefined}>
+            {buildInfo.label}
           </p>
         </div>
 

--- a/packages/frontend/src/utils/buildInfo.test.ts
+++ b/packages/frontend/src/utils/buildInfo.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { getBuildInfo } from './buildInfo';
+
+// getBuildInfo reads import.meta.env on every call rather than capturing it at
+// module scope, which is what lets vi.stubEnv reach it. A module-scope capture
+// would be evaluated once at import and the fallback below could not be tested
+// at all without vi.resetModules gymnastics.
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+const SHA = '570fd98a1c4e2b7d3f8a9016c5d4e2b7a3f81c40';
+
+describe('getBuildInfo', () => {
+  test('labels a build that carries both a SHA and a run number', () => {
+    vi.stubEnv('VITE_BUILD_SHA', SHA);
+    vi.stubEnv('VITE_BUILD_RUN', '412');
+
+    const info = getBuildInfo();
+
+    expect(info.isTracked).toBe(true);
+    expect(info.label).toBe('build 570fd98 · #412');
+  });
+
+  test('keeps the full SHA alongside the short one, for copying', () => {
+    vi.stubEnv('VITE_BUILD_SHA', SHA);
+    vi.stubEnv('VITE_BUILD_RUN', '412');
+
+    const info = getBuildInfo();
+
+    expect(info.sha).toBe(SHA);
+    expect(info.shortSha).toBe('570fd98');
+    expect(info.run).toBe('412');
+  });
+
+  test('falls back to "local build" when nothing was injected', () => {
+    vi.stubEnv('VITE_BUILD_SHA', undefined);
+    vi.stubEnv('VITE_BUILD_RUN', undefined);
+
+    const info = getBuildInfo();
+
+    expect(info.isTracked).toBe(false);
+    expect(info.label).toBe('local build');
+    expect(info.sha).toBe('');
+  });
+
+  // Half-configured counts as untracked. A run number with no commit behind it
+  // implies a provenance the bundle does not have, so it must not render as
+  // one — and a SHA with no run number cannot distinguish two builds of the
+  // same commit, which is the whole point of the run number.
+  test('treats a run number without a SHA as untracked', () => {
+    vi.stubEnv('VITE_BUILD_SHA', undefined);
+    vi.stubEnv('VITE_BUILD_RUN', '412');
+
+    expect(getBuildInfo().label).toBe('local build');
+  });
+
+  test('treats a SHA without a run number as untracked', () => {
+    vi.stubEnv('VITE_BUILD_SHA', SHA);
+    vi.stubEnv('VITE_BUILD_RUN', undefined);
+
+    expect(getBuildInfo().label).toBe('local build');
+  });
+
+  // Vite substitutes a missing variable with an empty string in some build
+  // configurations rather than leaving it undefined, so blank must be treated
+  // exactly like absent — otherwise the page renders "build  · #".
+  test('treats blank and whitespace-only values as absent', () => {
+    vi.stubEnv('VITE_BUILD_SHA', '   ');
+    vi.stubEnv('VITE_BUILD_RUN', '');
+
+    expect(getBuildInfo().isTracked).toBe(false);
+    expect(getBuildInfo().label).toBe('local build');
+  });
+
+  test('trims surrounding whitespace off injected values', () => {
+    vi.stubEnv('VITE_BUILD_SHA', ` ${SHA} `);
+    vi.stubEnv('VITE_BUILD_RUN', ' 412 ');
+
+    const info = getBuildInfo();
+
+    expect(info.sha).toBe(SHA);
+    expect(info.label).toBe('build 570fd98 · #412');
+  });
+
+  // A SHA shorter than 7 characters is not something CI produces, but slicing
+  // must not invent characters or throw if one ever arrives.
+  test('uses the whole SHA when it is shorter than seven characters', () => {
+    vi.stubEnv('VITE_BUILD_SHA', 'abc12');
+    vi.stubEnv('VITE_BUILD_RUN', '7');
+
+    expect(getBuildInfo().label).toBe('build abc12 · #7');
+  });
+});

--- a/packages/frontend/src/utils/buildInfo.ts
+++ b/packages/frontend/src/utils/buildInfo.ts
@@ -1,0 +1,61 @@
+/**
+ * Which BUILD of the app is running, as opposed to which release.
+ *
+ * The version in the changelog comes from changelog.json and is authored at
+ * release time, so it identifies a release, not a build of it. ACC and
+ * production can serve different builds of the same version string, and
+ * redeploying unchanged code produces a new artifact carrying the same
+ * version — so "which build am I looking at?" is not answerable from the
+ * version alone.
+ *
+ * The SHA says what was built; the run number distinguishes two builds of
+ * identical code. Both are injected by the deploy workflows (see
+ * .github/workflows/azure-frontend-{acc,production}.yml). Nothing is derived
+ * from git here, and here that is not merely a preference: the Static Web
+ * Apps action builds inside its own Oryx container rather than on the runner,
+ * so neither `git` nor `.git` is guaranteed to exist at build time. A build id
+ * that silently fails to resolve is worse than none — it lies.
+ */
+
+export interface BuildInfo {
+  /** Full 40-character commit SHA, or '' when not injected. */
+  sha: string;
+  /** First 7 characters of the SHA, or '' when not injected. */
+  shortSha: string;
+  /** GitHub Actions run number, or '' when not injected. */
+  run: string;
+  /** True only when both values are present — see the half-configured note below. */
+  isTracked: boolean;
+  /** Ready to render. Never blank. */
+  label: string;
+}
+
+const UNTRACKED: BuildInfo = {
+  sha: '',
+  shortSha: '',
+  run: '',
+  isTracked: false,
+  label: 'local build',
+};
+
+/**
+ * Read the injected build identifiers and describe them.
+ *
+ * The env is read here, on every call, rather than captured at module scope:
+ * a module-scope capture is evaluated once at import and cannot be stubbed
+ * per test, which would leave the fallback path untestable.
+ *
+ * Half-configured counts as untracked. A run number with no SHA behind it
+ * implies a provenance the bundle does not have, and a SHA with no run number
+ * cannot tell two builds of the same commit apart — which is the whole reason
+ * the run number is here. Either way the answer is 'local build'.
+ */
+export function getBuildInfo(): BuildInfo {
+  const sha = (import.meta.env.VITE_BUILD_SHA ?? '').trim();
+  const run = (import.meta.env.VITE_BUILD_RUN ?? '').trim();
+
+  if (!sha || !run) return UNTRACKED;
+
+  const shortSha = sha.slice(0, 7);
+  return { sha, shortSha, run, isTracked: true, label: `build ${shortSha} · #${run}` };
+}

--- a/packages/frontend/src/vite-env.d.ts
+++ b/packages/frontend/src/vite-env.d.ts
@@ -4,6 +4,10 @@ interface ImportMetaEnv {
   readonly VITE_API_BASE_URL: string;
   // Base URL of the CPSV Editor, used for the DSO → DMN publish handoff deep-link.
   readonly VITE_CPSV_EDITOR_URL: string;
+  // Commit SHA of the build, injected by the deploy workflows. Absent locally.
+  readonly VITE_BUILD_SHA?: string;
+  // GitHub Actions run number, injected by the deploy workflows. Absent locally.
+  readonly VITE_BUILD_RUN?: string;
   // Add more env variables here as needed
 }
 


### PR DESCRIPTION
Third and last of the three apps to get this — after the CPSV Editor (ttl-editor #83) and RONL Business API (#79).

## The problem

The version in the Changelog page is authored at release time, so it identifies a **release**, not a **build** of it. ACC and production can serve different builds of the same version string, and redeploying unchanged code produces a new artifact carrying the same version. So "which build am I looking at?" was not answerable from the running app.

The commit SHA says what was built. The run number distinguishes two builds of identical code — that is what makes this a build id rather than a code id.

## What it looks like

One small monospace line under the existing subtitle:

```
Changelog
Track new features, improvements, and bug fixes in Linked Data Explorer.
build 570fd98 · #412
```

The full 40-character SHA is on the `title` attribute so it can be copied for a lookup. With nothing injected the line reads `local build` — never blank, never looking like a deployed artifact.

## What is different here from RBA and ttl-editor

**Oryx builds this one, not the runner.** Both frontend workflows pass `app_build_command` to `Azure/static-web-apps-deploy` with no `skip_app_build`, so the build happens inside the action's own container. The workflow already says as much: *"The Static Web Apps action builds inside its own container and runs none of our scripts."*

Two consequences:

- The `env:` block sits on the **deploy step**, not a build step, because there is no build step. That is where the action picks up the runner environment to forward into the container.
- "Do not derive the SHA from git at build time" stops being a preference and becomes a requirement: neither `git` nor `.git` is guaranteed to exist in that container.

Also unlike RBA: the changelog here is a page rather than a lazily loaded drawer, so the build string lands in the main `index` chunk instead of a split one.

## Design notes

**A separate module, not logic in the component.** `src/utils/buildInfo.ts` exposes `getBuildInfo()`; the fallback rules are then testable without rendering anything.

**The env is read inside the function, not captured at module scope.** A module-scope capture is evaluated once at import and cannot be stubbed per test, which would leave the fallback untestable.

**Half-configured counts as untracked.** A run number with no SHA renders `local build`, not `#412` — showing a run number with no commit behind it implies a provenance the bundle does not have. A SHA with no run number is equally untracked, since it cannot tell two builds of one commit apart. Blank and whitespace-only values are treated as absent.

## Verification

| Check | Result |
|---|---|
| `VITE_BUILD_SHA=… VITE_BUILD_RUN=412 npm run build:acc` | both values present in the bundle |
| `npm run build:acc` (no env) | `local build` present, zero stale SHA, chunk hash changed |
| buildInfo unit tests | 8/8, written RED-first |
| Full frontend suite | 69 files, 1028 tests, all passing |
| Lint / Typecheck / check-format | clean |
| Semgrep (494 Pro-tier rules, 6 files) | 0 findings |

## The one thing still unproven

Every check above establishes the code path. **None of them prove the environment crosses into the Oryx container** — that boundary does not exist in RBA and cannot be exercised locally. The preview deployment on this PR is the first and only evidence.

If the preview reads `local build`, the wiring is wrong rather than the code, and the fallback is `skip_app_build: true` plus an explicit build step on the runner, matching what RBA does.

## Expected oddity on this PR

On a pull request `github.sha` is the **merge commit GitHub synthesises**, not the head of the branch, so the SHA on the preview will match no commit in this branch's history. That is normal and it is what got built. On a push it is the real commit.

## Second commit

`chore(frontend): keep prettier off Semgrep Guardian's scratch files` — unrelated to the feature, kept separate. Guardian writes a `.semgrep/` directory into the working tree; `.gitignore` already excluded it, `.prettierignore` did not, so `check-format` failed on files no one authored.
