### PR TITLE
ci: promote check-supply-chain to a blocking check

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -116,36 +116,38 @@ jobs:
         # if: always() for the same reason as the validator above — one run
         # should report on every half of the policy, not stop at the first.
         if: always()
-        # NON-BLOCKING for now, and not merely out of caution.
         #
-        # Renovate rewrites workflow pins and never touches SECURITY-PIPELINE.md,
-        # so every action-bump pull request fails the register half until the
-        # register is updated by hand. Verified against the real thing, not
-        # assumed: PR #66 (actions/checkout → v7.0.1) reports
-        #   [register] actions/checkout: workflow pins 3d3c42e5aac5… (v7.0.1)
-        #              but SECURITY-PIPELINE.md records only 11d5960a3267…
-        # while PIN TRUTH passes — Renovate's digest and comment agree with
-        # each other and with GitHub. The check is right and the register is
-        # stale, which is exactly what it exists to say.
+        # BLOCKING. It was introduced with continue-on-error: true in #77 and
+        # promoted in #81, once the thing it was waiting on had been shown to
+        # work twice.
         #
-        # Blocking on that would make a required check fail on routine
-        # dependency updates, which is how gates get resented and then
-        # bypassed.
+        # What it was waiting on: Renovate rewrites workflow pins and never
+        # touches SECURITY-PIPELINE.md, so every action-bump pull request
+        # fails the register half until the register is updated by hand.
+        # Blocking on that would fail a required check on routine dependency
+        # updates -- how gates get resented and then bypassed.
         #
-        # The agreed answer is that the register is updated ON the Renovate
-        # pull request's branch, before it is merged -- not afterwards, which
-        # would leave the check red for that pull request's whole life and
-        # make this step impossible to promote, since no bump could ever show
-        # a green result to merge on. Promote to blocking once that habit
-        # holds; see SECURITY-PIPELINE.md, "Keeping this register true", and
-        # issue #73.
+        # What resolved it: the register is updated ON the bump's branch,
+        # before merging, so the check is green on the pull request rather
+        # than only on acc afterwards. Exercised on #66 (actions/checkout to
+        # v7.0.1, which also collapsed a two-digest split pin) and #67
+        # (actions/setup-node to v7.0.0). Both went green on the branch and
+        # merged green. See SECURITY-PIPELINE.md, "Keeping this register
+        # true".
         #
-        # The second reason to wait: this step makes a network call inside a
-        # job the ruleset requires, so an API outage or rate limit could fail
-        # a gate that has nothing to do with the change under review. Pass
-        # --offline to check format and register agreement without resolving
-        # pins, if that ever proves to be the problem.
-        continue-on-error: true
+        # Why NOT staying non-blocking, which is the part that is easy to get
+        # wrong: continue-on-error does not merely keep the job green, it
+        # rewrites the STEP's reported conclusion too, and the honest result
+        # (outcome: failure) is not exposed by the REST API at all. On #66 the
+        # job, the step and the pull request's checks list all read "success"
+        # while this step's own log carried a real finding. A check nobody can
+        # see fail is not protecting anything -- it is a check that has to be
+        # remembered, which is the condition the register drifted in.
+        #
+        # If the GitHub API ever proves flaky enough to fail this gate on an
+        # outage or a rate limit, add --offline rather than reverting to
+        # continue-on-error: it keeps the register half blocking and drops
+        # only the network-dependent half.
         env:
           # contents: read suffices — this only resolves public refs.
           GITHUB_TOKEN: ${{ github.token }}

--- a/SECURITY-PIPELINE.md
+++ b/SECURITY-PIPELINE.md
@@ -175,8 +175,23 @@ each other and with GitHub. The check was right and the register was stale. The
 row above was updated on that pull request's branch, which is the habit this
 section describes, and the check went green before it merged.
 
-The step is `continue-on-error: true` until that habit is established. See
-issue [#73](https://github.com/sgort/linked-data-explorer/issues/73).
+**The step blocks.** It was introduced non-blocking in
+[#77](https://github.com/sgort/linked-data-explorer/pull/77) and promoted in
+[#81](https://github.com/sgort/linked-data-explorer/pull/81), once the habit
+above had been exercised twice —
+[#66](https://github.com/sgort/linked-data-explorer/pull/66)
+(`actions/checkout` → v7.0.1, which also collapsed a two-digest split pin) and
+[#67](https://github.com/sgort/linked-data-explorer/pull/67)
+(`actions/setup-node` → v7.0.0). Both went green on the branch and merged green.
+
+So an action bump that leaves this table behind now **fails the audit**. That is
+the intended cost: the register is part of the policy, and a register describing
+workflows that have moved on is not documentation, it is a claim that is no
+longer true.
+
+If the GitHub API ever fails the gate through an outage or a rate limit, add
+`--offline` rather than restoring `continue-on-error` — it keeps the register
+half blocking and drops only the network-dependent half.
 
 An action may legitimately hold **more than one row**. Until #66 this table
 carried two for `actions/checkout` — v4.4.0 in three workflows, v3.7.0 in four,


### PR DESCRIPTION
Closes #78.

Removes `continue-on-error: true` from the pin-truth step in the `audit` job. A register that no longer describes the workflows now fails the gate.

## What it was waiting on

Renovate rewrites workflow pins and their version comments together and never touches `SECURITY-PIPELINE.md`, so every action bump fails the register half until the register is updated by hand. Blocking on that would fail a required check on routine dependency updates — how gates get resented and then bypassed. #77 therefore landed non-blocking, deliberately.

The answer was to update the register **on the bump's branch, before merging**, so the check is green on the pull request rather than only on `acc` afterwards.

## It has now been exercised twice

| PR | Bump | Outcome |
|---|---|---|
| #66 | `actions/checkout` → v7.0.1 | found the drift, register moved on the branch, green before merge. Also collapsed a two-digest split pin and took **three stale prose passages** with it |
| #67 | `actions/setup-node` → v7.0.0 | same, in a **single-line** edit — nothing in the surrounding prose went stale |

Both went green on the branch before merging, which is the property that makes blocking viable rather than obstructive. The contrast between them is also informative: the check verifies the *table*, and nothing verifies the prose around it. #66 needed a human to notice; #67 genuinely didn't.

## Why not just leave it non-blocking

This is the part that's easy to get wrong, and it's the strongest argument for promoting.

`continue-on-error` doesn't merely keep the job green — it **rewrites the step's reported conclusion too**, and the honest result (`outcome: failure`) isn't exposed by the REST API at all. On #66, before its register was fixed:

```
job: audit
job conclusion: success
step: Verify pin truth and register agreement -> success
```

while that same step's log read:

```
1 finding(s):

  [register] actions/checkout: workflow pins 3d3c42e5aac5… (v7.0.1) but
             SECURITY-PIPELINE.md records only 11d5960a3267… (v4.4.0), a37ce9120846… (v3.7.0)
```

A real finding — and the checks list, the job, and the step all said success. **Only the log told the truth.**

A check nobody can see fail is not protecting anything. It is a check that has to be *remembered*, which is exactly the condition the register drifted in to begin with.

## The risk this accepts

A network call now sits inside a job the ruleset requires, so a GitHub API outage or rate limit can fail a gate unrelated to the change under review. Six audit runs have resolved digests without a hiccup — but that is one day's evidence, and worth stating plainly rather than glossing.

**The fallback is `--offline`, not reverting.** It keeps the register half blocking and drops only the network-dependent half. Recorded in both the workflow comment and `SECURITY-PIPELINE.md`, because the tempting fix under pressure would be to restore `continue-on-error`, which brings back the invisibility above.

## Verification

- Parsed workflow confirms `continue-on-error` is **absent** and `if: always()` is **retained** — so a zizmor or validator failure still doesn't skip this step.
- `npm run check-supply-chain` exits 0 on this branch, so promoting the step doesn't itself turn the gate red.
- This PR's own `audit` run is the first real exercise of the blocking form.

## Note for the other repositories

`sgort/ronl-business-api` has the adoption issue open and will land non-blocking for the same reasons. The same two-exercise bar applies before promoting there — and the invisibility argument above is worth carrying across, since it isn't obvious until you go looking for a finding that every UI surface says isn't there.
