### PR TITLE
ci: build, test and deploy lockfile-only changes, and stop starving their refresh

### DIFF
--- a/.github/workflows/azure-backend-acc.yml
+++ b/.github/workflows/azure-backend-acc.yml
@@ -18,12 +18,22 @@ on:
     paths:
       - 'packages/backend/**'
       - '.github/workflows/azure-backend-acc.yml'
+      # The root lockfile and manifest, because every workspace resolves through
+      # them. Without these, a lockfile-only change -- Renovate's lock-file
+      # maintenance above all -- was built, tested and deployed by nothing: #92
+      # moved 338 packages, 82 of them runtime, and CI ran audit and scan alone.
+      # A backend-only bump reaches this workflow too, because the lockfile is
+      # shared and a hoisted dependency can move under either workspace. #97.
+      - 'package-lock.json'
+      - 'package.json'
   push:
     branches:
       - acc
     paths:
       - 'packages/backend/**'
       - '.github/workflows/azure-backend-acc.yml'
+      - 'package-lock.json'
+      - 'package.json'
   workflow_dispatch:
 
 # Serialise deployments to one environment. Keyed on the pull-request

--- a/.github/workflows/azure-backend-production.yml
+++ b/.github/workflows/azure-backend-production.yml
@@ -25,6 +25,11 @@ on:
     paths:
       - 'packages/backend/**'
       - '.github/workflows/azure-backend-production.yml'
+      # The root lockfile and manifest, so a lockfile-only promotion redeploys
+      # rather than leaving production on the previous tree. See the acc
+      # workflow and #97.
+      - 'package-lock.json'
+      - 'package.json'
   workflow_dispatch:
 
 # Same serialisation as the acc workflow, but production runs QUEUE

--- a/.github/workflows/azure-frontend-acc.yml
+++ b/.github/workflows/azure-frontend-acc.yml
@@ -7,6 +7,14 @@ on:
     paths:
       - 'packages/frontend/**'
       - '.github/workflows/azure-frontend-acc.yml'
+      # The root lockfile and manifest, because every workspace resolves through
+      # them. Without these, a lockfile-only change -- Renovate's lock-file
+      # maintenance above all -- was built, tested and deployed by nothing: #92
+      # moved 338 packages, 82 of them runtime, and CI ran audit and scan alone.
+      # A backend-only bump reaches this workflow too, because the lockfile is
+      # shared and a hoisted dependency can move under either workspace. #97.
+      - 'package-lock.json'
+      - 'package.json'
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
@@ -14,6 +22,8 @@ on:
     paths:
       - 'packages/frontend/**'
       - '.github/workflows/azure-frontend-acc.yml'
+      - 'package-lock.json'
+      - 'package.json'
 
 # Serialise deployments to one environment. Keyed on the pull-request
 # NUMBER rather than the ref: keyed on github.ref alone, the

--- a/.github/workflows/azure-frontend-production.yml
+++ b/.github/workflows/azure-frontend-production.yml
@@ -7,6 +7,11 @@ on:
     paths:
       - 'packages/frontend/**'
       - '.github/workflows/azure-frontend-production.yml'
+      # The root lockfile and manifest, so a lockfile-only promotion redeploys
+      # rather than leaving production on the previous tree. See the acc
+      # workflow and #97.
+      - 'package-lock.json'
+      - 'package.json'
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
@@ -14,6 +19,8 @@ on:
     paths:
       - 'packages/frontend/**'
       - '.github/workflows/azure-frontend-production.yml'
+      - 'package-lock.json'
+      - 'package.json'
 
 # Same serialisation as the acc workflow, but production runs QUEUE
 # rather than cancel: interrupting a live production deployment to

--- a/docs/ci-posture-across-repos.md
+++ b/docs/ci-posture-across-repos.md
@@ -426,7 +426,30 @@ group rules without `matchUpdateTypes` catch lock-file maintenance too, and CI
 built and tested none of them: all three acceptance workflows are path-filtered to
 their own package, and the root `package-lock.json` is in none of those filters.
 Both gaps are
-[linked-data-explorer#97](https://github.com/sgort/linked-data-explorer/issues/97).
+[linked-data-explorer#97](https://github.com/sgort/linked-data-explorer/issues/97),
+closed the same day:
+
+- **The root `package-lock.json` and `package.json` are now in all four
+  deploy workflows' filters**, acc and production, push and pull request. A
+  lockfile-only change is built, tested and deployed like any other, and a
+  lockfile-only promotion redeploys production instead of leaving it on the
+  previous tree.
+- **The per-workspace group rules list every update type except
+  `lockFileMaintenance`**, so one refresh is one pull request. Lock-file
+  maintenance's own default is `groupName: null`; the rules were overriding it.
+- **Lock-file maintenance has `prPriority: 10`**, so it takes the first free
+  slot. It cannot evict an open pull request, so a short backlog is still the
+  other half.
+
+The cost of the first change is Static Web Apps previews: every lockfile pull
+request now holds one on the acceptance app. That is affordable here and would
+not be everywhere. Linked Data Explorer's frontend apps are on the **Standard**
+plan, 10 staging environments per app, so `prConcurrentLimit: 5` leaves five for
+people. ronl-business-api's frontend is on **Free**, 3 per app — the ceiling five
+pull requests exhausted on 2026-08-28, and why its fix went the other way:
+narrowing the filter, not widening it. **Check the plan before copying this
+filter change**, and size the Renovate cap against the slots, not the other way
+round.
 
 **ttl-editor has no `lockFileMaintenance` at all.** Its residual Supply Chain
 findings — `brace-expansion`, `picomatch`, `postcss-selector-parser` — each have a

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,13 @@
     "than floating. See SECURITY-PIPELINE.md.",
     "baseBranchPatterns targets acc, this repository's integration and",
     "default branch. main is promoted from acc and must never receive",
-    "dependency pull requests directly."
+    "dependency pull requests directly.",
+    "prConcurrentLimit 5 is a sized cap, not a default. Pull requests that touch",
+    "packages/frontend/** or the root lockfile each hold a Static Web Apps preview",
+    "on the acceptance app, which is on the Standard plan: 10 staging environments.",
+    "Five for Renovate leaves five for people. Lower it and lock-file maintenance",
+    "starves again (#97); raise it and previews can run out, as they did on",
+    "ronl-business-api's Free-plan app (3 environments) on 2026-08-28."
   ],
   "extends": [
     "config:recommended",
@@ -31,7 +37,7 @@
   "packageRules": [
     {
       "description": [
-        "Actions land across all seven workflows at once, so they are grouped",
+        "Actions land across all eight workflows at once, so they are grouped",
         "separately from the workspace dependencies below."
       ],
       "matchManagers": ["github-actions"],
@@ -57,18 +63,69 @@
       "description": [
         "Three deployables, three groups. An update that breaks one workspace",
         "should not be entangled with the other two in a single pull request -",
-        "each has its own deploy workflow and its own acceptance site."
+        "each has its own deploy workflow and its own acceptance site.",
+        "matchUpdateTypes lists every update type EXCEPT lockFileMaintenance.",
+        "Without it these rules stamped a group name onto lock-file maintenance",
+        "too, so one refresh arrived as three identical pull requests - #92, #93",
+        "and #94, byte-identical lockfiles - tripling its share of",
+        "prConcurrentLimit. Its own default is groupName null. See #97."
       ],
       "matchFileNames": ["packages/backend/**"],
-      "groupName": "backend dependencies"
+      "groupName": "backend dependencies",
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest",
+        "digest",
+        "rollback",
+        "bump",
+        "replacement"
+      ]
     },
     {
       "matchFileNames": ["packages/frontend/**"],
-      "groupName": "frontend dependencies"
+      "groupName": "frontend dependencies",
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest",
+        "digest",
+        "rollback",
+        "bump",
+        "replacement"
+      ]
     },
     {
       "matchFileNames": ["packages/ropa-site/**"],
-      "groupName": "ropa-site dependencies"
+      "groupName": "ropa-site dependencies",
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest",
+        "digest",
+        "rollback",
+        "bump",
+        "replacement"
+      ]
+    },
+    {
+      "description": [
+        "Lock-file maintenance is the only thing that moves the transitive tree,",
+        "and it was starved: enabled on 2026-08-29, it then sat rate-limited",
+        "behind open feature bumps until forced by hand, while rollup stayed at a",
+        "January version. When it ran, one refresh closed 63 of 66 Semgrep Supply",
+        "Chain findings. prPriority makes it the first branch created when a slot",
+        "frees. It cannot evict an open pull request, so a full queue still delays",
+        "it - keeping the backlog short is the other half. See #97."
+      ],
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "prPriority": 10
     }
   ],
   "prConcurrentLimit": 5,


### PR DESCRIPTION
Closes #97. Nothing maintained the transitive dependency tree, and nothing tested it. There were three connected gaps, found while triaging the first Semgrep baseline.

## 1. Lockfile-only changes skipped CI

Each of the four deploy workflows was path-filtered to its own package plus its own workflow file. Every workspace resolves through the single root `package-lock.json`, and none of those filters named it.

**#92 moved 338 packages, 82 of them runtime.** CI ran `audit` and `scan` and nothing else: no build, no tests. Merging it deployed nothing either. ACC kept the January tree until an unrelated change happened to touch `packages/`.

The root `package-lock.json` and `package.json` are now in all seven `paths` lists: acc and production, push and pull request. **These are pure additions.** No existing line changes, and `ropa-site`, which has no `package.json`, is not touched.

## 2. Lock-file maintenance arrived three times

The per-workspace group rules set `groupName` without `matchUpdateTypes`, so they caught lock-file maintenance too. One refresh became **three byte-identical PRs** (#92, #93, #94), which tripled its share of the concurrency limit. Lock-file maintenance's own default is `groupName: null`.

The group rules now list every update type **except** `lockFileMaintenance`. Everything else is grouped exactly as before.

## 3. Lock-file maintenance was starved

It was enabled on 2026-08-29, then sat rate-limited behind open feature bumps until it was forced by hand. It now has **`prPriority: 10`**, so it takes the first slot that frees. That cannot evict an open PR, so keeping the Renovate backlog short is the other half.

## The cap: kept at 5, now with a stated reason

Widening the frontend filter means every lockfile PR holds a Static Web Apps preview on the acceptance app. The number of slots decides how many such PRs can be open at once:

| App | Plan | Staging environments |
|---|---|---|
| `linkeddataexplorer-acceptatie` (LDE frontend acc) | **Standard** | **10** |
| `ronl-business-frontend-acc` (RBA) | Free | 3 |

I confirmed both against the Azure resources and Microsoft's plan table. `prConcurrentLimit: 5` leaves five slots for people. Lowering it would recreate the starvation this change removes. The reasoning is in `renovate.json`'s description.

The posture page records that this is **not portable as-is**: *check the plan before copying the filter change.* RBA's fix on 2026-08-28 went the other way, narrowing its filter, because it has 3 slots.

## What this PR triggers

It edits the acc workflow files, and each of those files is in its own `paths` list. So this PR **builds, tests and previews** backend and frontend, and merging it **redeploys ACC**. The production workflows fire on the next promotion. This is the *"a workflow's own file is a trigger"* rule from the posture page.

## Verification

| Check | Result |
|---|---|
| `renovate-config-validator --strict`, at the version CI pins (44.50.3) | passes |
| `check-supply-chain --offline` | passes |
| zizmor | 0 findings |
| workflow files | all parse |
| `check-format` | clean |

**Still to confirm:** Renovate's next scheduled run, **Monday 14 September before 05:00**, should open **one** lock-file-maintenance PR, not three. That is the only real test of the grouping change.

## Not in this PR

Working down the open Renovate backlog (#85, #86, #68, #69, and #80, which is blocked) is #97's remaining checkbox, and a decision about each PR on its own merits.
