### PR TITLE
ci: hold major updates for dashboard approval, so lock-file maintenance gets a slot

### DIFF
--- a/docs/ci-posture-across-repos.md
+++ b/docs/ci-posture-across-repos.md
@@ -437,9 +437,18 @@ closed the same day:
 - **The per-workspace group rules list every update type except
   `lockFileMaintenance`**, so one refresh is one pull request. Lock-file
   maintenance's own default is `groupName: null`; the rules were overriding it.
-- **Lock-file maintenance has `prPriority: 10`**, so it takes the first free
-  slot. It cannot evict an open pull request, so a short backlog is still the
-  other half.
+- **Lock-file maintenance has `prPriority: 10`** — which turned out to be the
+  weaker half. Priority only orders branches eligible in the same run, and
+  lock-file maintenance is eligible only inside its Monday schedule. Within
+  minutes of two Renovate pull requests being merged to free slots, an unrelated
+  update took one and three more were queued for the other, all eligible any
+  day. Priority alone would never have kept a slot for Monday.
+- **Major updates now need Dependency Dashboard approval**, and that is what does
+  keep it. The queue competing with lock-file maintenance was almost entirely
+  majors — `npm` 12 and two workspace major groups — which nobody merges on
+  autopilot anyway. Behind approval they wait as checkboxes and hold no slot.
+  `vulnerabilityAlerts` sets `dependencyDashboardApproval: false` explicitly, so
+  a security fix that happens to be a major version never waits on a click.
 
 The cost of the first change is Static Web Apps previews: every lockfile pull
 request now holds one on the acceptance app. That is affordable here and would

--- a/renovate.json
+++ b/renovate.json
@@ -29,10 +29,14 @@
       "14-day wait would delay exactly the updates that must not wait, which",
       "is why such policies get disabled mid-incident. Requires GitHub",
       "Dependabot ALERTS to be enabled on the repository; Dependabot security",
-      "UPDATES must stay off, or it opens competing PRs that ignore the cooldown."
+      "UPDATES must stay off, or it opens competing PRs that ignore the cooldown.",
+      "dependencyDashboardApproval is set false here explicitly, because major",
+      "updates below need approval: a security fix that happens to be a major",
+      "version must not wait on a checkbox."
     ],
     "minimumReleaseAge": null,
-    "labels": ["security"]
+    "labels": ["security"],
+    "dependencyDashboardApproval": false
   },
   "packageRules": [
     {
@@ -116,13 +120,30 @@
     },
     {
       "description": [
+        "Major updates wait in the Dependency Dashboard (#36) as checkboxes and hold",
+        "no slot in prConcurrentLimit until someone ticks one. The queue competing",
+        "with lock-file maintenance was almost entirely majors - npm 12 and two",
+        "workspace major groups spanning express, eslint, jest, typescript, vite and",
+        "tiptap - which nobody merges on autopilot anyway. Without this, freeing",
+        "slots bought minutes: on 2026-09-11, of two slots freed by merging, one was",
+        "taken within minutes by an unrelated update and three more were queued for",
+        "the other, all eligible any day - so the last slot would be gone long before",
+        "lock-file maintenance's Monday window opened. See #97."
+      ],
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": [
         "Lock-file maintenance is the only thing that moves the transitive tree,",
         "and it was starved: enabled on 2026-08-29, it then sat rate-limited",
         "behind open feature bumps until forced by hand, while rollup stayed at a",
         "January version. When it ran, one refresh closed 63 of 66 Semgrep Supply",
         "Chain findings. prPriority makes it the first branch created when a slot",
-        "frees. It cannot evict an open pull request, so a full queue still delays",
-        "it - keeping the backlog short is the other half. See #97."
+        "frees - but only against branches eligible in the same run, and lock-file",
+        "maintenance is only eligible inside its Monday schedule. During the week,",
+        "updates eligible any time fill every free slot first, so priority alone",
+        "cannot keep one for it; majors needing approval, above, is what does. See #97."
       ],
       "matchUpdateTypes": ["lockFileMaintenance"],
       "prPriority": 10


### PR DESCRIPTION
Refs #97. This corrects part of #103's reasoning, based on what was observed right after it merged.

## What #103 got wrong

#103 gave lock-file maintenance `prPriority: 10`, on the reasoning that it would take the first slot that freed. That was sound but insufficient, and the evidence arrived within minutes:

- #85 and #86 were merged to free two slots below `prConcurrentLimit: 5`.
- One slot was taken almost at once by an unrelated update, **#104**.
- The Dependency Dashboard showed **three more** rate-limited updates waiting for the other slot, all eligible any day.

**Priority only orders branches that are eligible in the same run**, and lock-file maintenance is eligible only inside its Monday schedule. During the week, everything else fills each free slot first. Priority alone would never have kept one open for Monday.

## The fix

The queue competing for those slots was almost entirely **major updates**:

- `npm` 12;
- a backend major group of 17 packages, including `express`, `eslint`, `jest` and `typescript`;
- a frontend major group of 15 packages, including `vite`, `tiptap`, `eslint` and `jsdom`.

Nobody merges those on autopilot anyway. They now need **Dependency Dashboard approval**. Each one waits in #36 as a checkbox and **holds no slot** until someone ticks it. That leaves the five slots for minor and patch updates and for lock-file maintenance.

`vulnerabilityAlerts` sets `dependencyDashboardApproval: false` explicitly, so **a security fix that happens to be a major version never waits on a click.**

## Corrections

The `prPriority` rule's description and the posture page's account of #97's closure both said priority makes lock-file maintenance take the first free slot. Both now describe what was observed: priority is the weaker half, and the approval rule is what keeps the slot open.

## Early evidence for #103's grouping fix

The Dependency Dashboard now lists **one** lock-file-maintenance entry. Before #103 it listed three. That is direct evidence the grouping fix works, ahead of Monday's scheduled run.

## After merge

- The rate-limited majors reappear in #36 as approval checkboxes.
- **The majors already open (#68, #69, #80) stay open.** The rule governs how new majors are created, not existing pull requests. That leaves the queue at four of five, with one slot for Monday.
- **Monday 14 September, before 05:00:** one lock-file-maintenance PR should be created. That closes both of #97's remaining conditions.

## Verification

`renovate-config-validator --strict` passes at the version CI pins (44.50.3). `check-format` and `check-supply-chain` pass. The only files touched are `renovate.json` and the docs, so nothing deploys.