### PR TITLE
docs: record that scan gates acc and main, in the places that said otherwise

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -20,11 +20,18 @@ name: Semgrep
 # request cannot skip the scan by targeting an unwatched base or by touching
 # nothing watched. push stays filtered to the two branches that deploy.
 #
-# NOT yet a required check in either ruleset. That comes once the baseline is
-# known and triaged -- at which point the trigger shape above stops being
-# precautionary and becomes load-bearing, because a required check that no
-# trigger produces wedges a pull request permanently. Promotion is a ruleset
-# change rather than a change to this file. `continue-on-error` would be the
+# `scan` IS a required check in BOTH rulesets -- "acc supply-chain gate" and
+# "main promotion gate" -- added on 2026-09-11 once the baseline was triaged from
+# 86 findings to 5, none blocking. So the trigger shape above is now load-bearing
+# rather than precautionary: a required check that no trigger produces wedges a
+# pull request permanently, and on main that pull request is the promotion.
+# Promotion to required was a ruleset change, which is why nothing in this file
+# moved when it happened; see SECURITY-PIPELINE.md, "What the rulesets require".
+#
+# No fork caveat here, unlike ttl-editor: this repository has no forks, so no
+# pull request arrives without SEMGREP_APP_TOKEN. If one ever does, semgrep ci
+# cannot start, --no-suppress-errors fails the step, and the required check
+# blocks it -- see ttl-editor#128 for the fork-safe shape. `continue-on-error` would be the
 # obvious alternative and is the wrong tool, for the reason zizmor.yml already
 # spells out: it rewrites the STEP's reported conclusion as well as the job's,
 # so a finding shows up only in the log while every check reads "success".

--- a/SECURITY-PIPELINE.md
+++ b/SECURITY-PIPELINE.md
@@ -232,7 +232,39 @@ The audit workflow deliberately has **no `paths:` filter**. Every other workflow
 here is path-filtered; filtering this one would let a pull request skip the gate
 by touching nothing the filter watches.
 
-The `acc` ruleset requires a pull request and a passing `audit` check, so the
-gate is not advisory — a branch that reintroduces a floating tag cannot merge.
-That includes releases: `/bump-release` was rewritten to land through a pull
-request for exactly this reason.
+Two rulesets make the gate binding rather than advisory — a branch that
+reintroduces a floating tag cannot merge. That includes releases: `/bump-release`
+was rewritten to land through a pull request for exactly this reason.
+
+### What the rulesets require
+
+A ruleset is GitHub state, not a file: nothing in a diff records it, and nothing
+here is enforced by being written down. It is written down because otherwise the
+only account of what gates `acc` and `main` lives in a settings page nobody reads
+until something is already stuck.
+
+| Ruleset                 | Id         | Ref               | Required checks | Merge methods |
+| ----------------------- | ---------- | ----------------- | --------------- | ------------- |
+| `acc supply-chain gate` | `21794157` | `refs/heads/acc`  | `audit`, `scan` | merge only    |
+| `main promotion gate`   | `22630654` | `refs/heads/main` | `audit`, `scan` | merge only    |
+
+`audit` is `zizmor.yml`; `scan` is `semgrep.yml`, added to both on 2026-09-11.
+Both workflows trigger on `pull_request` with no branch or path filter, which is
+what makes them safe to require: neither can go missing on any base.
+
+**The two rulesets differ in one parameter, deliberately.**
+`require_extra_approval_for_unattributed_changes` is `true` on `acc` and `false`
+on `main`. The `main` ruleset was created without it, GitHub stored it as `true`,
+and with zero required approvals and no second maintainer to give one, that
+would have deadlocked the very promotion the ruleset exists to protect. Rewrite
+either ruleset from a template and this is the line that drifts back.
+
+Worth knowing before it bites:
+
+- **`bypass_actors` is empty on both.** There is no administrator override. If
+  semgrep.dev is unreachable or `SEMGREP_APP_TOKEN` is revoked, merges to `acc`
+  **and to `main`** stop until a ruleset is edited — for this repository that
+  includes promotion to production.
+- **No forks today.** A pull request from a fork would carry no secret, so `scan`
+  could not start and would block it. See ttl-editor#128 for the fork-safe
+  shape, should that ever change.

--- a/docs/ci-posture-across-repos.md
+++ b/docs/ci-posture-across-repos.md
@@ -7,7 +7,7 @@ verification, and a per-file test-coverage floor.
 
 A **fourth** now exists in two of the three: ttl-editor gates merges on a Semgrep
 scan covering the npm dependency tree and the application code, and Linked Data
-Explorer runs the same scan, reporting but not yet required. It is described
+Explorer runs the same scan, required on both `acc` and `main`. It is described
 under §2 rather than given a section of its own, because it is the other half of
 the supply chain that `check-supply-chain` was never able to see.
 
@@ -29,7 +29,7 @@ gate landed and v2026.09.3 was promoted; the other two are as of their last pass
 | ----------------------------- | -------------------- | -------------------- | ----------------------- |
 | **Build id in the changelog** | ✅                   | ✅                   | ✅                      |
 | **check-supply-chain**        | ✅ blocking          | ✅ blocking          | ⚠️ non-blocking         |
-| **Semgrep Code + SCA**        | ✅ blocking          | ⏳ reporting         | —                       |
+| **Semgrep Code + SCA**        | ✅ blocking          | ✅ blocking          | —                       |
 | **Per-file 80% branch floor** | ✅ native thresholds | ✅ native thresholds | ✅ native thresholds    |
 | **Formatting checked in CI**  | ✅                   | ✅                   | —                       |
 | **Tests run before merge**    | ✅                   | ✅                   | ⚠️ frontend only        |
@@ -326,8 +326,9 @@ ttl-editor closed that in September 2026 with a `Semgrep` workflow whose `scan`
 job is a required check alongside `audit`. It runs Semgrep Code and Supply Chain
 against an authenticated scan, reporting to the `sgort/ttl-editor` project in
 Semgrep Cloud. Linked Data Explorer adopted the same workflow on 11 September
-2026 and runs it as a reporting check before requiring it; RONL Business API does
-not have it yet.
+2026, ran it as a reporting check while the baseline was triaged, and required it
+on both `acc` and `main` the same day — the difference from ttl-editor being that
+its `main` was already gated. RONL Business API does not have it yet.
 
 Three things differed when it was ported to Linked Data Explorer, a monorepo:
 
@@ -838,7 +839,9 @@ cited across all seventy-five changelog entries.
 Closed on 2026-09-09 with a `main promotion gate` ruleset created **before** the
 promotion pull request was opened, mirroring the `acc` one: `deletion`,
 `non_fast_forward`, `pull_request` with `allowed_merge_methods: ["merge"]`, and
-`required_status_checks: [audit]` with `strict: false`.
+`required_status_checks: [audit]` with `strict: false`. `scan` joined `audit` in
+both rulesets on 2026-09-11; read back after writing, each ruleset changed in
+that one field and no other.
 
 Three things that were load-bearing, in the order they mattered:
 


### PR DESCRIPTION
`scan` became a required check in **both** rulesets today, `acc supply-chain gate` and `main promotion gate`. That happened once the Semgrep baseline had been triaged from 86 findings to 5, none of them blocking.

That change touched no file, because a ruleset is GitHub state and not part of the tree. It left four statements saying the opposite:

| Where | Said |
|---|---|
| `semgrep.yml` header | *"NOT yet a required check in either ruleset"* |
| posture page intro | *"reporting but not yet required"* |
| posture page summary row | `⏳ reporting` |
| posture page §2 | *"runs it as a reporting check before requiring it"* |

Left alone, the workflow would tell every reader the scan is advisory while it blocks merges to production. That is the same class of stale label ttl-editor#129 corrected there.

## What changed

- **`semgrep.yml`.** Only comment lines change, and the file still parses. The header now also says why there is no fork caveat here: this repository has no forks. It points at ttl-editor#128 in case that ever changes.
- **`SECURITY-PIPELINE.md`.** Its enforcement section said *"the `acc` ruleset requires … a passing `audit` check"*. There are two rulesets and now two checks. A new section, **"What the rulesets require"**, lists both rulesets with their ids, refs, required checks and merge methods.
- **Posture page.** Intro, summary row and §2 are corrected. §4's account of the `main` gate, which listed `audit` as its only check as of 2026-09-09, gains a line recording that `scan` joined it.

## Recorded because the posture page asked for it

The two rulesets differ in one parameter, deliberately. `require_extra_approval_for_unattributed_changes` is `true` on `acc` and `false` on `main`. The `main` ruleset was created without it, GitHub stored it as `true`, and with no second maintainer to approve, that would have deadlocked the promotion. The posture page said this was worth recording somewhere durable, or it would read as drift.

Both rulesets were written with a full explicit payload and read back afterwards. Each changed in the required-checks field and in no other, and this parameter survived.

**The cost:** `bypass_actors` is empty on both. An unreachable semgrep.dev or a revoked token stops merges to `main` as well as `acc`, and here that includes promotion to production.

## Proven without pushing

#80 was opened before `semgrep.yml` existed. It now reads **blocked**, with `audit` present and `scan` missing. The four Renovate pull requests that Renovate had already rebased onto the new `acc` carry a `scan` run and stay `clean`.

## Verification

`check-format` and `check-supply-chain --offline` pass, and zizmor reports 0 findings.