### PR TITLE
fix(security): harden what the first Semgrep triage found, and say why the rest stays

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -10,6 +10,7 @@ import { versionMiddleware } from './middleware/version.middleware';
 import { externalTaskWorker } from './services/externalTaskWorker.service';
 import { migrate } from './db/migrate';
 import { rootHandler } from './utils/rootViews';
+import { isPublicPath } from './utils/publicPaths';
 
 const app: Express = express();
 
@@ -41,11 +42,11 @@ const corsOptions: cors.CorsOptions = {
 app.use(helmet());
 
 // apply CORS to both normal requests and preflight
-const isPublicPath = (path: string) =>
-  path.startsWith('/v1/ropa/public') || path.startsWith('/v1/bundles/public');
 
 app.use((req, res, next) => {
   if (isPublicPath(req.path)) {
+    // Wildcard by design, for the public read-only mounts only -- see utils/publicPaths.ts.
+    // nosemgrep: javascript.express.web.cors-permissive-express.cors-permissive-express
     cors({ origin: '*', methods: ['GET', 'OPTIONS'] })(req, res, next);
   } else {
     cors(corsOptions)(req, res, next);
@@ -53,6 +54,8 @@ app.use((req, res, next) => {
 });
 app.options('*', (req, res, next) => {
   if (isPublicPath(req.path)) {
+    // Wildcard by design, for the public read-only mounts only -- see utils/publicPaths.ts.
+    // nosemgrep: javascript.express.web.cors-permissive-express.cors-permissive-express
     cors({ origin: '*', methods: ['GET', 'OPTIONS'] })(req, res, next);
   } else {
     cors(corsOptions)(req, res, next);

--- a/packages/backend/src/routes/assets.public.routes.ts
+++ b/packages/backend/src/routes/assets.public.routes.ts
@@ -8,6 +8,9 @@ import logger from '../utils/logger';
 const router = Router();
 
 // Fully open CORS — consumed by the RONL Business API caseworker dashboard
+// Kept although index.ts already applies it, so the router is correct when mounted on
+// its own -- as its tests do. Public, read-only, no credentials; see utils/publicPaths.ts.
+// nosemgrep: javascript.express.web.cors-permissive-express.cors-permissive-express
 router.use(cors({ origin: '*', methods: ['GET', 'OPTIONS'] }));
 
 router.get('/', async (_req: Request, res: Response) => {

--- a/packages/backend/src/routes/ropa.public.routes.ts
+++ b/packages/backend/src/routes/ropa.public.routes.ts
@@ -7,6 +7,9 @@ import logger from '../utils/logger';
 const router = Router();
 
 // Fully open CORS — this route is consumed by ropa.flevoland.nl and similar
+// Kept although index.ts already applies it, so the router is correct when mounted on
+// its own -- as its tests do. Public, read-only, no credentials; see utils/publicPaths.ts.
+// nosemgrep: javascript.express.web.cors-permissive-express.cors-permissive-express
 router.use(cors({ origin: '*', methods: ['GET', 'OPTIONS'] }));
 
 router.get('/', async (req: Request, res: Response) => {

--- a/packages/backend/src/utils/publicPaths.test.ts
+++ b/packages/backend/src/utils/publicPaths.test.ts
@@ -1,0 +1,33 @@
+import { isPublicPath } from './publicPaths';
+
+// isPublicPath decides which requests get wildcard CORS (origin '*', GET/OPTIONS,
+// no credentials) instead of the credentialed allowlist in index.ts. Everything it
+// returns true for is readable cross-origin by any site, so it must be exact.
+describe('isPublicPath', () => {
+  test.each(['/v1/ropa/public', '/v1/bundles/public'])(
+    'treats the public mount %s as public',
+    (p) => {
+      expect(isPublicPath(p)).toBe(true);
+    }
+  );
+
+  test.each(['/v1/ropa/public/', '/v1/bundles/public/abc'])(
+    'treats a path below a public mount (%s) as public',
+    (p) => {
+      expect(isPublicPath(p)).toBe(true);
+    }
+  );
+
+  test.each(['/v1/dmns', '/v1/assets/ropa', '/v1/ropa', '/'])('treats %s as not public', (p) => {
+    expect(isPublicPath(p)).toBe(false);
+  });
+  // The defect: a bare prefix match hands wildcard CORS to any sibling route whose
+  // name merely begins with "public". No such route exists today -- the mount table
+  // in routes/registry.ts has none -- which is exactly why it would arrive unnoticed.
+  test.each(['/v1/ropa/publications', '/v1/ropa/public-admin', '/v1/bundles/publicity'])(
+    'does not treat the sibling route %s as public',
+    (p) => {
+      expect(isPublicPath(p)).toBe(false);
+    }
+  );
+});

--- a/packages/backend/src/utils/publicPaths.ts
+++ b/packages/backend/src/utils/publicPaths.ts
@@ -1,0 +1,18 @@
+/**
+ * Paths that get wildcard CORS -- origin '*', GET/OPTIONS only, no credentials --
+ * rather than the credentialed allowlist in index.ts.
+ *
+ * They serve deliberately public, read-only data to named third-party consumers:
+ * ropa.flevoland.nl and similar for /v1/ropa/public, and the RONL Business API
+ * caseworker dashboard for /v1/bundles/public. The data behind them is shaped for
+ * publication (listPublicRopa returns active records only and strips controller
+ * and DPO contacts), and the backend performs no inbound authentication, so these
+ * endpoints are already readable by anything that is not a browser. Wildcard CORS
+ * extends that to browser scripts on other origins, which is the point.
+ */
+const PUBLIC_MOUNTS = ['/v1/ropa/public', '/v1/bundles/public'];
+
+// Matches a mount or anything below it, never a sibling that merely shares the
+// prefix: /v1/ropa/publications must fall through to the credentialed allowlist.
+export const isPublicPath = (path: string) =>
+  PUBLIC_MOUNTS.some((mount) => path === mount || path.startsWith(`${mount}/`));

--- a/packages/frontend/src/components/BpmnModeler/BpmnModeler.tsx
+++ b/packages/frontend/src/components/BpmnModeler/BpmnModeler.tsx
@@ -5,6 +5,7 @@ import { BpmnService } from '../../services/bpmnService';
 import { BpmnProcess } from '../../types';
 import { ASYLUM_MIGRATION_EXAMPLE_XML, DEFAULT_BPMN_XML } from '../../utils/bpmnTemplates';
 import { EXAMPLE_VERSIONS, getStoredVersion, setStoredVersion } from '../../utils/exampleVersions';
+import { applyRonlAttr, readRonlAttr, type RonlAttr } from '../../utils/ronlAttributes';
 import BpmnCanvas from './BpmnCanvas';
 import ProcessList from './ProcessList';
 
@@ -82,24 +83,6 @@ type FooterDraft = {
   dsoActiviteitUrn?: string;
 };
 
-/** Rewrites a single ronl:* attribute on the <bpmn:process> tag. */
-function applyRonlAttr(xml: string, attr: string, value: string | undefined): string {
-  let out = xml;
-  if (!out.includes('xmlns:ronl=')) {
-    out = out.replace(/(<(?:bpmn:)?definitions\b)/, '$1 xmlns:ronl="http://ronl.nl/schema/1.0"');
-  }
-  if (value) {
-    if (out.includes(`ronl:${attr}=`)) {
-      out = out.replace(new RegExp(`ronl:${attr}="[^"]*"`), `ronl:${attr}="${value}"`);
-    } else {
-      out = out.replace(/(<(?:bpmn:)?process\b[^>]*?)(\/?>)/, `$1 ronl:${attr}="${value}"$2`);
-    }
-  } else {
-    out = out.replace(new RegExp(`\\s*ronl:${attr}="[^"]*"`), '');
-  }
-  return out;
-}
-
 const BpmnModeler: React.FC<BpmnModelerProps> = ({ endpoint }) => {
   const [processes, setProcesses] = useState<BpmnProcess[]>(BpmnService.getProcesses());
   const [activeProcessId, setActiveProcessId] = useState<string | null>(null);
@@ -113,15 +96,14 @@ const BpmnModeler: React.FC<BpmnModelerProps> = ({ endpoint }) => {
   /** Read the effective value for a footer field: draft wins, then process field, then XML. */
   const readEffective = <K extends keyof FooterDraft>(
     key: K,
-    xmlAttr: string
+    xmlAttr: RonlAttr
   ): FooterDraft[K] | undefined => {
     if (key in draft) return draft[key];
     if (key === 'language' || key === 'organization') {
       const v = activeProcess?.[key as 'language' | 'organization'];
       if (v) return v as FooterDraft[K];
     }
-    const m = currentXml.match(new RegExp(`ronl:${xmlAttr}="([^"]+)"`));
-    return (m?.[1] as FooterDraft[K]) ?? undefined;
+    return readRonlAttr(currentXml, xmlAttr) as FooterDraft[K] | undefined;
   };
 
   /** True when the user has unsaved canvas edits or unsaved footer edits. */

--- a/packages/frontend/src/utils/exportService.test.ts
+++ b/packages/frontend/src/utils/exportService.test.ts
@@ -323,8 +323,34 @@ describe('exportChain — package (ZIP)', () => {
     expect(result.success).toBe(true);
     expect(await entriesOf(result.content)).toEqual(['README.md', 'age-check.dmn', 'chain.bpmn']);
     expect(consoleError).toHaveBeenCalledWith(
-      'Failed to fetch DMN missing:',
+      'Failed to fetch DMN %s:',
+      'missing',
       expect.objectContaining({ message: 'Failed to fetch DMN missing: Not Found' })
+    );
+  });
+
+  // console.error treats its FIRST argument as a format string, so a DMN id placed
+  // there is interpreted: '%s' consumes the next argument -- here, the error object --
+  // and the log line loses the very thing it exists to report. The id is data, and
+  // belongs in an argument position, never in the format.
+  test('passes the DMN id as data, never as part of the console format string', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) =>
+        String(url).includes('missing')
+          ? { ok: false, statusText: 'Not Found', text: async () => '' }
+          : { ok: true, statusText: 'OK', text: async () => '<definitions />' }
+      )
+    );
+
+    await exportChain(['age-check', 'missing%s'], {}, [dmn()], options({ format: 'package' }));
+
+    const call = consoleError.mock.calls.find((c) => String(c[1]).includes('missing%s'));
+    expect(call?.[0]).toBe('Failed to fetch DMN %s:');
+    expect(call?.[1]).toBe('missing%s');
+    expect(call?.[2]).toEqual(
+      expect.objectContaining({ message: expect.stringContaining('Not Found') })
     );
   });
 

--- a/packages/frontend/src/utils/exportService.ts
+++ b/packages/frontend/src/utils/exportService.ts
@@ -244,7 +244,7 @@ async function exportAsPackage(
         const dmnXml = await fetchDmnXml(dmnId);
         zip.file(`${dmnId}.dmn`, dmnXml);
       } catch (error) {
-        console.error(`Failed to fetch DMN ${dmnId}:`, error);
+        console.error('Failed to fetch DMN %s:', dmnId, error);
         // Continue with other DMNs even if one fails
       }
     }

--- a/packages/frontend/src/utils/ronlAttributes.test.ts
+++ b/packages/frontend/src/utils/ronlAttributes.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { describe, expect, test } from 'vitest';
+
+import { applyRonlAttr, readRonlAttr } from './ronlAttributes';
+
+// xmlns:bpmn is declared so the fixture is itself well-formed: without it every
+// well-formedness assertion below fails regardless of what applyRonlAttr writes.
+const BARE =
+  '<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="d">' +
+  '<bpmn:process id="p" isExecutable="true"></bpmn:process></bpmn:definitions>';
+const NS = 'xmlns:ronl="http://ronl.nl/schema/1.0"';
+
+describe('applyRonlAttr', () => {
+  test('declares the ronl namespace and writes the attribute onto the process tag', () => {
+    const out = applyRonlAttr(BARE, 'organization', 'flevoland');
+    expect(out).toContain(`<bpmn:definitions ${NS} xmlns:bpmn=`);
+    expect(out).toContain(
+      '<bpmn:process id="p" isExecutable="true" ronl:organization="flevoland">'
+    );
+  });
+
+  test('replaces an existing value rather than adding a second attribute', () => {
+    const once = applyRonlAttr(BARE, 'language', 'nl');
+    const twice = applyRonlAttr(once, 'language', 'en');
+    expect(twice).toContain('ronl:language="en"');
+    expect(twice.match(/ronl:language=/g)).toHaveLength(1);
+  });
+
+  test('removes the attribute when the value is cleared', () => {
+    const set = applyRonlAttr(BARE, 'ropaRef', 'r-1');
+    expect(applyRonlAttr(set, 'ropaRef', undefined)).not.toContain('ronl:ropaRef');
+  });
+
+  test('handles a self-closing process tag', () => {
+    const selfClosing = '<bpmn:definitions id="d"><bpmn:process id="p"/></bpmn:definitions>';
+    expect(applyRonlAttr(selfClosing, 'language', 'nl')).toContain(
+      '<bpmn:process id="p" ronl:language="nl"/>'
+    );
+  });
+});
+
+describe('readRonlAttr', () => {
+  test('reads back a value that applyRonlAttr wrote', () => {
+    expect(
+      readRonlAttr(applyRonlAttr(BARE, 'dsoActiviteitUrn', 'urn:x:1'), 'dsoActiviteitUrn')
+    ).toBe('urn:x:1');
+  });
+
+  test('returns undefined when the attribute is absent', () => {
+    expect(readRonlAttr(BARE, 'organization')).toBeUndefined();
+  });
+});
+
+// Values are written into an XML attribute, and into a String.replace replacement
+// string. Today all four come from selectors, so neither defect is reachable -- a
+// property of the current wiring rather than of these functions.
+describe('applyRonlAttr with values that need escaping', () => {
+  const isWellFormed = (xml: string) =>
+    new DOMParser().parseFromString(xml, 'application/xml').getElementsByTagName('parsererror')
+      .length === 0;
+
+  test('the fixture is itself well-formed, so failures below are about the value', () => {
+    expect(isWellFormed(BARE)).toBe(true);
+  });
+
+  test.each(['Gemeente "Den Haag"', 'Kosten & baten', 'a < b'])(
+    'keeps the XML well-formed and round-trips %s',
+    (value) => {
+      const out = applyRonlAttr(BARE, 'organization', value);
+      expect(isWellFormed(out)).toBe(true);
+      expect(readRonlAttr(out, 'organization')).toBe(value);
+    }
+  );
+
+  test.each(['A$2B', 'A$&B', "A$'B", 'A$1B'])(
+    'writes %s literally when inserting a new attribute',
+    (value) => {
+      const out = applyRonlAttr(BARE, 'organization', value);
+      expect(readRonlAttr(out, 'organization')).toBe(value);
+      expect(isWellFormed(out)).toBe(true);
+    }
+  );
+
+  test.each(['A$2B', 'A$&B', "A$'B"])(
+    'writes %s literally when replacing an existing attribute',
+    (value) => {
+      const out = applyRonlAttr(applyRonlAttr(BARE, 'organization', 'old'), 'organization', value);
+      expect(readRonlAttr(out, 'organization')).toBe(value);
+      expect(isWellFormed(out)).toBe(true);
+    }
+  );
+});

--- a/packages/frontend/src/utils/ronlAttributes.ts
+++ b/packages/frontend/src/utils/ronlAttributes.ts
@@ -1,0 +1,57 @@
+/**
+ * The only ronl:* attributes the modeler writes. Typed as a closed union so the
+ * attribute name interpolated into the RegExps below is a compile-time literal,
+ * never data -- which is what makes those RegExps safe, and what the nosemgrep
+ * directives on them rely on.
+ */
+export type RonlAttr = 'language' | 'organization' | 'ropaRef' | 'dsoActiviteitUrn';
+
+// Values are written into an XML attribute, so they are escaped on the way in and
+// decoded on the way out; & first when escaping and last when decoding, or an
+// already-escaped entity would be mangled.
+const escapeXmlAttr = (value: string) =>
+  value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+const decodeXmlAttr = (value: string) =>
+  value
+    .replace(/&quot;/g, '"')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
+
+/** Rewrites a single ronl:* attribute on the <bpmn:process> tag. */
+export function applyRonlAttr(xml: string, attr: RonlAttr, value: string | undefined): string {
+  let out = xml;
+  if (!out.includes('xmlns:ronl=')) {
+    out = out.replace(/(<(?:bpmn:)?definitions\b)/, '$1 xmlns:ronl="http://ronl.nl/schema/1.0"');
+  }
+  if (value) {
+    const attribute = `ronl:${attr}="${escapeXmlAttr(value)}"`;
+    // Replacer functions, not replacement strings: in a replacement string $1, $&
+    // and $' are expanded, so a value containing them pasted captured groups, the
+    // matched tag or the rest of the document into the attribute.
+    if (out.includes(`ronl:${attr}=`)) {
+      // attr is a RonlAttr literal and [^"]* is linear: no injection, no backtracking.
+      // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp
+      out = out.replace(new RegExp(`ronl:${attr}="[^"]*"`), () => attribute);
+    } else {
+      out = out.replace(
+        /(<(?:bpmn:)?process\b[^>]*?)(\/?>)/,
+        (_match, head: string, close: string) => `${head} ${attribute}${close}`
+      );
+    }
+  } else {
+    // attr is a RonlAttr literal and [^"]* is linear: no injection, no backtracking.
+    // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp
+    out = out.replace(new RegExp(`\\s*ronl:${attr}="[^"]*"`), '');
+  }
+  return out;
+}
+
+/** Reads a single ronl:* attribute from the XML, or undefined when absent. */
+export function readRonlAttr(xml: string, attr: RonlAttr): string | undefined {
+  // attr is a RonlAttr literal and [^"]* is linear: no injection, no backtracking.
+  // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp
+  const m = xml.match(new RegExp(`ronl:${attr}="([^"]+)"`));
+  return m?.[1] === undefined ? undefined : decodeXmlAttr(m[1]);
+}


### PR DESCRIPTION
Hardening from the first Semgrep triage of `acc`. Semgrep Code goes from **10 → 2**.

## The ten findings

| Finding | Verdict | This PR |
|---|---|---|
| `missing-integrity`: Tailwind **Play CDN** live in the production `index.html` | 🔴 **true positive** | its own issue, since the fix is a UI change that needs visual verification |
| `cors-permissive-express` ×4 | by design | exact-segment match fix, plus a scoped `nosemgrep` with its reason |
| `detect-non-literal-regexp` ×3 in `BpmnModeler` | false positive | fixed a latent defect found alongside it, typed the attribute name, scoped `nosemgrep` |
| `unsafe-formatstring` | false positive, trivial | fixed, which retires the finding outright |
| `insecure-object-assign` | false positive | left for dashboard triage |

## Three fixes, all written test-first

**CORS matched on a bare prefix.** `isPublicPath` decides which requests get wildcard CORS instead of the credentialed allowlist. `startsWith('/v1/ropa/public')` also matches `/v1/ropa/publications`, `/v1/ropa/public-admin`, and any sibling whose name begins with *public*. No such route exists today; I checked every mount in `routes/registry.ts`. That is why one would arrive unnoticed. It now matches the mount or a path below it, never a sibling.

**`applyRonlAttr` wrote unescaped values into BPMN XML**, and into a `String.replace` replacement string:

- An unescaped `"`, `&` or `<` breaks the XML.
- In the replacement string, `$1`, `$&` and `$'` are **expanded**. A value of `A$'B` wrote **the rest of the document** into the attribute: `A</bpmn:process></bpmn:definitions>B`.

Values are now escaped on write and decoded on read, and both replaces use replacer functions. The defect stays latent: all four values come from selectors, not free text.

**`console.error` took the DMN id inside its format string**, where a `%s` would consume the error object the line exists to report. The id is now an argument. This one retires its finding outright.

## Reaching code that could not be tested

Both targets were module-private, and reachable only through modules with side effects: importing `index.ts` runs `migrate()` and `listen()`. So I extracted each one **verbatim** and pinned its current behaviour with characterisation tests before writing any failing test:

| Extracted | From | Into |
|---|---|---|
| `isPublicPath` | `index.ts` | `backend/src/utils/publicPaths.ts` |
| `applyRonlAttr`, plus a matching `readRonlAttr` | `BpmnModeler.tsx` | `frontend/src/utils/ronlAttributes.ts` |

`readRonlAttr` replaces the inline regex in `readEffective`, and decodes on read. Without it, escaping on write would show `&quot;` back in the footer.

## Two RED results that were wrong before they were right

Both are easy to miss, so I am recording them:

- **`DOMParser is not defined`.** The utils test ran in Vitest's `node` environment, so three tests *errored* instead of failing. Fixed with `// @vitest-environment jsdom`.
- **The fixture was not well-formed.** It used the `bpmn:` prefix without declaring it, so every well-formedness check failed whatever the code did.

With both fixed, and a guard test asserting that the fixture itself parses, I ran the tests against the **original** code: **nine genuine assertion failures**. One case, `A$2B` on the replace path, was never vulnerable, because that regex has no capture group. It is kept as regression coverage, not counted as a RED.

## Suppressions, scoped and reasoned

- **CORS ×4.** The wildcard is deliberate: two read-only `GET` mounts for named third-party consumers, no credentials, and data shaped for publication (`listPublicRopa` strips the controller and DPO contacts). The backend performs no inbound authentication, so these endpoints are already readable by `curl`.
- **Regex ×3.** The attribute name is now typed as a closed `RonlAttr` union, so the compiler enforces that it is a literal. `[^"]*` is linear.

`detect-non-literal-regexp` stays live everywhere else.

## Verification

| Check | Result |
|---|---|
| `npm test` (backend Jest + frontend Vitest, per-file 80% branch floors) | green, run by the maintainer |
| `npm run typecheck` | clean, both workspaces |
| `npm run lint` | clean; it caught one import-order slip, fixed with the rule's autofix |
| `npm run check-format` | clean |
| Semgrep Code | **10 → 2**, checked by rule and file, not only by count |

The two findings left are `missing-integrity` (Tailwind) and `insecure-object-assign`.
