### PR TITLE
test: give the per-file 80% branch floor room to breathe

### DIFF
--- a/packages/frontend/src/components/ChainBuilder/ChainConfig.test.tsx
+++ b/packages/frontend/src/components/ChainBuilder/ChainConfig.test.tsx
@@ -60,7 +60,13 @@ function validation(overrides: Partial<ChainValidation> = {}): ChainValidation {
 
 function template(
   overrides: Partial<
-    ChainPreset & { type: string; category: string; complexity: string; estimatedTime: number }
+    ChainPreset & {
+      type: string;
+      category: string;
+      complexity: string;
+      estimatedTime: number;
+      usageCount: number;
+    }
   > = {}
 ) {
   return {
@@ -151,6 +157,89 @@ describe('ChainConfig — empty chain (template browser)', () => {
     await userEvent.click(screen.getByTitle('Delete template'));
 
     expect(deleteUserTemplate).toHaveBeenCalledWith('https://example.com/sparql', 'u1');
+  });
+
+  test('the Custom category is served from localStorage without a backend query', async () => {
+    getAllTemplates.mockResolvedValue([template({ id: 'p1', name: 'Predefined chain' })]);
+    getUserTemplates.mockReturnValue([
+      {
+        ...template({ id: 'u1', name: 'My custom chain', category: 'custom' }),
+        endpoint: 'e',
+        isUserTemplate: true,
+      },
+    ]);
+    render(<ChainConfig {...baseProps} chain={[]} validation={null} />);
+    await screen.findByText('Predefined chain');
+
+    await userEvent.selectOptions(screen.getByRole('combobox'), 'custom');
+
+    expect(await screen.findByText('My custom chain')).toBeTruthy();
+    expect(screen.queryByText('Predefined chain')).toBeNull();
+    // 'custom' is not a backend category — asking for it returns nothing and
+    // would wipe the list the user actually wants.
+    expect(getTemplatesByCategory).not.toHaveBeenCalled();
+  });
+
+  test('cancelling the delete confirmation neither deletes nor loads the template', async () => {
+    getAllTemplates.mockResolvedValue([]);
+    getUserTemplates.mockReturnValue([
+      { ...template({ id: 'u1', name: 'My custom chain' }), endpoint: 'e', isUserTemplate: true },
+    ]);
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const onLoadPreset = vi.fn();
+    render(<ChainConfig {...baseProps} chain={[]} validation={null} onLoadPreset={onLoadPreset} />);
+    await screen.findByText('My Templates');
+
+    await userEvent.click(screen.getByTitle('Delete template'));
+
+    expect(deleteUserTemplate).not.toHaveBeenCalled();
+    expect(screen.getByText('My custom chain')).toBeTruthy();
+    // The delete button sits inside the template's load button; without the
+    // stopPropagation the cancelled delete would load the chain instead.
+    expect(onLoadPreset).not.toHaveBeenCalled();
+  });
+
+  test('a delete the storage layer rejects alerts instead of silently reloading', async () => {
+    getAllTemplates.mockResolvedValue([]);
+    getUserTemplates.mockReturnValue([
+      { ...template({ id: 'u1', name: 'My custom chain' }), endpoint: 'e', isUserTemplate: true },
+    ]);
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    deleteUserTemplate.mockReturnValue(false);
+    render(<ChainConfig {...baseProps} chain={[]} validation={null} />);
+    await screen.findByText('My Templates');
+
+    await userEvent.click(screen.getByTitle('Delete template'));
+
+    expect(alertSpy).toHaveBeenCalledWith('Failed to delete template');
+    expect(screen.getByText('My custom chain')).toBeTruthy();
+  });
+
+  test('DRD templates are marked as such in both lists', async () => {
+    getAllTemplates.mockResolvedValue([template({ id: 'p1', name: 'DRD chain', type: 'drd' })]);
+    getUserTemplates.mockReturnValue([
+      {
+        ...template({ id: 'u1', name: 'My DRD chain', type: 'drd' }),
+        endpoint: 'e',
+        isUserTemplate: true,
+      },
+    ]);
+    render(<ChainConfig {...baseProps} chain={[]} validation={null} />);
+
+    expect(await screen.findByText('DRD chain')).toBeTruthy();
+    expect(screen.getByText('DRD')).toBeTruthy();
+    // One marker per list — the sequential '⛓️' would be wrong for both.
+    expect(screen.getAllByText('🎯')).toHaveLength(2);
+    expect(screen.queryByText('⛓️')).toBeNull();
+  });
+
+  test('a template that records usage shows the count', async () => {
+    getAllTemplates.mockResolvedValue([template({ usageCount: 12 })]);
+    getUserTemplates.mockReturnValue([]);
+    render(<ChainConfig {...baseProps} chain={[]} validation={null} />);
+
+    expect(await screen.findByText('12 uses')).toBeTruthy();
   });
 });
 
@@ -377,5 +466,140 @@ describe('ChainConfig — populated chain', () => {
 
     expect(screen.queryByRole('heading', { name: 'Save as DRD Template' })).toBeNull();
     expect(saveUserTemplate).not.toHaveBeenCalled();
+  });
+
+  /** Saves a sequential template named `name` over the given chain. */
+  async function saveSequentialTemplate(chain: DmnModel[], name: string, v = validation()) {
+    getAllTemplates.mockResolvedValue([]);
+    getUserTemplates.mockReturnValue([]);
+    saveUserTemplate.mockReturnValue({ ...template(), name });
+    vi.spyOn(window, 'alert').mockImplementation(() => {});
+    render(
+      <ChainConfig {...baseProps} chain={chain} validation={{ ...v, isDrdCompatible: false }} />
+    );
+
+    await userEvent.click(screen.getByTitle('Save template'));
+    await userEvent.type(screen.getByPlaceholderText(/My Eligibility Check/), name);
+    await userEvent.click(screen.getByRole('button', { name: 'Save Template' }));
+  }
+
+  test('a template saved without a description gets one derived from the chain', async () => {
+    await saveSequentialTemplate(
+      [dmn(), dmn({ id: 'd2', identifier: 'income-check' })],
+      'Two step'
+    );
+
+    await vi.waitFor(() =>
+      expect(saveUserTemplate).toHaveBeenCalledWith(
+        'https://example.com/sparql',
+        expect.objectContaining({
+          description: 'Sequential chain with 2 DMNs',
+          complexity: 'medium',
+        })
+      )
+    );
+  });
+
+  test('a chain of more than three DMNs is saved as complex', async () => {
+    const chain = ['a', 'b', 'c', 'd'].map((id, i) => dmn({ id: `d${i}`, identifier: id }));
+
+    await saveSequentialTemplate(chain, 'Four step');
+
+    await vi.waitFor(() =>
+      expect(saveUserTemplate).toHaveBeenCalledWith(
+        'https://example.com/sparql',
+        expect.objectContaining({
+          description: 'Sequential chain with 4 DMNs',
+          complexity: 'complex',
+        })
+      )
+    );
+  });
+
+  test('a validation without a timing estimate falls back to one derived from the chain', async () => {
+    await saveSequentialTemplate([dmn()], 'No estimate', validation({ estimatedTime: 0 }));
+
+    await vi.waitFor(() =>
+      // 1 DMN → 1 * 150 + 50. Storing 0 would advertise the chain as instant.
+      expect(saveUserTemplate).toHaveBeenCalledWith(
+        'https://example.com/sparql',
+        expect.objectContaining({ estimatedTime: 200 })
+      )
+    );
+  });
+
+  /** Opens the DRD save modal and submits it against a failing deploy response. */
+  async function failingDrdDeploy(deployBody: unknown) {
+    getAllTemplates.mockResolvedValue([]);
+    getUserTemplates.mockReturnValue([]);
+    global.fetch = vi.fn().mockResolvedValue({ json: async () => deployBody });
+    render(
+      <ChainConfig
+        {...baseProps}
+        chain={[dmn()]}
+        validation={validation({ isDrdCompatible: true })}
+      />
+    );
+
+    await userEvent.click(screen.getByTitle('Save as DRD'));
+    await userEvent.type(screen.getByPlaceholderText(/My Eligibility Check/), 'My DRD');
+    await userEvent.click(screen.getByRole('button', { name: 'Save as DRD' }));
+  }
+
+  test('a deploy failure carrying an error object surfaces its message', async () => {
+    // Camunda answers with an object here, not the string the sibling test uses.
+    await failingDrdDeploy({ success: false, error: { message: 'DMN age-check not deployed' } });
+
+    expect(await screen.findByText(/DMN age-check not deployed/)).toBeTruthy();
+    expect(saveUserTemplate).not.toHaveBeenCalled();
+  });
+
+  test('a deploy failure with an unrecognised error shape falls back to the serialised payload', async () => {
+    await failingDrdDeploy({ success: false, error: { code: 42 } });
+
+    expect(await screen.findByText(/\{"code":42\}/)).toBeTruthy();
+  });
+
+  test('a deploy failure with no error field at all falls back to a generic message', async () => {
+    await failingDrdDeploy({ success: false });
+
+    expect(await screen.findByText(/DRD deployment failed/)).toBeTruthy();
+  });
+
+  test('the Inputs section collapses and expands', async () => {
+    getAllTemplates.mockResolvedValue([]);
+    getUserTemplates.mockReturnValue([]);
+    render(<ChainConfig {...baseProps} chain={[dmn()]} validation={validation()} />);
+
+    expect(screen.getByText('InputForm stub')).toBeTruthy();
+    await userEvent.click(screen.getByText('Inputs'));
+    expect(screen.queryByText('InputForm stub')).toBeNull();
+
+    await userEvent.click(screen.getByText('Inputs'));
+    expect(screen.getByText('InputForm stub')).toBeTruthy();
+  });
+
+  test('a chain linked by semantic matches warns that execution stays sequential', async () => {
+    getAllTemplates.mockResolvedValue([]);
+    getUserTemplates.mockReturnValue([]);
+    render(
+      <ChainConfig
+        {...baseProps}
+        chain={[dmn()]}
+        validation={validation({
+          semanticMatches: [
+            {
+              outputDmn: 'age-check',
+              outputVar: 'leeftijd',
+              inputDmn: 'income-check',
+              inputVar: 'age',
+              matchType: 'semantic',
+            },
+          ],
+        })}
+      />
+    );
+
+    expect(screen.getByText('Sequential execution required (semantic links)')).toBeTruthy();
   });
 });

--- a/packages/frontend/src/components/ChainBuilder/ExportChain.test.tsx
+++ b/packages/frontend/src/components/ChainBuilder/ExportChain.test.tsx
@@ -162,6 +162,123 @@ describe('ExportChain', () => {
     expect(screen.getByText('Export Chain')).toBeTruthy();
   });
 
+  test('a failed export with no error text falls back to a generic message', async () => {
+    validateChainForExport.mockReturnValue({ valid: true, errors: [] });
+    exportChain.mockResolvedValue({ success: false });
+    render(
+      <ExportChain
+        dmnIds={['age-check']}
+        inputs={{}}
+        chainDmns={[dmn()]}
+        validation={validation()}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /Export/ }));
+    await userEvent.click(screen.getAllByRole('button', { name: /Export/ })[1]);
+
+    expect(await screen.findByText('Export failed')).toBeTruthy();
+  });
+
+  test('an exportChain rejection surfaces the thrown message', async () => {
+    validateChainForExport.mockReturnValue({ valid: true, errors: [] });
+    exportChain.mockRejectedValue(new Error('Serializer crashed'));
+    render(
+      <ExportChain
+        dmnIds={['age-check']}
+        inputs={{}}
+        chainDmns={[dmn()]}
+        validation={validation()}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /Export/ }));
+    await userEvent.click(screen.getAllByRole('button', { name: /Export/ })[1]);
+
+    expect(await screen.findByText('Serializer crashed')).toBeTruthy();
+    expect(screen.getByText('Export Chain')).toBeTruthy();
+  });
+
+  test('a rejection that is not an Error still leaves the modal usable', async () => {
+    validateChainForExport.mockReturnValue({ valid: true, errors: [] });
+    exportChain.mockRejectedValue('not an Error instance');
+    render(
+      <ExportChain
+        dmnIds={['age-check']}
+        inputs={{}}
+        chainDmns={[dmn()]}
+        validation={validation()}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /Export/ }));
+    await userEvent.click(screen.getAllByRole('button', { name: /Export/ })[1]);
+
+    expect(await screen.findByText('Unknown error')).toBeTruthy();
+    // The finally block must still clear isExporting, or the footer button
+    // stays stuck on "Exporting…" with no way to retry.
+    expect(screen.getAllByRole('button', { name: /Export/ })[1]).not.toBeDisabled();
+  });
+
+  test('the chain summary pluralises the DMN count', async () => {
+    validateChainForExport.mockReturnValue({ valid: true, errors: [] });
+    render(
+      <ExportChain
+        dmnIds={['age-check', 'income-check']}
+        inputs={{ age: 30 }}
+        chainDmns={[dmn(), dmn({ id: 'd2', identifier: 'income-check' })]}
+        validation={validation()}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /Export/ }));
+
+    expect(screen.getByText('2 DMNs • 1 input')).toBeTruthy();
+  });
+
+  test('Enter in the filename field runs the export', async () => {
+    validateChainForExport.mockReturnValue({ valid: true, errors: [] });
+    exportChain.mockResolvedValue({ success: true });
+    render(
+      <ExportChain
+        dmnIds={['age-check']}
+        inputs={{}}
+        chainDmns={[dmn()]}
+        validation={validation()}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /Export/ }));
+    await userEvent.type(screen.getByPlaceholderText('Enter filename...'), '-v2{Enter}');
+
+    expect(exportChain).toHaveBeenCalledWith(
+      ['age-check'],
+      {},
+      [dmn()],
+      expect.objectContaining({ filename: 'chain-1-dmns-v2' })
+    );
+  });
+
+  test('Enter with an empty filename does not run the export', async () => {
+    validateChainForExport.mockReturnValue({ valid: true, errors: [] });
+    render(
+      <ExportChain
+        dmnIds={['age-check']}
+        inputs={{}}
+        chainDmns={[dmn()]}
+        validation={validation()}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /Export/ }));
+    const input = screen.getByPlaceholderText('Enter filename...');
+    await userEvent.clear(input);
+    await userEvent.type(input, '{Enter}');
+
+    expect(exportChain).not.toHaveBeenCalled();
+    expect(screen.getByText('Export Chain')).toBeTruthy();
+  });
+
   test('Cancel closes the modal and resets the filename', async () => {
     validateChainForExport.mockReturnValue({ valid: true, errors: [] });
     render(

--- a/packages/frontend/src/components/ChainBuilder/SemanticView.test.tsx
+++ b/packages/frontend/src/components/ChainBuilder/SemanticView.test.tsx
@@ -108,4 +108,95 @@ describe('SemanticView', () => {
     const counts = screen.getAllByText('1');
     expect(counts.length).toBeGreaterThanOrEqual(2);
   });
+
+  test('a response flagged unsuccessful is ignored even when it carries data', async () => {
+    // The API answers 200 with success:false and a stale/partial payload.
+    // Without the success check that payload would render as if it were sound.
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (String(url).includes('semantic-equivalences')) {
+        return jsonResponse({
+          success: false,
+          error: 'endpoint unreachable',
+          data: [
+            {
+              dmn1: { title: 'Stale A' },
+              dmn2: { title: 'Stale B' },
+              sharedConcept: 'https://example.com/concept/leeftijd',
+              concept1: { label: 'Leeftijd', variable: { identifier: 'age' } },
+              concept2: { label: 'Age', variable: { identifier: 'age' } },
+            },
+          ],
+        });
+      }
+      return jsonResponse({
+        success: false,
+        error: 'endpoint unreachable',
+        data: [
+          {
+            matchType: 'semantic',
+            dmn1: { title: 'Stale C' },
+            dmn2: { title: 'Stale D' },
+            outputVariable: 'out',
+            inputVariable: 'in',
+            sharedConcept: 'https://example.com/concept/naam',
+          },
+        ],
+      });
+    });
+    render(<SemanticView endpoint="e" apiBaseUrl="a" />);
+
+    expect(
+      await screen.findByText(
+        'No semantic chain links found. Variables match by exact identifier only.'
+      )
+    ).toBeTruthy();
+    expect(screen.getByText('No semantic equivalences found via skos:exactMatch.')).toBeTruthy();
+    expect(screen.queryByText('Stale A')).toBeNull();
+    expect(screen.queryByText('Stale C')).toBeNull();
+  });
+
+  test('a data payload that is not an array is ignored rather than crashing the render', async () => {
+    // Both lists are rendered with .map(), so a non-array `data` that slips
+    // past the guard throws during render and blanks the whole tab.
+    global.fetch = vi
+      .fn()
+      .mockImplementation(() => jsonResponse({ success: true, data: { message: 'unexpected' } }));
+    render(<SemanticView endpoint="e" apiBaseUrl="a" />);
+
+    expect(
+      await screen.findByText(
+        'No semantic chain links found. Variables match by exact identifier only.'
+      )
+    ).toBeTruthy();
+    expect(screen.getByText('No semantic equivalences found via skos:exactMatch.')).toBeTruthy();
+  });
+
+  test('a concept notation is rendered in parentheses beside its label', async () => {
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (String(url).includes('semantic-equivalences')) {
+        return jsonResponse({
+          success: true,
+          data: [
+            {
+              dmn1: { title: 'A' },
+              dmn2: { title: 'B' },
+              sharedConcept: 'https://example.com/concept/leeftijd',
+              concept1: {
+                label: 'Leeftijd',
+                notation: 'LFT-01',
+                variable: { identifier: 'age' },
+              },
+              concept2: { label: 'Age', notation: 'AGE-01', variable: { identifier: 'age' } },
+            },
+          ],
+        });
+      }
+      return jsonResponse({ success: true, data: [] });
+    });
+
+    render(<SemanticView endpoint="e" apiBaseUrl="a" />);
+
+    expect(await screen.findByText('Leeftijd (LFT-01)')).toBeTruthy();
+    expect(screen.getByText('Age (AGE-01)')).toBeTruthy();
+  });
 });

--- a/packages/frontend/src/components/ChainBuilder/TestCasePanel.test.tsx
+++ b/packages/frontend/src/components/ChainBuilder/TestCasePanel.test.tsx
@@ -76,6 +76,51 @@ describe('TestCasePanel', () => {
     expect(screen.getByText('1 input')).toBeTruthy();
   });
 
+  test('the input count is pluralised for anything other than exactly one input', () => {
+    getTestCasesForChain.mockReturnValue([
+      testCase({ id: 'tc-none', name: 'No inputs', inputs: {} }),
+      testCase({ id: 'tc-two', name: 'Two inputs', inputs: { age: 30, income: 1000 } }),
+    ]);
+    render(
+      <TestCasePanel chain={[dmn()]} endpoint="e" currentInputs={{}} onLoadTestCase={vi.fn()} />
+    );
+
+    expect(screen.getByText('0 inputs')).toBeTruthy();
+    expect(screen.getByText('2 inputs')).toBeTruthy();
+  });
+
+  test('a test case description is shown under its name', () => {
+    getTestCasesForChain.mockReturnValue([
+      testCase({ description: 'Applicant just over the age threshold' }),
+    ]);
+    render(
+      <TestCasePanel chain={[dmn()]} endpoint="e" currentInputs={{}} onLoadTestCase={vi.fn()} />
+    );
+
+    expect(screen.getByText('Applicant just over the age threshold')).toBeTruthy();
+  });
+
+  test('a test case that has been run before shows its last-run date', () => {
+    const lastRun = '2026-03-05T10:00:00.000Z';
+    getTestCasesForChain.mockReturnValue([testCase({ lastRun })]);
+    render(
+      <TestCasePanel chain={[dmn()]} endpoint="e" currentInputs={{}} onLoadTestCase={vi.fn()} />
+    );
+
+    // toLocaleDateString is the platform's, not the component's — the component
+    // decides only whether to render the stamp at all, and in what wording.
+    expect(screen.getByText(`• Last run: ${new Date(lastRun).toLocaleDateString()}`)).toBeTruthy();
+  });
+
+  test('a test case that has never been run shows no last-run stamp', () => {
+    getTestCasesForChain.mockReturnValue([testCase()]);
+    render(
+      <TestCasePanel chain={[dmn()]} endpoint="e" currentInputs={{}} onLoadTestCase={vi.fn()} />
+    );
+
+    expect(screen.queryByText(/Last run:/)).toBeNull();
+  });
+
   test('clicking a test case updates its lastRun and calls onLoadTestCase', async () => {
     getTestCasesForChain.mockReturnValue([testCase()]);
     const onLoadTestCase = vi.fn();
@@ -111,6 +156,23 @@ describe('TestCasePanel', () => {
 
     expect(deleteTestCase).toHaveBeenCalledWith('e', ['age-check'], 'tc1');
     expect(screen.queryByText('Happy path')).toBeNull();
+  });
+
+  test('a confirmed delete that the storage layer rejects leaves the test case in place', async () => {
+    // The list is only filtered when deleteTestCase reports success. Drop that
+    // guard and the row disappears from the panel while the record survives in
+    // localStorage — a stale list that reappears on the next mount.
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    getTestCasesForChain.mockReturnValue([testCase()]);
+    deleteTestCase.mockReturnValue(false);
+    render(
+      <TestCasePanel chain={[dmn()]} endpoint="e" currentInputs={{}} onLoadTestCase={vi.fn()} />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: '' }));
+
+    expect(deleteTestCase).toHaveBeenCalledWith('e', ['age-check'], 'tc1');
+    expect(screen.getByText('Happy path')).toBeTruthy();
   });
 
   test('cancelling the delete confirmation leaves the test case in place', async () => {

--- a/packages/frontend/src/components/ChainBuilder/VendorBadge.test.tsx
+++ b/packages/frontend/src/components/ChainBuilder/VendorBadge.test.tsx
@@ -26,11 +26,32 @@ describe('VendorBadge', () => {
     expect(screen.getByTitle('2 vendor implementations available')).toBeTruthy();
   });
 
+  test('the compact variant uses the singular noun for count 1', () => {
+    render(<VendorBadge count={1} compact />);
+    expect(screen.getByTitle('1 vendor implementation available')).toBeTruthy();
+  });
+
   test('clicking the badge calls onClick', async () => {
     const onClick = vi.fn();
     render(<VendorBadge count={2} onClick={onClick} />);
 
     await userEvent.click(screen.getByRole('button'));
     expect(onClick).toHaveBeenCalled();
+  });
+
+  test('clicking a badge rendered without onClick raises nothing', async () => {
+    // onClick is optional, and the badge is rendered without one wherever it is
+    // purely informational. Dropping the `if (onClick)` guard calls undefined;
+    // React reports that through window's error event rather than failing the
+    // click, so the listener is what makes the regression visible here.
+    const onError = vi.fn();
+    window.addEventListener('error', onError);
+    render(<VendorBadge count={2} />);
+
+    await userEvent.click(screen.getByRole('button'));
+    window.removeEventListener('error', onError);
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(screen.getByText('2 Vendor Implementations')).toBeTruthy();
   });
 });

--- a/packages/frontend/src/components/ChainBuilder/VendorModal.test.tsx
+++ b/packages/frontend/src/components/ChainBuilder/VendorModal.test.tsx
@@ -66,6 +66,79 @@ describe('VendorModal', () => {
     expect(await screen.findByText('network down')).toBeTruthy();
   });
 
+  test('a reported failure with no message falls back to a generic one', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ json: async () => ({ success: false }) });
+    render(
+      <VendorModal dmnIdentifier="age-check" dmnTitle="Age check" endpoint="e" onClose={vi.fn()} />
+    );
+    expect(await screen.findByText('Failed to fetch vendor services')).toBeTruthy();
+  });
+
+  test('a rejection that is not an Error still leaves the modal readable', async () => {
+    global.fetch = vi.fn().mockRejectedValue('not an Error instance');
+    render(
+      <VendorModal dmnIdentifier="age-check" dmnTitle="Age check" endpoint="e" onClose={vi.fn()} />
+    );
+    expect(await screen.findByText('Unknown error')).toBeTruthy();
+    expect(screen.queryByText('Loading vendor services...')).toBeNull();
+  });
+
+  test('every optional vendor detail is rendered when the record carries it', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: async () => ({
+        success: true,
+        data: {
+          vendorServices: [
+            vendor({
+              implementedByName: 'Common Ground Platform',
+              description: 'Hosted age check for municipalities',
+              serviceUrl: 'https://acme.example.com/age-check',
+              provider: {
+                name: 'Acme BV',
+                logoUrl: 'https://acme.example.com/logo.svg',
+                homepage: 'https://acme.example.com',
+              },
+            }),
+          ],
+        },
+      }),
+    });
+
+    render(
+      <VendorModal dmnIdentifier="age-check" dmnTitle="Age check" endpoint="e" onClose={vi.fn()} />
+    );
+
+    expect(await screen.findByText('Hosted age check for municipalities')).toBeTruthy();
+    expect(screen.getByAltText('Acme BV')).toHaveAttribute(
+      'src',
+      'https://acme.example.com/logo.svg'
+    );
+    expect(screen.getByText('Common Ground Platform')).toBeTruthy();
+    expect(screen.getByText('Access Service').closest('a')).toHaveAttribute(
+      'href',
+      'https://acme.example.com/age-check'
+    );
+    expect(screen.getByText('https://acme.example.com').closest('a')).toHaveAttribute(
+      'href',
+      'https://acme.example.com'
+    );
+  });
+
+  test('optional vendor details are left out when the record omits them', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: async () => ({ success: true, data: { vendorServices: [vendor()] } }),
+    });
+
+    render(
+      <VendorModal dmnIdentifier="age-check" dmnTitle="Age check" endpoint="e" onClose={vi.fn()} />
+    );
+
+    expect(await screen.findByText('Acme BV')).toBeTruthy();
+    expect(screen.queryByRole('img')).toBeNull();
+    expect(screen.queryByText('Access Service')).toBeNull();
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+
   test('renders license/access-type badges and contact details', async () => {
     global.fetch = vi.fn().mockResolvedValue({
       json: async () => ({

--- a/packages/frontend/src/components/DocumentComposer/AssetLibrary.test.tsx
+++ b/packages/frontend/src/components/DocumentComposer/AssetLibrary.test.tsx
@@ -51,6 +51,19 @@ describe('AssetLibrary', () => {
     expect(screen.queryByText('document.pdf')).toBeNull();
   });
 
+  test('an asset card shows its size in KB, or "Unknown size" when the API omits it', async () => {
+    // TriplyDB does not always report assetSize, and `size ? ... : ...` on a
+    // missing value must not produce "NaN KB" on the card.
+    fetchAssets.mockResolvedValue([
+      asset({ id: 'a1', name: 'sized.png', size: 2048 }),
+      asset({ id: 'a2', name: 'unsized.png', size: undefined }),
+    ]);
+    render(<AssetLibrary endpoint="e" />);
+
+    expect(await screen.findByText('2 KB')).toBeTruthy();
+    expect(screen.getByText('Unknown size')).toBeTruthy();
+  });
+
   test('shows an empty-state message when there are no images', async () => {
     fetchAssets.mockResolvedValue([]);
     render(<AssetLibrary endpoint="e" />);

--- a/packages/frontend/src/components/DocumentComposer/TextBlockEditor.test.tsx
+++ b/packages/frontend/src/components/DocumentComposer/TextBlockEditor.test.tsx
@@ -95,4 +95,23 @@ describe('TextBlockEditor', () => {
     );
     expect(screen.getByText('Existing text')).toBeTruthy();
   });
+
+  test('a content prop replaced from outside is pushed into the editor', () => {
+    const doc = (text: string) => ({
+      type: 'doc' as const,
+      content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+    });
+    const { rerender } = render(
+      <TextBlockEditor content={doc('First block')} onChange={vi.fn()} />
+    );
+    expect(screen.getByText('First block')).toBeTruthy();
+
+    // What happens when a different template is loaded into the same slot.
+    // TipTap owns the document after mount, so without the sync effect the
+    // editor keeps showing the previous template's text.
+    rerender(<TextBlockEditor content={doc('Second block')} onChange={vi.fn()} />);
+
+    expect(screen.getByText('Second block')).toBeTruthy();
+    expect(screen.queryByText('First block')).toBeNull();
+  });
 });

--- a/packages/frontend/src/components/FormEditor/FormList.test.tsx
+++ b/packages/frontend/src/components/FormEditor/FormList.test.tsx
@@ -63,6 +63,20 @@ describe('FormList', () => {
     expect(screen.queryByText('Flevoland form')).toBeNull();
   });
 
+  test('clicking a collapsed organization expands it again', async () => {
+    render(
+      <FormList
+        {...baseProps}
+        forms={[form({ id: 'f1', name: 'Flevoland form', organization: 'flevoland' })]}
+      />
+    );
+
+    await userEvent.click(screen.getByText('flevoland'));
+    await userEvent.click(screen.getByText('flevoland'));
+
+    expect(screen.getByText('Flevoland form')).toBeTruthy();
+  });
+
   test('a status badge is shown for example/wip/dso/e2e forms', () => {
     render(
       <FormList
@@ -128,6 +142,34 @@ describe('FormList', () => {
 
     await userEvent.dblClick(screen.getByText('Aanvraagformulier'));
     expect(screen.queryByDisplayValue('Aanvraagformulier')).toBeNull();
+  });
+
+  test('Escape abandons a rename without committing it', async () => {
+    const onUpdateFormName = vi.fn();
+    render(<FormList {...baseProps} forms={[form()]} onUpdateFormName={onUpdateFormName} />);
+
+    await userEvent.dblClick(screen.getByText('Aanvraagformulier'));
+    const input = screen.getByDisplayValue('Aanvraagformulier');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'Half-typed name{Escape}');
+
+    expect(onUpdateFormName).not.toHaveBeenCalled();
+    expect(screen.getByText('Aanvraagformulier')).toBeTruthy();
+  });
+
+  test('committing a blank name keeps the original', async () => {
+    const onUpdateFormName = vi.fn();
+    render(<FormList {...baseProps} forms={[form()]} onUpdateFormName={onUpdateFormName} />);
+
+    await userEvent.dblClick(screen.getByText('Aanvraagformulier'));
+    const input = screen.getByDisplayValue('Aanvraagformulier');
+    await userEvent.clear(input);
+    await userEvent.type(input, '   {Enter}');
+
+    // A whitespace-only rename must not reach the store — it would leave the
+    // card with no readable title and nothing to double-click back into.
+    expect(onUpdateFormName).not.toHaveBeenCalled();
+    expect(screen.getByText('Aanvraagformulier')).toBeTruthy();
   });
 
   test('the toolbar search filters the visible forms', async () => {
@@ -202,6 +244,29 @@ describe('FormList', () => {
     expect(schema).not.toHaveProperty('e2eFixture');
   });
 
+  test('importing a schema with no id falls back to the filename', async () => {
+    const onImportForm = vi.fn();
+    render(<FormList {...baseProps} forms={[]} onImportForm={onImportForm} />);
+
+    const file = new File([JSON.stringify({ components: [] })], 'zorgtoeslag-aanvraag.nl.form', {
+      type: 'application/json',
+    });
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await userEvent.upload(input, file);
+
+    await vi.waitFor(() =>
+      // The language suffix is stripped from the fallback name, but not from
+      // the language it infers.
+      expect(onImportForm).toHaveBeenCalledWith(
+        expect.any(Object),
+        'zorgtoeslag-aanvraag',
+        'nl',
+        undefined,
+        false
+      )
+    );
+  });
+
   test('importing an invalid .form file alerts instead of crashing', async () => {
     const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
     render(<FormList {...baseProps} forms={[]} />);
@@ -222,5 +287,45 @@ describe('FormList', () => {
     rerender(<FormList {...baseProps} forms={[form()]} activeForm={form()} activeFormId="f1" />);
     expect(screen.getByText('Language')).toBeTruthy();
     expect(screen.getByText('Organization')).toBeTruthy();
+  });
+
+  test('the footer selectors are disabled for a readonly active form', () => {
+    const readonlyForm = form({ readonly: true });
+    render(
+      <FormList
+        {...baseProps}
+        forms={[readonlyForm]}
+        activeForm={readonlyForm}
+        activeFormId="f1"
+        onLanguageChange={vi.fn()}
+        onOrganizationChange={vi.fn()}
+      />
+    );
+
+    // Handlers are supplied, so readonly is the only thing that may disable
+    // these — an example form's language and organization are not the user's
+    // to change. (The toolbar's own language filter is a second combobox, so
+    // the footer one is reached through an option only it carries.)
+    expect(
+      screen.getByRole('option', { name: '— Language-agnostic —' }).closest('select')
+    ).toBeDisabled();
+    expect(screen.getByPlaceholderText('e.g. flevoland')).toBeDisabled();
+  });
+
+  test('a form whose schema carries no id is still searchable by name', async () => {
+    render(
+      <FormList
+        {...baseProps}
+        forms={[
+          form({ id: 'f1', name: 'Aanvraagformulier', schema: {} }),
+          form({ id: 'f2', name: 'Bezwaarformulier', schema: {} }),
+        ]}
+      />
+    );
+
+    await userEvent.type(screen.getByPlaceholderText(/Search/i), 'Bezwaar');
+
+    expect(screen.getByText('Bezwaarformulier')).toBeTruthy();
+    expect(screen.queryByText('Aanvraagformulier')).toBeNull();
   });
 });

--- a/packages/frontend/src/components/RopaEditor/RopaRecordEditor.test.tsx
+++ b/packages/frontend/src/components/RopaEditor/RopaRecordEditor.test.tsx
@@ -82,6 +82,26 @@ afterEach(() => {
   getForms.mockReset();
 });
 
+/**
+ * Runs `act` and fails if it raised an uncaught error.
+ *
+ * The guards in handleHydrate/handleWriteBpmnLink exist to stop a missing
+ * process, form or component list from being dereferenced. React reports a
+ * throw inside a click handler through window's error event instead of
+ * rejecting the click, so without this listener a test asserting "nothing was
+ * added" passes just as happily when the handler died halfway through.
+ */
+async function withoutUncaughtErrors(act: () => Promise<void>) {
+  const onError = vi.fn();
+  window.addEventListener('error', onError);
+  try {
+    await act();
+  } finally {
+    window.removeEventListener('error', onError);
+  }
+  expect(onError).not.toHaveBeenCalled();
+}
+
 describe('RopaRecordEditor — blank vs. existing record', () => {
   test('a null record renders the blank-record defaults', () => {
     getProcesses.mockReturnValue([]);
@@ -209,7 +229,7 @@ describe('RopaRecordEditor — Personal Data Fields / hydrate', () => {
     expect(screen.getByText('Hydrate from forms')).toBeDisabled();
   });
 
-  test("hydrates new fields from the linked BPMN process's camunda:formRef forms, skipping keyless components and already-present keys", async () => {
+  test("hydrates new fields from the linked BPMN process's camunda:formRef forms, skipping keyless components", async () => {
     getProcesses.mockReturnValue([
       process({
         xml: '<bpmn:definitions><bpmn:userTask camunda:formRef="form-1" /></bpmn:definitions>',
@@ -237,6 +257,102 @@ describe('RopaRecordEditor — Personal Data Fields / hydrate', () => {
 
     expect(await screen.findByText('leeftijd')).toBeTruthy();
     expect(screen.getAllByRole('row')).toHaveLength(2); // header row + 1 field row
+  });
+
+  test('hydrating twice does not duplicate a field that is already recorded', async () => {
+    getProcesses.mockReturnValue([
+      process({
+        xml: '<bpmn:definitions><bpmn:userTask camunda:formRef="form-1" /></bpmn:definitions>',
+      }),
+    ]);
+    getForms.mockReturnValue([
+      form({
+        schema: {
+          id: 'form-1',
+          components: [
+            { key: 'leeftijd', label: 'Leeftijd' },
+            { key: 'inkomen', label: 'Inkomen' },
+          ],
+        },
+      }),
+    ]);
+
+    render(
+      <RopaRecordEditor
+        record={record({
+          personalDataFields: [
+            {
+              id: 'existing',
+              ropaRecordId: 'r1',
+              formId: 'form-1',
+              fieldKey: 'leeftijd',
+              fieldLabel: 'Leeftijd (curated)',
+              dataCategory: 'other',
+              specialCategory: false,
+              sortOrder: 0,
+            },
+          ],
+        })}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Personal Data Fields' }));
+    await userEvent.click(screen.getByText('Hydrate from forms'));
+
+    // 'inkomen' is added; 'leeftijd' keeps the label the user curated rather
+    // than gaining a second row from the form.
+    expect(await screen.findByText('inkomen')).toBeTruthy();
+    expect(screen.getAllByRole('row')).toHaveLength(3); // header + 2 fields
+    expect(screen.getByDisplayValue('Leeftijd (curated)')).toBeTruthy();
+  });
+
+  test('hydrating is a no-op when no stored process matches the record', async () => {
+    getProcesses.mockReturnValue([process({ bpmnProcessId: 'SomeOtherProcess' })]);
+    getForms.mockReturnValue([form()]);
+
+    render(
+      <RopaRecordEditor
+        record={record({ personalDataFields: [] })}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Personal Data Fields' }));
+    await withoutUncaughtErrors(() => userEvent.click(screen.getByText('Hydrate from forms')));
+
+    expect(getForms).not.toHaveBeenCalled();
+    expect(screen.queryByRole('row')).toBeNull();
+  });
+
+  test('hydrating skips form refs with no stored form and forms with no components', async () => {
+    getProcesses.mockReturnValue([
+      process({
+        xml:
+          '<bpmn:definitions>' +
+          '<bpmn:userTask camunda:formRef="deleted-form" />' +
+          '<bpmn:userTask camunda:formRef="empty-form" />' +
+          '</bpmn:definitions>',
+      }),
+    ]);
+    getForms.mockReturnValue([form({ id: 'f2', schema: { id: 'empty-form' } })]);
+
+    render(
+      <RopaRecordEditor
+        record={record({ personalDataFields: [] })}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Personal Data Fields' }));
+    await withoutUncaughtErrors(() => userEvent.click(screen.getByText('Hydrate from forms')));
+
+    // Neither ref yields a field, and neither takes the tab down with it.
+    expect(screen.queryByRole('row')).toBeNull();
+    expect(screen.getByText('Hydrate from forms')).toBeTruthy();
   });
 
   test('removing a field row deletes it from the table', async () => {
@@ -350,6 +466,67 @@ describe('RopaRecordEditor — BPMN link', () => {
     expect(saveProcess).toHaveBeenCalledWith(
       expect.objectContaining({ xml: expect.not.stringContaining('ronl:ropaRef') })
     );
+  });
+
+  test('rewriting an existing link replaces the ropaRef instead of adding a second one', async () => {
+    getProcesses.mockReturnValue([
+      process({
+        xml: '<bpmn:definitions xmlns:ronl="http://ronl.nl/schema/1.0"><bpmn:process ronl:ropaRef="r-old" /></bpmn:definitions>',
+      }),
+    ]);
+    render(<RopaRecordEditor record={record()} onSave={vi.fn()} onCancel={vi.fn()} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'BPMN Link' }));
+    await userEvent.click(screen.getByText('Write ronl:ropaRef to BPMN'));
+
+    const [[saved]] = saveProcess.mock.calls;
+    expect(saved.xml).toContain('ronl:ropaRef="r1"');
+    expect(saved.xml).not.toContain('r-old');
+    // The namespace was already declared; declaring it twice makes the XML
+    // invalid and bpmn-js refuses to open the diagram.
+    expect(saved.xml.match(/xmlns:ronl=/g)).toHaveLength(1);
+  });
+
+  test('a ropaRef pointing at another record is flagged rather than shown as linked', async () => {
+    getProcesses.mockReturnValue([
+      process({
+        xml: '<bpmn:definitions xmlns:ronl="http://ronl.nl/schema/1.0"><bpmn:process ronl:ropaRef="r-other" /></bpmn:definitions>',
+      }),
+    ]);
+    render(<RopaRecordEditor record={record()} onSave={vi.fn()} onCancel={vi.fn()} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'BPMN Link' }));
+
+    expect(await screen.findByText('Points to a different record')).toBeTruthy();
+    expect(screen.queryByText('✓ Linked')).toBeNull();
+  });
+
+  test('writing the link does nothing when no stored process matches', async () => {
+    getProcesses.mockReturnValue([process({ bpmnProcessId: 'SomeOtherProcess' })]);
+    render(<RopaRecordEditor record={record()} onSave={vi.fn()} onCancel={vi.fn()} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'BPMN Link' }));
+    await withoutUncaughtErrors(() =>
+      userEvent.click(screen.getByText('Write ronl:ropaRef to BPMN'))
+    );
+
+    expect(saveProcess).not.toHaveBeenCalled();
+  });
+
+  test('a record with no id and no process shows placeholders and cannot be written', async () => {
+    getProcesses.mockReturnValue([]);
+    render(<RopaRecordEditor record={null} onSave={vi.fn()} onCancel={vi.fn()} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'BPMN Link' }));
+
+    expect(screen.getByText('— not set —')).toBeTruthy();
+    expect(screen.getByText('— save the record first —')).toBeTruthy();
+    expect(screen.getByText('Write ronl:ropaRef to BPMN')).toBeDisabled();
+    expect(
+      screen.getByText(
+        'Save the record on the Record tab first — the ID is required to write the link.'
+      )
+    ).toBeTruthy();
   });
 });
 

--- a/packages/frontend/src/services/userTemplateStorage.test.ts
+++ b/packages/frontend/src/services/userTemplateStorage.test.ts
@@ -50,6 +50,22 @@ describe('getUserTemplates / getUserTemplateById', () => {
     localStorage.setItem('linkeddata-explorer-user-templates', 'not json');
     expect(getUserTemplates(ENDPOINT)).toEqual([]);
   });
+
+  test('return [] / null for an endpoint absent from a populated store', () => {
+    // Distinct from the empty-store case above: here `stored` parses fine and
+    // the lookup misses. Without the `|| []` fallback this hands back
+    // undefined and every caller that maps over the result throws.
+    saveUserTemplate('https://other.example.com/sparql', baseTemplate());
+
+    expect(getUserTemplates(ENDPOINT)).toEqual([]);
+    expect(getUserTemplateById(ENDPOINT, 'no-such-id')).toBeNull();
+  });
+});
+
+describe('getAllUserTemplates', () => {
+  test('returns [] when nothing has been stored at all', () => {
+    expect(getAllUserTemplates()).toEqual([]);
+  });
 });
 
 describe('saveUserTemplate', () => {
@@ -68,6 +84,15 @@ describe('saveUserTemplate', () => {
     expect(getUserTemplates(ENDPOINT)).toHaveLength(1);
     expect(getAllUserTemplates()).toHaveLength(2);
   });
+
+  test('appends to the endpoint bucket instead of resetting it', () => {
+    // The `if (!storage[endpoint])` initialiser must not run on the second
+    // save; if it did, each save would discard everything saved before it.
+    const first = saveUserTemplate(ENDPOINT, baseTemplate());
+    const second = saveUserTemplate(ENDPOINT, { ...baseTemplate(), name: 'Second chain' });
+
+    expect(getUserTemplates(ENDPOINT).map((t) => t.id)).toEqual([first.id, second.id]);
+  });
 });
 
 describe('updateUserTemplate', () => {
@@ -81,8 +106,19 @@ describe('updateUserTemplate', () => {
     expect(updated?.updatedAt).not.toBe(saved.updatedAt);
   });
 
-  test('returns null when the endpoint has no templates at all', () => {
+  test('returns null when nothing is stored at all', () => {
     expect(updateUserTemplate(ENDPOINT, 'no-such-id', { name: 'x' })).toBeNull();
+  });
+
+  test('returns null when the store holds no bucket for this endpoint', () => {
+    // A different path than the empty-store case above, which returns at the
+    // `if (!stored)` guard and never reaches the endpoint lookup. Here the
+    // store parses and the lookup misses, and no other endpoint's bucket may
+    // be touched on the way out.
+    const other = saveUserTemplate('https://other.example.com/sparql', baseTemplate());
+
+    expect(updateUserTemplate(ENDPOINT, 'no-such-id', { name: 'x' })).toBeNull();
+    expect(getUserTemplates('https://other.example.com/sparql')).toEqual([other]);
   });
 
   test('returns null when the id does not match any template', () => {
@@ -98,8 +134,15 @@ describe('deleteUserTemplate', () => {
     expect(getUserTemplates(ENDPOINT)).toEqual([]);
   });
 
-  test('returns false when the endpoint has no templates at all', () => {
+  test('returns false when nothing is stored at all', () => {
     expect(deleteUserTemplate(ENDPOINT, 'no-such-id')).toBe(false);
+  });
+
+  test('returns false when the store holds no bucket for this endpoint', () => {
+    saveUserTemplate('https://other.example.com/sparql', baseTemplate());
+
+    expect(deleteUserTemplate(ENDPOINT, 'no-such-id')).toBe(false);
+    expect(getAllUserTemplates()).toHaveLength(1);
   });
 
   test('returns false when the id does not match any template', () => {

--- a/packages/frontend/src/utils/exampleVersions.test.ts
+++ b/packages/frontend/src/utils/exampleVersions.test.ts
@@ -21,6 +21,16 @@ describe('getStoredVersion', () => {
     localStorage.setItem('linkedDataExplorer_exampleVersions', 'not json');
     expect(getStoredVersion('example_awb_process')).toBe(0);
   });
+
+  test('returns 0 for an example missing from an otherwise populated map', () => {
+    // The case a new example hits on an existing installation: the version map
+    // exists but has no entry yet. Without the `?? 0` this yields undefined,
+    // and BpmnModeler's `getStoredVersion(id) < EXAMPLE_VERSIONS[id]` is false
+    // for undefined — so the new example would never be seeded.
+    setStoredVersion('example_awb_process', 4);
+
+    expect(getStoredVersion('example_dvtp_toestemming')).toBe(0);
+  });
 });
 
 describe('setStoredVersion', () => {

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -31,17 +31,25 @@ export default defineConfig(({ mode }) => {
         // A per-file 80% branch floor, enforced rather than assumed.
         //
         // perFile is the mechanism, not a detail: against the package average
-        // (90.59%) the threshold is inert, because one file dropping to 40%
+        // (92.88%) the threshold is inert, because one file dropping to 40%
         // barely moves it. Branches specifically, because statement and line
         // coverage largely restate "was this file imported", and an uncovered
         // branch is a decision no test has ever checked.
         //
-        // Measured clean when this landed — 64 files, none below 80. But the
-        // margin is thin: CaseworkerCasePanel.tsx sits at EXACTLY 80.00, and
-        // thirteen more files are between 80 and 85. The first uncovered
-        // branch added to any of them turns this red. That is the floor
-        // working, not a misconfiguration — but it is worth knowing before
-        // someone meets it on an unrelated change.
+        // When this landed, TestCasePanel.tsx sat at EXACTLY 80.00 and thirteen
+        // more files were between 80 and 85 — one uncovered branch away from
+        // red. (An earlier revision of this comment named the 80.00 file
+        // CaseworkerCasePanel.tsx; no such file exists.) Those files have since
+        // been given margin: the lowest is now GraphView.tsx at 82.26%.
+        //
+        // GraphView is where the floor is still tight, and deliberately so.
+        // Its eleven uncovered branches are all inside the d3 force-simulation
+        // tick and drag handlers — `d.x || 0` position fallbacks and
+        // `if (!event.active)` drag guards — which need a running simulation
+        // and synthesised drag events to reach. That is a d3 harness, not a
+        // test of this component; adding a branch to GraphView will turn this
+        // red, and the answer then is to test the new branch, not to lower the
+        // floor.
         //
         // Branches only. A functions floor would fail today; this is not a
         // companion setting to add without measuring first.


### PR DESCRIPTION
The per-file 80% branch floor landed in #82 measured-clean, but with no slack:
`TestCasePanel.tsx` sat at **exactly 80.00%** and thirteen more files between 80
and 85. The first uncovered branch added to any of them would have turned CI red
on a change that had nothing to do with them. This buys that slack by covering
branches that were worth covering anyway.

**No production code changed** — test files only, plus the comment in
`vite.config.ts`.

## Result

| | before | after |
|---|---|---|
| Package branches | 90.59% | **92.88%** |
| Lowest file | 80.00% (zero margin) | **82.26%** |
| Files below 85% | 14 | **1** |
| Tests | 1042 | **1073** (68 files, green) |

| file | before | after | | file | before | after |
|---|---|---|---|---|---|---|
| `TestCasePanel` | 80.00 | **100.00** | | `ChainConfig` | 80.56 | **94.44** |
| `ExportChain` | 80.77 | **98.08** | | `FormList` | 82.14 | **98.21** |
| `userTemplateStorage` | 80.77 | **100.00** | | `RopaRecordEditor` | 81.37 | **94.12** |
| `SemanticView` | 81.82 | **100.00** | | `VendorModal` | 84.78 | **100.00** |
| `VendorBadge` | 84.62 | **100.00** | | `TextBlockEditor` | 85.00 | **90.00** |
| `exampleVersions` | 83.33 | **100.00** | | `AssetLibrary` | 80.95 | **85.71** |

## The name in the config comment was wrong

There is no `CaseworkerCasePanel.tsx` in this repo, and there never has been.
The file at exactly 80.00% was `ChainBuilder/TestCasePanel.tsx`. The comment now
says so, and records the current shape of the floor rather than the one from the
day it landed. #82's commit message is left alone — it is already pushed.

## Every test was mutation-checked

Tests written against code that already exists pass on the first run, which
proves nothing about whether they *can* fail. So each new test had the branch it
targets deliberately broken in the production file, and had to fail — then the
file was restored.

That caught five tests of this change passing vacuously:

- Two `SemanticView` guard tests used a response fixture with no `data` field at
  all, so `data ?? []` and the real guard behaved identically. Rewritten with a
  `success: false` payload that *carries* data, and a `success: true` payload
  whose `data` is not an array.
- Four `RopaRecordEditor` tests and one `VendorBadge` test asserted "nothing was
  added" / "nothing was saved" — which stays true when the handler **throws**
  partway through, because React surfaces an error thrown inside a click handler
  on `window`'s error event rather than rejecting the click. They now run the
  click through a listener that fails the test if anything was raised
  (`withoutUncaughtErrors` in `RopaRecordEditor.test.tsx`).

## Three guards are unreachable and were left uncovered

Each sits behind a submit button already `disabled` on exactly the same
condition, so no test can reach it without reaching past the UI:

- `ExportChain` — `filename.trim() || chainName`
- `ChainConfig` — `if (!templateName.trim())` in `handleSaveTemplate`
- `RopaRecordEditor` — `if (!local.id || !local.bpmnProcessId)`

Testing them would mean calling the handler directly, which tests nothing a user
can do. They are why `ExportChain` stops at 98.08 and `ChainConfig` at 94.44
rather than 100.

## Two covered branches are behaviour-preserving

`userTemplateStorage`'s `if (!templates) return null/false` guards and
`FormList`'s `(f.schema)?.id ?? ''` are load-bearing only against a throw the
surrounding `try/catch` already swallows, and against a value `Array.join`
already coerces. Their mutations survive by construction. The tests still earn
their place — they assert the returned contract and that a neighbouring
endpoint's bucket is untouched — and the comments say what they do and do not
catch rather than implying more.

## GraphView is left at 82.26% on purpose

Its eleven uncovered branches are all inside the d3 force-simulation tick and
drag handlers: `d.x || 0` position fallbacks that need a node at the origin, and
`if (!event.active)` guards that need synthesised `D3DragEvent`s. Reaching them
means standing up a d3 harness and asserting on d3's mechanics, not on this
component. `vite.config.ts` now records that, so whoever next meets the floor
there knows the answer is to test their new branch rather than lower the
threshold.

## Verification

```
npm run test --workspace=@linked-data-explorer/frontend   # 68 files, 1073 tests, thresholds met
npm run typecheck --workspace=@linked-data-explorer/frontend
npm run lint --workspace=@linked-data-explorer/frontend
npm run check-format --workspace=@linked-data-explorer/frontend
```

All green. The backend workspace is untouched, so its own floor is unaffected.

One `ShaclValidator` test timed out during a full parallel run mid-change and
passed 37/37 in isolation. No file here touches it — noted because a
parallel-only failure is not a finding.
