### PR TITLE
ci: enforce the per-file 80% branch floor, and close the two audit gaps

### DIFF
--- a/.github/workflows/azure-backend-acc.yml
+++ b/.github/workflows/azure-backend-acc.yml
@@ -1,6 +1,23 @@
 name: Deploy Backend to Acceptance
 
 on:
+  # The backend's 1140 tests used to run only AFTER a merge, because this
+  # workflow triggered on push alone. A backend pull request therefore reached
+  # acc with `audit` as its only check -- which validates workflows and
+  # renovate.json and says nothing about whether the code works. Dependency
+  # bumps were verified by a person remembering to check the branch out, and a
+  # genuine defect (the example-fixture-parity failure on
+  # feature/rip-r21-signature-tag) sat on a pushed branch for days because no
+  # pull request ever ran that test. Issue #46.
+  #
+  # The frontend workflow already worked this way; this brings the backend into
+  # line rather than inventing a pattern.
+  pull_request:
+    branches:
+      - acc
+    paths:
+      - 'packages/backend/**'
+      - '.github/workflows/azure-backend-acc.yml'
   push:
     branches:
       - acc
@@ -71,7 +88,13 @@ jobs:
           grep -n "v1/health" dist/routes/index.js || echo "ERROR: v1 routes not found!"
           grep -n "sparqlService" dist/routes/health.routes.js || echo "ERROR: sparqlService not found!"
 
+      # Everything from here on deploys. On a pull request the job stops after
+      # lint, typecheck, tests and build -- which is the point of #46: get the
+      # verdict before the merge, not after it. Gating each step rather than
+      # splitting the job keeps the check name `Deploy Backend to Acceptance`
+      # stable, so no ruleset or branch-protection entry has to change.
       - name: Prepare deployment package
+        if: github.event_name != 'pull_request'
         working-directory: packages/backend
         run: |
           mkdir -p deploy
@@ -103,6 +126,7 @@ jobs:
           echo "SCM_DO_BUILD_DURING_DEPLOYMENT = false" >> .deployment
 
       - name: Deploy to Azure Web App
+        if: github.event_name != 'pull_request'
         uses: azure/webapps-deploy@02a81bead70021f5284939794bcec79c271ab383 # v3.0.8
         with:
           app-name: 'ronl-linkeddata-backend-acc'
@@ -110,9 +134,11 @@ jobs:
           package: './packages/backend/deploy'
 
       - name: Wait for deployment
+        if: github.event_name != 'pull_request'
         run: sleep 20
 
       - name: Health check
+        if: github.event_name != 'pull_request'
         run: |
           echo "Checking backend health..."
           
@@ -133,6 +159,7 @@ jobs:
           exit 1
 
       - name: Verify v1 endpoints
+        if: github.event_name != 'pull_request'
         run: |
           echo "Checking v1 endpoints..."
           
@@ -155,7 +182,7 @@ jobs:
           fi
 
       - name: Deployment success
-        if: success()
+        if: success() && github.event_name != 'pull_request'
         run: |
           echo "🚀 Backend successfully deployed to acceptance!"
           echo "URL: https://acc.backend.linkeddata.open-regels.nl"

--- a/.github/workflows/azure-backend-production.yml
+++ b/.github/workflows/azure-backend-production.yml
@@ -1,6 +1,24 @@
 name: Deploy Backend to Production
 
 on:
+  # NO pull_request trigger here, deliberately -- issue #46 asked for this to be
+  # decided rather than left to drift, and the acc workflow got the opposite
+  # answer.
+  #
+  # Two reasons, in order of weight:
+  #
+  # 1. This job declares `environment: production`, which carries
+  #    required_reviewers and a branch policy. A pull_request trigger would
+  #    make every pull request to main wait on a human approval BEFORE the
+  #    tests could run -- an approval gate in front of the check meant to
+  #    inform it, which is exactly backwards.
+  #
+  # 2. main is promoted from acc. A pull request here carries content that
+  #    already ran lint, typecheck and the full suite on its acc pull request,
+  #    so a second pre-merge run would re-test the same commits.
+  #
+  # The acc workflow is where pre-merge verification belongs; see the note on
+  # its triggers. If main ever stops being promoted from acc, revisit this.
   push:
     branches:
       - main

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -106,6 +106,31 @@ jobs:
         # nothing useful.
         run: npx --yes --package renovate@44.50.3 renovate-config-validator --strict
 
+      - name: Install dependencies for the formatter
+        # Needed because the formatting check below must run THIS repository's
+        # prettier, not a version named here. Issue #45 exists because prettier
+        # 3.7 -> 3.9 changed how short union types are formatted: five
+        # untouched files started failing `prettier --check` the moment #38
+        # merged, with every CI check green, and the symptom would have been
+        # the next person's `git push` failing on files they had never opened.
+        # An `npx prettier@<pinned>` here would be a second version to keep in
+        # step with package.json -- reintroducing the same class of drift the
+        # check is meant to catch. npm ci costs install time and cannot drift.
+        if: always()
+        run: npm ci
+      - name: Check formatting
+        # prettier lives per workspace here, each with its own .prettierrc and
+        # .prettierignore, and .prettierignore is resolved relative to the
+        # working directory. So `prettier --check .` from the repository root
+        # would silently check dist/ and coverage/ and disagree with what the
+        # pre-push hook enforces. The root script fans out per workspace, which
+        # is the same command developers run.
+        #
+        # if: always() for the same reason as the validator above -- a zizmor
+        # failure should not hide a formatting failure behind it.
+        if: always()
+        run: npm run check-format
+
       - name: Verify pin truth and register agreement
         # zizmor validates pin FORMAT — that `uses:` names a 40-character SHA.
         # It cannot say the SHA is the RIGHT one, so a wrong or hostile digest

--- a/packages/backend/jest.config.js
+++ b/packages/backend/jest.config.js
@@ -17,6 +17,28 @@ module.exports = {
     // mocked pool, just not yet covered.
     '!src/db/seed-ropa.ts',
   ],
+  // A per-file 80% branch floor, enforced rather than assumed.
+  //
+  // A GLOB key, not `global`. Jest applies a glob threshold to each matching
+  // file individually; a package-wide average (92.22% here) is precisely what
+  // hides one file falling off a cliff.
+  //
+  // Branches specifically: statement and line coverage largely restate "was
+  // this file imported", function coverage rewards splitting code into more
+  // functions, and an uncovered branch is a decision no test has ever checked.
+  //
+  // Measured clean when this landed — 49 files, none below 80, lowest
+  // sparql.service.ts at 82.85. More margin than the frontend has.
+  //
+  // This gates pull requests only because azure-backend-acc.yml gained a
+  // pull_request trigger in the same change (#46). Before that the suite ran
+  // after the merge, so a threshold here would have failed on acc rather than
+  // on the branch that caused it.
+  coverageThreshold: {
+    './src/**/*.ts': {
+      branches: 80,
+    },
+  },
   transform: {
     '^.+\\.tsx?$': [
       'ts-jest',

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -28,6 +28,27 @@ export default defineConfig(({ mode }) => {
         provider: 'v8',
         include: ['src/**/*.{ts,tsx}'],
         exclude: ['src/**/*.test.{ts,tsx}', 'src/main.tsx', 'src/vite-env.d.ts', 'src/test/**'],
+        // A per-file 80% branch floor, enforced rather than assumed.
+        //
+        // perFile is the mechanism, not a detail: against the package average
+        // (90.59%) the threshold is inert, because one file dropping to 40%
+        // barely moves it. Branches specifically, because statement and line
+        // coverage largely restate "was this file imported", and an uncovered
+        // branch is a decision no test has ever checked.
+        //
+        // Measured clean when this landed — 64 files, none below 80. But the
+        // margin is thin: CaseworkerCasePanel.tsx sits at EXACTLY 80.00, and
+        // thirteen more files are between 80 and 85. The first uncovered
+        // branch added to any of them turns this red. That is the floor
+        // working, not a misconfiguration — but it is worth knowing before
+        // someone meets it on an unrelated change.
+        //
+        // Branches only. A functions floor would fail today; this is not a
+        // companion setting to add without measuring first.
+        thresholds: {
+          branches: 80,
+          perFile: true,
+        },
       },
     },
   };


### PR DESCRIPTION
Closes #45. Closes #46.

Three changes with one cause: rules that held on a developer's machine and not on `acc`.

## Measured before enforcing

| workspace | tests | branch % | files < 80 | lowest |
|---|---|---|---|---|
| backend | 1140 | 92.22 | **none** | `sparql.service.ts` 82.85 |
| frontend | 1019 | 90.59 | **none** | **`CaseworkerCasePanel.tsx` 80.00** |

Verified against 49 + 64 table rows, so "none" is a measurement rather than a parser that matched nothing.

## 1. The floor

Per-file **branch** thresholds in both runners — Jest via a glob key (applied per matching file), Vitest via `thresholds: { branches: 80, perFile: true }`.

`perFile` is the mechanism, not a detail: against the package average the threshold is inert, because one file dropping to 40% barely moves 90%.

**Branches specifically** — statement and line coverage largely restate "was this file imported", function coverage rewards splitting code into more functions, and an uncovered branch is a decision no test has ever checked.

⚠️ **The margin is thin, and the config says so.** `CaseworkerCasePanel.tsx` is at **exactly 80.00**, with thirteen more files between 80 and 85. The first uncovered branch added to any of them turns CI red. That is the floor working — but it is worth meeting in a config comment rather than in a surprising failure on an unrelated change. Whether that file gets a few tests to buy margin is a separate decision.

## 2. #46 — the backend ran no tests on a pull request

`azure-backend-acc.yml` triggered on `push` alone, so 1140 tests ran only *after* the merge. Added a `pull_request` trigger and gated the six deploy-side steps on the event.

Gating steps rather than splitting the job keeps the check name `Deploy Backend to Acceptance` stable, so **no ruleset entry changes**.

This is also what makes the backend threshold worth anything: before it, the floor would have failed on `acc` rather than on the branch that broke it.

### The production question, decided on evidence

#46 asked for `azure-backend-production.yml` to get the same treatment *or a deliberate exclusion*. It gets the exclusion, because the two environments differ in a way that settles it:

| environment | protection rules |
|---|---|
| `acceptance` | none |
| `production` | **required_reviewers, branch_policy** |

A `pull_request` trigger there would make every pull request to `main` wait on a human approval **before the tests could run** — an approval gate in front of the check meant to inform it. `main` is also promoted from `acc`, so those commits already ran the full suite on their `acc` pull request.

Recorded in the workflow with the reasoning, so it reads as a decision rather than an oversight.

## 3. #45 — check-format ran in no workflow

Added to the `audit` job, preceded by `npm ci`.

**The install cost is deliberate.** An `npx prettier@<pinned>` would be a *second* version to keep in step with `package.json` — reintroducing the exact drift the check exists to catch. #45 happened because prettier 3.7 → 3.9 changed short-union formatting: five untouched files began failing the moment #38 merged, with every CI check green, and the symptom would have been the next person's `git push` failing on files they had never opened.

**And it must run the fan-out, not a root-level check.** Prettier lives per workspace here, each with its own `.prettierrc` and `.prettierignore` — and `.prettierignore` resolves relative to the working directory. `prettier --check .` from the root would silently check `dist/` and `coverage/` and disagree with what pre-push enforces. The step runs `npm run check-format`, the same command developers run.

`check-format` passes on this branch, so the step lands green — #45's caution was that it must arrive alongside any reformat it demands, and it demands none.

## Verification

Both suites pass with thresholds active (1140, 1019). More usefully, **the gate was proven by making it fail**:

```
Jest:   ".../src/__threshold-probe.ts" coverage threshold for branches (80%) not met: 0%
Vitest: ERROR: Coverage for branches (0%) does not meet global threshold (80%) for src/__threshold-probe.ts
```

Both exit 1 and both name the file. Vitest reports "global threshold" even in per-file mode — its wording, not a misconfiguration; naming the file rather than the 90.59% package average is what demonstrates per-file behaviour.

Probes removed and both suites green again. All three workflows parse. `check-format` passes. semgrep clean. The supply-chain register still agrees — these steps add no `uses:` line.

## What to watch on this PR

This is the first pull request where the backend workflow runs on `pull_request`, so **`Deploy Backend to Acceptance` should appear as a check and stop after the build** — no deploy, no health check. If it deploys, the event gating is wrong and that is the thing to catch here rather than after a merge.
