### PR TITLE
chore: bump release to v2026.09.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linked-data-explorer-monorepo",
-  "version": "2026.09.2",
+  "version": "2026.09.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linked-data-explorer-monorepo",
-      "version": "2026.09.2",
+      "version": "2026.09.3",
       "hasInstallScript": true,
       "license": "EUPL-1.2",
       "workspaces": [
@@ -17528,7 +17528,7 @@
     },
     "packages/backend": {
       "name": "@linked-data-explorer/backend",
-      "version": "2026.09.2",
+      "version": "2026.09.3",
       "license": "EUPL-1.2",
       "dependencies": {
         "@rdfjs/dataset": "^2.0.3",
@@ -17572,7 +17572,7 @@
     },
     "packages/frontend": {
       "name": "@linked-data-explorer/frontend",
-      "version": "2026.09.2",
+      "version": "2026.09.3",
       "dependencies": {
         "@bpmn-io/form-js": "^1.25.0",
         "@bpmn-io/properties-panel": "^3.52.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linked-data-explorer-monorepo",
-  "version": "2026.09.2",
+  "version": "2026.09.3",
   "private": true,
   "description": "Monorepo for Linked Data Explorer - RONL DMN Orchestration Platform",
   "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linked-data-explorer/backend",
-  "version": "2026.09.2",
+  "version": "2026.09.3",
   "description": "Backend orchestration service for DMN chain execution",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@linked-data-explorer/frontend",
   "private": true,
-  "version": "2026.09.2",
+  "version": "2026.09.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/frontend/src/changelog.json
+++ b/packages/frontend/src/changelog.json
@@ -2,6 +2,46 @@
   "versions": [
     {
       "format": "commits",
+      "version": "2026.09.3",
+      "status": "Released",
+      "date": "11 sep 2026",
+      "scope": "both",
+      "commits": [
+        {
+          "sha": "f347bbf",
+          "author": "Steven Gort",
+          "type": "fix",
+          "subject": "Hardening from the first Semgrep triage",
+          "details": [
+            "Wildcard CORS for the two public read-only endpoints matched on a bare path prefix, so any future sibling route whose name began with \"public\" — /v1/ropa/publications, say — would have inherited it instead of the credentialed allowlist. It now matches the mount or a path below it, never a sibling.",
+            "The BPMN modeler wrote process metadata into the XML unescaped, and through String.replace, where $1, $& and $' are expanded: a value of A$'B wrote the rest of the document into the attribute. Values are now escaped on write and decoded on read. Latent rather than live — all four values come from selectors — but fixed where it lives, not where it is currently called from.",
+            "A DMN export failure now logs the DMN id as data rather than inside the console format string, where a stray %s swallowed the error the line exists to report. Semgrep's ten application Code findings go to two: the Tailwind Play CDN, tracked separately as a true positive, and one false positive for dashboard triage."
+          ]
+        },
+        {
+          "sha": "eed4ebb",
+          "author": "renovate[bot]",
+          "type": "chore",
+          "subject": "The transitive dependency tree refreshed for the first time since January",
+          "details": [
+            "Renovate's lock-file maintenance, forced after it had been rate-limited behind open pull requests since it was enabled. It moved 338 packages, 82 of them runtime dependencies — axios, dompurify, bpmn-js, diagram-js and the @rdfjs packages among them — every one within a range the manifests already declared, and none published within the 14-day cooldown.",
+            "It closed 63 of 66 Semgrep Supply Chain findings in one change, including all five that Semgrep classed as reachable, all HIGH: js-yaml in the lint and coverage tooling, and rollup, which sat at 4.55.1 from January although 4.59.0 was out in February."
+          ]
+        },
+        {
+          "sha": "f0ed220",
+          "author": "Steven Gort",
+          "type": "ci",
+          "subject": "Semgrep scans every pull request, and now gates acc and main",
+          "details": [
+            "Semgrep Code and Supply Chain run on every pull request and on every push to acc and main, in one job covering all three workspaces through the single root lockfile. Supply Chain covers what nothing else here did: check-supply-chain verifies GitHub Actions pins and says nothing about package-lock.json.",
+            "Introduced as a reporting check, it became a required check in both the acc and main rulesets once the first baseline had been triaged from 86 findings to 5, none blocking — so the application now reaches acceptance and production only through a scan of the exact commit being deployed."
+          ]
+        }
+      ]
+    },
+    {
+      "format": "commits",
       "version": "2026.09.2",
       "status": "Released",
       "date": "9 sep 2026",


### PR DESCRIPTION
Cuts **v2026.09.3**, scope **`both`**. Merging this pushes `acc`, which triggers the frontend and backend acceptance deploys.

## What changed

| File | Change |
|---|---|
| `packages/frontend/src/changelog.json` | new entry prepended, `status: "Released"`, 3 commits |
| `package.json`, `packages/frontend/package.json`, `packages/backend/package.json` | `2026.09.2` → `2026.09.3` |
| `package-lock.json` | exactly the four matching `version` fields: top-level, `packages[""]`, and both workspaces. Nothing else moved |

The scope is `both` because #95 touched `packages/backend` and `packages/frontend`. `ropa-site` has no `package.json` and is never version-bumped.

## The entry

```
[fix  ] f347bbf  Steven Gort    Hardening from the first Semgrep triage
[chore] eed4ebb  renovate[bot]  The transitive dependency tree refreshed for the first time since January
[ci   ] f0ed220  Steven Gort    Semgrep scans every pull request, and now gates acc and main
```

- **Semgrep adoption and triage, 86 findings → 5.** Semgrep now runs as a required check on both `acc` and `main`, in one job covering all three workspaces.
- **The first lock-file maintenance since January.** It moved 338 packages, 82 of them runtime, and closed 63 of 66 Supply Chain findings, including all five that Semgrep classed as reachable, all HIGH. None of the refreshed versions was published within the 14-day cooldown; each was checked against the registry.
- **Hardening.** Exact-segment CORS matching, XML escaping in the BPMN modeler, and the DMN export log line.

`eed4ebb` has no commit body, because Renovate writes none. Its details come from facts verified while it was being merged, not from a commit message.

Four `docs` commits in range were deliberately excluded (`3f2dd6b`, `eb5af4f`, `a1410af`, `689006d`). The changelog is kept as a product record, not a repository record. They are dropped rather than deferred: the next range starts at this bump.

## Verification

| Check | Result |
|---|---|
| Changelog SHAs | all three resolve and are live on `origin/acc`; none appears in any earlier entry; order matches `git log --no-merges` |
| `npm ci --dry-run` | lockfile still resolves |
| `npm run check-format` | clean |
| `Changelog` component tests | 11/11, so the new entry renders |

## Process notes

- The five open Renovate pull requests (#86, #85, #80, #69, #68) were reviewed in step 0 and deliberately left for the next release, so no lockfile rewrite raced this bump.
- The changelog splice ran from a `node` script and refuses to run twice. That was verified by a second run, which exited 1 without writing.

## Merging

**Use a merge commit.** Squash and rebase are disabled, both in the repository settings and in the ruleset's `allowed_merge_methods`. The entry names each commit by its SHA, and both alternatives rewrite those hashes.

This is the first release to go through the `acc` gate with `scan` required. The promotion to `main` that follows will be the first through the `main promotion gate` with `scan` required.
