### PR TITLE
ci: scan the monorepo with Semgrep, reporting before it is required

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,122 @@
+name: Semgrep
+
+# Semgrep Code and Supply Chain, on every pull request and on every push to acc
+# and main. Supply Chain covers what check-supply-chain structurally cannot:
+# check-supply-chain verifies that GitHub Actions digest pins resolve to the
+# versions their comments claim, and says nothing about the packages in
+# package-lock.json. Renovate remediates that tree; this is what verifies it.
+#
+# One job covers the whole monorepo. All three workspaces -- backend, frontend,
+# ropa-site -- resolve through the single root package-lock.json, so there is
+# one lockfile for Supply Chain to read and no per-workspace fan-out to keep in
+# step with the workspace list.
+#
+# Ported from ttl-editor, where it was introduced and triaged (ttl-editor#112,
+# #113). docs/ci-posture-across-repos.md section 2, "The other supply chain",
+# records why each decision below was taken.
+#
+# Same trigger shape as zizmor.yml, and for the same reason documented at length
+# there: no branches filter and no paths filter on pull_request, so a pull
+# request cannot skip the scan by targeting an unwatched base or by touching
+# nothing watched. push stays filtered to the two branches that deploy.
+#
+# NOT yet a required check in either ruleset. That comes once the baseline is
+# known and triaged -- at which point the trigger shape above stops being
+# precautionary and becomes load-bearing, because a required check that no
+# trigger produces wedges a pull request permanently. Promotion is a ruleset
+# change rather than a change to this file. `continue-on-error` would be the
+# obvious alternative and is the wrong tool, for the reason zizmor.yml already
+# spells out: it rewrites the STEP's reported conclusion as well as the job's,
+# so a finding shows up only in the log while every check reads "success".
+on:
+  pull_request:
+  push:
+    branches:
+      - acc
+      - main
+
+# Same group key as every other workflow here, but NOT their unconditional
+# cancel-in-progress: true -- the one deliberate divergence in this file.
+#
+# The push runs on acc and main are what write the Semgrep Cloud baseline.
+# Cancelling one mid-upload leaves the dashboard describing a scan that never
+# finished, and nothing is queued to correct it. Pull-request runs write nothing
+# durable, so superseding a stale one is free. Hence: cancel on pull_request,
+# never on push. Do not "tidy" this into line with the siblings.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# Read-only. Findings go to Semgrep Cloud over the API, not to the GitHub
+# security tab, so security-events: write is not needed. If SARIF upload is ever
+# added, that permission comes with it -- and zizmor.yml sets
+# advanced-security: false for precisely this reason.
+permissions:
+  contents: read
+
+jobs:
+  semgrep:
+    name: scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # semgrep ci is diff-aware on a pull request: it scans the merge base
+          # against the head and reports only what the pull request introduces.
+          # It cannot compute that from a shallow clone, and degrades quietly to
+          # a full scan rather than failing -- which would put the whole backlog
+          # on every pull request and train everyone to ignore it.
+          fetch-depth: 0
+
+      - name: Install Semgrep
+        # Hand-pinned, like zizmor's `version:` input and the renovate@44.50.3
+        # argument in the audit workflow. Renovate's managers do not parse a
+        # version out of a run: block, so this is bumped by hand; see the note
+        # under the Pinned table in SECURITY-PIPELINE.md.
+        #
+        # The venv is required, not stylistic: ubuntu-latest marks its system
+        # Python as externally-managed (PEP 668), so a bare `pip install` exits
+        # 1 with error: externally-managed-environment.
+        run: |
+          python3 -m venv "$RUNNER_TEMP/semgrep-venv"
+          "$RUNNER_TEMP/semgrep-venv/bin/pip" install --quiet semgrep==1.176.1
+          echo "$RUNNER_TEMP/semgrep-venv/bin" >> "$GITHUB_PATH"
+
+      - name: Verify the pinned version installed
+        # Cheap, and it makes the log state which Semgrep produced the findings
+        # below it. A scan whose tool version is not in its own output is how
+        # ttl-editor's first triage became ambiguous.
+        run: semgrep --version
+
+      - name: Scan
+        env:
+          # Required. Without it `semgrep ci` refuses to run, and an
+          # unauthenticated `semgrep scan` silently drops Supply Chain -- the
+          # half of this job nothing else in the repository covers. Agent (CI)
+          # scope only; this job never calls the Web API.
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+        # No --dry-run: results go to the Semgrep Cloud dashboard so the count
+        # is tracked over time rather than living in a run log that expires.
+        #
+        # The push runs must be what establish the baseline. Semgrep derives
+        # the project identity from its environment: inside Actions it reads
+        # GITHUB_REPOSITORY and registers sgort/linked-data-explorer, while a
+        # workstation run registers local_scan/linked-data-explorer. Seeding the
+        # baseline from a laptop would split the history across two projects.
+        #
+        # Exit status is policy-driven: semgrep ci exits non-zero only on
+        # findings the Semgrep Cloud policy marks BLOCKING. A dry run on cfa6b40
+        # found 86, none blocking. Tighten the policy to make it bite, not this
+        # file.
+        #
+        # --no-suppress-errors is deliberate. By default semgrep ci prints
+        # "There were errors during analysis but Semgrep will succeed" and exits
+        # 0, which is how a broken install once went unnoticed: the scan crashed
+        # and still reported success. Verified here against the two backend
+        # deploy workflows, whose run: blocks produce four warn-level
+        # PartialParsing notices -- those do not fail the job; a tool that
+        # cannot run does.
+        run: semgrep ci --no-suppress-errors

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,61 @@
+# Paths Semgrep should not scan, in .gitignore syntax.
+#
+# Semgrep already limits itself to files tracked by git, so node_modules,
+# dist/ and coverage/ in every workspace are excluded by .gitignore without
+# needing a line here. This file is for paths that ARE tracked and ARE meant to
+# be, but are not application code.
+
+# Reference material at the repository root: sample TTL, DMN and organisation
+# exports used by hand and by the e2e fixtures. Not loaded by any package.
+#
+# The leading slash is load-bearing. A bare `examples/` is .gitignore syntax for
+# "a directory named examples at ANY depth", which would also swallow
+# packages/frontend/public/examples/ -- and Vite copies public/ into the build,
+# so that one IS served and must keep being scanned. ttl-editor hit exactly
+# this: its first .semgrepignore used the bare form and silently dropped a
+# served file, caught only by diffing the scanned file lists, because the
+# finding counts agreed either way.
+#
+# What it silences today, from a dry run on cfa6b40: eval-detected,
+# hardcoded-password-default-argument x2 and use-defused-xml-parse, all in
+# scripts under examples/organizations/.
+/examples/
+
+# Test files are excluded from Code scanning, but NOT from Secrets scanning,
+# which carries its own separate ignore list in the Semgrep project settings and
+# keeps covering them. A hardcoded credential in a test is the one finding class
+# here worth having, and it survives this rule.
+#
+# Reading a fixture off disk means path.resolve; asserting on generated text
+# means building a RegExp from a variable. Both are ordinary test code, so
+# path-join-resolve-traversal and detect-non-literal-regexp fire on it forever
+# -- six findings on cfa6b40 -- and triaging each new test file by hand is not a
+# strategy. The narrower fix, scoping those two rules to non-test paths, is not
+# available: Semgrep has no per-rule path setting, and forking two registry
+# rules to add paths.exclude is more to maintain than this is worth.
+#
+# Also clears six PartialParsing warnings, where the parser trips on a
+# TypeScript generic call in the ChainBuilder, DocumentComposer and
+# exportService tests. Warn-level, and verified not to fail the job under
+# --no-suppress-errors -- but noise in every log.
+#
+# Every test file in this repository is .test.ts or .test.tsx; there are no
+# .spec files and no JavaScript tests. Widen this if that changes.
+*.test.ts
+*.test.tsx
+
+# Restores two rules from Semgrep's built-in default ignore list, which this file
+# REPLACES rather than extends. Without them, adding this file quietly brought 16
+# files back into scope that were not scanned before -- test fixtures, curl
+# templates and a Vitest setup file under packages/backend/tests/ and
+# packages/frontend/src/test/. Found by diffing the scanned file sets: the
+# finding count came out exactly as predicted either way, 86 to 76, because none
+# of those files happened to trip a rule. The count agreeing proved nothing.
+#
+# Bare on purpose, unlike /examples/ above: every directory of either name in
+# this repository is test support, and none is under a served public/ tree.
+# The other defaults -- node_modules/, dist/, build/, vendor/, *.min.js -- are
+# not restored because nothing matching them is tracked, and Semgrep scans only
+# tracked files.
+test/
+tests/

--- a/SECURITY-PIPELINE.md
+++ b/SECURITY-PIPELINE.md
@@ -22,7 +22,7 @@ release cannot reach this repository merely by being published.
 
 ## What is pinned
 
-Every action reference in all seven workflows is a 40-character commit hash with
+Every action reference in all eight workflows is a 40-character commit hash with
 its human-readable version in a trailing comment. The comment is not decoration:
 a digest nobody can read is a pin nobody will maintain, and Renovate moves the
 two together.
@@ -35,7 +35,23 @@ two together.
 | `azure/webapps-deploy`         | `02a81bead70021f5284939794bcec79c271ab383` | v3.0.8           |
 | `zizmorcore/zizmor-action`     | `3dc1ecc9bcb9e94e9b2c709687979e1298497054` | v0.6.2           |
 
-`zizmor 1.29.0` reports **0 findings** across all seven workflows.
+`zizmor 1.29.0` reports **0 findings** across all eight workflows.
+
+**Hand-pinned tools.** Two tools are pinned by an inline version argument rather
+than by a manifest entry, so Renovate's managers do not see them and they are
+bumped by hand. Neither appears in the table above, which lists actions only —
+`check-supply-chain` matches rows by action and digest.
+
+| Tool     | Pin                                                | Where         |
+| -------- | -------------------------------------------------- | ------------- |
+| zizmor   | `version: '1.29.0'` input to `zizmor-action`       | `zizmor.yml`  |
+| renovate | `npx --package renovate@44.50.3` for the validator | `zizmor.yml`  |
+| semgrep  | `pip install semgrep==1.176.1` into a venv         | `semgrep.yml` |
+
+`semgrep.yml` is the Semgrep Code and Supply Chain scan. Supply Chain covers the
+`package-lock.json` tree, which nothing above does: this page pins what the
+pipeline _executes_, and the lockfile's integrity hashes pin what `npm ci`
+_installs_, but neither says whether an installed version is vulnerable.
 
 Node dependencies install through `npm ci` in the frontend and backend build
 jobs, which installs the lockfile exactly and fails rather than resolving

--- a/docs/ci-posture-across-repos.md
+++ b/docs/ci-posture-across-repos.md
@@ -5,8 +5,9 @@ and RONL Business API (`ronl-business-api`) stand on three mechanisms that were
 rolled out across all of them in September 2026 — build provenance, supply-chain
 verification, and a per-file test-coverage floor.
 
-A **fourth** now exists in one of the three: ttl-editor gates merges on a Semgrep
-scan covering the npm dependency tree and the application code. It is described
+A **fourth** now exists in two of the three: ttl-editor gates merges on a Semgrep
+scan covering the npm dependency tree and the application code, and Linked Data
+Explorer runs the same scan, reporting but not yet required. It is described
 under §2 rather than given a section of its own, because it is the other half of
 the supply chain that `check-supply-chain` was never able to see.
 
@@ -28,7 +29,7 @@ gate landed and v2026.09.3 was promoted; the other two are as of their last pass
 | ----------------------------- | -------------------- | -------------------- | ----------------------- |
 | **Build id in the changelog** | ✅                   | ✅                   | ✅                      |
 | **check-supply-chain**        | ✅ blocking          | ✅ blocking          | ⚠️ non-blocking         |
-| **Semgrep Code + SCA**        | ✅ blocking          | —                    | —                       |
+| **Semgrep Code + SCA**        | ✅ blocking          | ⏳ reporting         | —                       |
 | **Per-file 80% branch floor** | ✅ native thresholds | ✅ native thresholds | ✅ native thresholds    |
 | **Formatting checked in CI**  | ✅                   | ✅                   | —                       |
 | **Tests run before merge**    | ✅                   | ✅                   | ⚠️ frontend only        |
@@ -318,7 +319,34 @@ and the difference only shows on the day the bot is wrong or stalled.
 ttl-editor closed that in September 2026 with a `Semgrep` workflow whose `scan`
 job is a required check alongside `audit`. It runs Semgrep Code and Supply Chain
 against an authenticated scan, reporting to the `sgort/ttl-editor` project in
-Semgrep Cloud. The other two repositories do not have it yet.
+Semgrep Cloud. Linked Data Explorer adopted the same workflow on 11 September
+2026 and runs it as a reporting check before requiring it; RONL Business API does
+not have it yet.
+
+Three things differed when it was ported to Linked Data Explorer, a monorepo:
+
+- **One job still covers everything.** All three workspaces resolve through the
+  single root `package-lock.json`, so Supply Chain reads one lockfile and there is
+  no per-workspace fan-out to keep in step with the workspace list.
+- **The same `examples/` trap, independently present.** A root `examples/` holds
+  reference material, and `packages/frontend/public/examples/` is served — Vite
+  copies `public/` into the build. The ignore rule is `/examples/`, anchored, for
+  exactly the reason ttl-editor learned the hard way.
+- **Its sibling workflows all cancel in progress unconditionally.** `semgrep.yml`
+  uses their group key but cancels only on `pull_request`, because a cancelled
+  push run leaves the Semgrep Cloud baseline half-written.
+- **A `.semgrepignore` replaces Semgrep's built-in default ignore list; it does
+  not extend it.** The defaults exclude `test/` and `tests/` directories, and
+  the first version of this file silently brought 16 files under
+  `packages/backend/tests/` and `packages/frontend/src/test/` back into scope.
+  The finding count came out exactly as predicted either way, because none of
+  them happened to trip a rule — only diffing the scanned file sets showed it.
+  ttl-editor has no such directories today, so its file is unaffected, but it
+  would be the day one is added.
+
+Its local dry run on `cfa6b40` found 86 findings, none blocking: 66 Supply Chain,
+all transitive and unreachable, and 20 Code — 6 in test files and 4 under
+`examples/`, both then excluded, leaving 10 in application code to triage.
 
 |                     |                                                                       |
 | ------------------- | --------------------------------------------------------------------- |
@@ -1029,21 +1057,21 @@ release rather than discovering the answer six months later.
 
 ## 6. Open work
 
-| repository           | issue | what                                                                                      |
-| -------------------- | ----- | ----------------------------------------------------------------------------------------- |
-| ronl-business-api    | #83   | promote check-supply-chain from non-blocking to blocking                                  |
-| ronl-business-api    | #84   | `@ronl/shared` has no test runner, so logic placed there escapes the floor                |
-| ronl-business-api    | #85   | an unreachable `PHASE_NOT_MODELLED` branch keeps three tests permanently skipped          |
-| ronl-business-api    | #87   | the backend runs no tests on a pull request, so its branch floor is retrospective         |
-| linked-data-explorer | —     | `GraphView.tsx` at 82.26%: one branch of slack, behind a d3 harness                       |
-| ttl-editor           | —     | three files sit within one branch of the floor, with no ratchet left to absorb a slip     |
-| ronl-business-api    | —     | production build id wired but unexercised; the other two have now run theirs              |
-| ttl-editor           | #131  | `main` has no required status checks — decided and kept, not an oversight                 |
-| ttl-editor           | #128  | Semgrep `scan` cannot pass on a forked pull request; accepted, tracked                    |
-| linked-data-explorer | —     | no Semgrep scan yet: npm dependency tree is remediated by Renovate and verified by nobody |
-| ronl-business-api    | —     | both `acc` and `main` differ between GitHub and GitLab; unaudited                         |
-| linked-data-explorer | #80   | Node 24 bump sets `engines.node >=24.20.0` but pins `24.19.0` in all four workflows       |
-| linked-data-explorer | —     | changelog entry `1.9.12` still carries the legacy `Latest` status, now visible in prod    |
+| repository           | issue | what                                                                                   |
+| -------------------- | ----- | -------------------------------------------------------------------------------------- |
+| ronl-business-api    | #83   | promote check-supply-chain from non-blocking to blocking                               |
+| ronl-business-api    | #84   | `@ronl/shared` has no test runner, so logic placed there escapes the floor             |
+| ronl-business-api    | #85   | an unreachable `PHASE_NOT_MODELLED` branch keeps three tests permanently skipped       |
+| ronl-business-api    | #87   | the backend runs no tests on a pull request, so its branch floor is retrospective      |
+| linked-data-explorer | —     | `GraphView.tsx` at 82.26%: one branch of slack, behind a d3 harness                    |
+| ttl-editor           | —     | three files sit within one branch of the floor, with no ratchet left to absorb a slip  |
+| ronl-business-api    | —     | production build id wired but unexercised; the other two have now run theirs           |
+| ttl-editor           | #131  | `main` has no required status checks — decided and kept, not an oversight              |
+| ttl-editor           | #128  | Semgrep `scan` cannot pass on a forked pull request; accepted, tracked                 |
+| linked-data-explorer | —     | Semgrep `scan` reports but is not yet required; 10 application Code findings to triage |
+| ronl-business-api    | —     | both `acc` and `main` differ between GitHub and GitLab; unaudited                      |
+| linked-data-explorer | #80   | Node 24 bump sets `engines.node >=24.20.0` but pins `24.19.0` in all four workflows    |
+| linked-data-explorer | —     | changelog entry `1.9.12` still carries the legacy `Latest` status, now visible in prod |
 
 Closed since the previous revision: Linked Data Explorer's frontend zero-margin
 entry, by


### PR DESCRIPTION
Adds a Semgrep Code and Supply Chain scan. It **reports but is not required** yet, in either ruleset.

## Why

Nothing in this repository verified the npm dependency tree. `check-supply-chain` confirms that **GitHub Actions** digest pins resolve to the versions their comments claim, and says nothing about `package-lock.json`. Renovate remediates that tree, and until now nothing checked it.

A local dry run on `cfa6b40` found **86 findings, 0 blocking**: 66 Supply Chain, all transitive and unreachable, plus 20 Code.

## What changed

| File | Change |
|---|---|
| `.github/workflows/semgrep.yml` | new: `scan` job, ported from ttl-editor |
| `.semgrepignore` | new: `/examples/`, `*.test.ts`, `*.test.tsx`, `test/`, `tests/` |
| `SECURITY-PIPELINE.md` | eight workflows, not seven, plus a hand-pinned tools table |
| `docs/ci-posture-across-repos.md` | LDE marked as reporting, and what differed in the port |

## Ported, with three adaptations

The workflow was introduced and triaged in ttl-editor (ttl-editor#112, #113). Three things changed on the way here:

- **One job covers the whole monorepo.** `backend`, `frontend` and `ropa-site` all resolve through the single root `package-lock.json`. Supply Chain has one lockfile to read, and there is no per-workspace fan-out to keep in step.
- **Concurrency cancels only on `pull_request`.** It uses this repository's existing group key. Every sibling workflow cancels in progress unconditionally; this one must not. The push runs on `acc` and `main` write the Semgrep Cloud baseline, and a cancelled one leaves it half-written.
- **Not required yet.** That follows once the baseline is known and triaged. The trigger shape is `zizmor.yml`'s: `pull_request` unfiltered, with no paths filter. So it is safe to require on any base when that happens.

## The finding worth keeping

**A `.semgrepignore` replaces Semgrep's built-in default ignore list; it does not extend it.**

The defaults exclude `test/` and `tests/`. The first version of this file quietly brought 16 files under `packages/backend/tests/` and `packages/frontend/src/test/` back into scope. The finding count came out exactly as predicted either way, 86 → 76, because none of those files tripped a rule. Only diffing the scanned file sets showed it.

I confirmed this against Semgrep's own source. The same source confirms that Secrets scanning ignores `.semgrepignore` entirely, so test files stay covered for credentials.

The `/examples/` leading slash matters for a related reason. `packages/frontend/public/examples/` also exists, and Vite serves `public/`. A bare `examples/` would have dropped a served tree from the scan, which is what happened to ttl-editor.

## Verification

```
86 -> 76 findings    763 -> 277 targets    10 -> 4 scan errors
488 files removed from the scanned set, every one a test file or under root examples/
newly scanned: only this change's own two files
packages/frontend/public/examples/ still scanned: 29 files
```

The four remaining errors are warn-level `PartialParsing` in the `run:` blocks of two backend deploy workflows. I tested them directly: they do **not** fail the job under `--no-suppress-errors`.

| Gate | Result |
|---|---|
| `npm run check-format` | clean |
| `npm run check-supply-chain -- --offline` | OK, register agrees |
| `zizmor --offline .` | 0 findings |

zizmor ran as 1.30.1 locally; CI pins 1.29.0, so the `audit` job on this PR is the run that confirms the register's "0 findings across all eight" line. Under the auditor persona, the only finding is `secrets-outside-env`, the same one ttl-editor accepted.

## Expected on this PR

`scan` is diff-aware on a pull request, and this PR adds no application code, so **near-zero findings is the correct result**. The `Verify the pinned version installed` step printing `1.176.1` shows the scan actually ran.

## After merge

The `acc` push does the full scan and registers `sgort/linked-data-explorer` in Semgrep Cloud with the 76-finding baseline. Next come triage of the 10 application Code findings, and then adding `scan` to both rulesets.

Needs `SEMGREP_APP_TOKEN` with Agent (CI) scope. It has already been created.
