### PR TITLE
chore: bump release to v2026.09.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linked-data-explorer-monorepo",
-  "version": "2026.09.3",
+  "version": "2026.09.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linked-data-explorer-monorepo",
-      "version": "2026.09.3",
+      "version": "2026.09.4",
       "hasInstallScript": true,
       "license": "EUPL-1.2",
       "workspaces": [
@@ -17528,7 +17528,7 @@
     },
     "packages/backend": {
       "name": "@linked-data-explorer/backend",
-      "version": "2026.09.3",
+      "version": "2026.09.4",
       "license": "EUPL-1.2",
       "dependencies": {
         "@rdfjs/dataset": "^2.0.3",
@@ -17572,7 +17572,7 @@
     },
     "packages/frontend": {
       "name": "@linked-data-explorer/frontend",
-      "version": "2026.09.3",
+      "version": "2026.09.4",
       "dependencies": {
         "@bpmn-io/form-js": "^1.25.0",
         "@bpmn-io/properties-panel": "^3.53.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linked-data-explorer-monorepo",
-  "version": "2026.09.3",
+  "version": "2026.09.4",
   "private": true,
   "description": "Monorepo for Linked Data Explorer - RONL DMN Orchestration Platform",
   "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linked-data-explorer/backend",
-  "version": "2026.09.3",
+  "version": "2026.09.4",
   "description": "Backend orchestration service for DMN chain execution",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@linked-data-explorer/frontend",
   "private": true,
-  "version": "2026.09.3",
+  "version": "2026.09.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/frontend/src/changelog.json
+++ b/packages/frontend/src/changelog.json
@@ -2,6 +2,62 @@
   "versions": [
     {
       "format": "commits",
+      "version": "2026.09.4",
+      "status": "Released",
+      "date": "11 sep 2026",
+      "scope": "both",
+      "commits": [
+        {
+          "sha": "bd52eac",
+          "author": "Steven Gort",
+          "type": "ci",
+          "subject": "Major dependency updates wait for approval, so the lockfile refresh gets a slot",
+          "details": [
+            "Major updates now wait in the Dependency Dashboard as checkboxes and hold no slot in Renovate's concurrency limit until someone approves one. The queue that kept crowding out lock-file maintenance was almost entirely majors — npm 12 and two workspace major groups spanning express, eslint, jest, typescript, vite and tiptap — which are never merged on autopilot anyway.",
+            "Giving lock-file maintenance priority alone had not been enough: it only orders branches eligible in the same run, and lock-file maintenance is eligible only inside its Monday schedule, so updates eligible any day filled every free slot first. Security fixes are exempt from the new approval step, so one that happens to be a major version never waits on a click."
+          ]
+        },
+        {
+          "sha": "4ef0848",
+          "author": "renovate[bot]",
+          "type": "fix",
+          "subject": "Backend dependency updates",
+          "details": [
+            "axios 1.20.0 and @types/n3 1.26.2. Rebased onto the current tree before merging, so its lockfile was regenerated against the refreshed dependencies rather than the January ones, and verified locally with lint, the full test suite and the backend build."
+          ]
+        },
+        {
+          "sha": "3e903af",
+          "author": "renovate[bot]",
+          "type": "fix",
+          "subject": "Frontend dependency updates",
+          "details": [
+            "bpmn-js 18.26.0, @bpmn-io/properties-panel 3.53.0, camunda-bpmn-moddle 7.0.2 and @testing-library/react 16.3.3. Rebased onto the current tree before merging and verified locally with lint, the full test suite and the build. It was also the first pull request on which a frontend-only change ran the backend's tests as well, because the shared lockfile now reaches both workflows."
+          ]
+        },
+        {
+          "sha": "4b3a1c0",
+          "author": "Steven Gort",
+          "type": "ci",
+          "subject": "Lockfile-only changes are built, tested and deployed",
+          "details": [
+            "The root package-lock.json and package.json now trigger the backend and frontend workflows in acceptance and production. Before, a change to the lockfile alone — Renovate's lock-file maintenance above all — was built, tested and deployed by nothing: the 338-package refresh in v2026.09.3 reached acceptance only because an unrelated change happened to follow it.",
+            "Renovate's per-workspace group rules no longer catch lock-file maintenance, so one refresh arrives as one pull request instead of three identical ones, and lock-file maintenance takes priority for the first free slot. The concurrency limit stays at five, sized against the acceptance app's ten preview environments."
+          ]
+        },
+        {
+          "sha": "8d88652",
+          "author": "Steven Gort",
+          "type": "chore",
+          "subject": "The last Semgrep false positive is suppressed in the code, not the dashboard",
+          "details": [
+            "An Object.assign in test-case storage was flagged as a prototype-pollution risk; its only caller passes a fixed timestamp field, and the data is the user's own. The suppression now lives on the line with its reason, and says when it would stop being true. Every Code suppression in this repository is now in the source rather than in dashboard state, leaving one open Code finding: the Tailwind Play CDN."
+          ]
+        }
+      ]
+    },
+    {
+      "format": "commits",
       "version": "2026.09.3",
       "status": "Released",
       "date": "11 sep 2026",


### PR DESCRIPTION
Cuts **v2026.09.4**, scope **`both`**. Merging this pushes `acc`, which triggers the frontend and backend acceptance deploys.

This release exists so that the next promotion is not a silent one. `acc` had moved past v2026.09.3 with two runtime dependency updates and three CI changes. Promoting without a release would have run code in production that v2026.09.3's entry does not describe, while the Changelog tab still said v2026.09.3.

## What changed

| File | Change |
|---|---|
| `packages/frontend/src/changelog.json` | new entry prepended, `status: "Released"`, 5 commits |
| `package.json`, `packages/frontend/package.json`, `packages/backend/package.json` | `2026.09.3` → `2026.09.4` |
| `package-lock.json` | exactly the four matching `version` fields; nothing else moved |

## The entry

```
[ci   ] bd52eac  Steven Gort    Major dependency updates wait for approval, so the lockfile refresh gets a slot
[fix  ] 4ef0848  renovate[bot]  Backend dependency updates
[fix  ] 3e903af  renovate[bot]  Frontend dependency updates
[ci   ] 4b3a1c0  Steven Gort    Lockfile-only changes are built, tested and deployed
[chore] 8d88652  Steven Gort    The last Semgrep false positive is suppressed in the code, not the dashboard
```

**The runtime changes that reach production:**

- backend: `axios` 1.20.0
- frontend: `bpmn-js` 18.26.0, `@bpmn-io/properties-panel` 3.53.0 and `camunda-bpmn-moddle` 7.0.2

Before merging, both dependency PRs were rebased onto the current tree and verified locally.

The Renovate commits carry no body, so their details give the versions and the verification. One `docs` commit (`44b576f`) was deliberately excluded. The changelog is kept as a product record. The commit is dropped rather than deferred, because the next range starts at this bump.

## Verification

| Check | Result |
|---|---|
| Changelog SHAs | all five are live on `origin/acc` and appear in no earlier entry; order matches `git log --no-merges` |
| `npm ci --dry-run` | resolves |
| `npm run check-format` | clean |
| `Changelog` component tests | 11/11, so the new entry renders |
| Full suite | green, run by the maintainer |

## Process notes

- **Followed Linked Data Explorer's own `.claude/commands/bump-release.md`**, read from `origin/acc` and confirmed unchanged since v2026.09.3.
- **Out of scope:** the four open Renovate pull requests (#104, #80, #69, #68) were reviewed in step 0 and left open.
- **The changelog splice** ran from a `node` script that refuses to run twice. A second run confirmed it: it exited 1 without writing.

## Merging

**Use a merge commit.** Squash and rebase are disabled, both in the repository settings and in the ruleset. The entry names each commit by SHA.
